### PR TITLE
Add `--allow-empty` to the `harmonize` health gates

### DIFF
--- a/lib/ammitto/cli.rb
+++ b/lib/ammitto/cli.rb
@@ -170,6 +170,9 @@ module Ammitto
     option :all, type: :boolean, default: false, desc: 'Harmonize all sources'
     option :scan, type: :boolean, default: false, desc: 'Auto-detect data-* repositories'
     option :combine, type: :boolean, default: false, desc: 'Create combined all.jsonld'
+    option :allow_empty, type: :string,
+                         desc: 'Sources exempt from the health gates: zero entities, source errors, ' \
+                               'and missing aggregates will not fail the run (comma-separated)'
     def harmonize(*sources)
       require_relative 'cli/harmonize_command'
       Cmd::HarmonizeCommand.new(options, sources).run

--- a/lib/ammitto/cli.rb
+++ b/lib/ammitto/cli.rb
@@ -172,7 +172,8 @@ module Ammitto
     option :combine, type: :boolean, default: false, desc: 'Create combined all.jsonld'
     option :allow_empty, type: :string,
                          desc: 'Sources exempt from the health gates: zero entities, source errors, ' \
-                               'and missing aggregates will not fail the run (comma-separated)'
+                               'and missing aggregates will not fail the run (comma-separated). ' \
+                               'Per-file transform errors always fail.'
     def harmonize(*sources)
       require_relative 'cli/harmonize_command'
       Cmd::HarmonizeCommand.new(options, sources).run

--- a/lib/ammitto/cli/harmonize_command.rb
+++ b/lib/ammitto/cli/harmonize_command.rb
@@ -39,6 +39,7 @@ module Ammitto
       # @return [void]
       def run
         validate_sources!
+        allowed_empty_sources # fail fast on unknown --allow-empty codes
 
         raise Thor::Error, 'No sources to harmonize. Specify sources or use --all.' if @sources.empty?
 
@@ -119,12 +120,13 @@ module Ammitto
 
       # Health gates: a run that produced no data or swallowed errors must
       # exit nonzero so cron/CI cannot publish empty artifacts as success.
-      # Dormant sources (no automated parse path yet) are exempt from the
-      # zero-entity requirement.
+      # Strict by default; the caller opts individual sources out of the
+      # zero-entity requirement with --allow-empty (the raise-or-silence
+      # policy belongs to the invoking workflow, not to a hardcoded list).
       # @param results [Array<Hash>] per-source results
       # @return [void]
       def enforce_health_gates(results)
-        dormant = Config::Defaults::DORMANT_SOURCES
+        allowed_empty = allowed_empty_sources
         failures = []
 
         output_dir = options[:output_dir] || './api/v1'
@@ -132,13 +134,13 @@ module Ammitto
         results.each do |r|
           code = r[:code]
           if r[:status] == :error
-            failures << "#{code}: #{r[:error]}" unless dormant.include?(code)
-          elsif r[:entities].to_i.zero? && !dormant.include?(code)
+            failures << "#{code}: #{r[:error]}" unless allowed_empty.include?(code)
+          elsif r[:entities].to_i.zero? && !allowed_empty.include?(code)
             failures << "#{code}: produced 0 entities"
           elsif r[:errors]&.any?
             failures << "#{code}: #{r[:errors].length} file(s) failed to transform " \
                         "(first: #{r[:errors].first})"
-          elsif !dormant.include?(code) &&
+          elsif !allowed_empty.include?(code) &&
                 !File.exist?(File.join(output_dir, 'sources', "#{code}.jsonld"))
             failures << "#{code}: per-source aggregate sources/#{code}.jsonld was not written"
           end
@@ -148,6 +150,21 @@ module Ammitto
 
         raise Thor::Error,
               "Harmonize health gate failed:\n  #{failures.join("\n  ")}"
+      end
+
+      # Sources the caller allows to produce zero entities (--allow-empty)
+      # @return [Array<Symbol>] validated source codes
+      def allowed_empty_sources
+        @allowed_empty_sources ||= begin
+          codes = options[:allow_empty].to_s.split(',').map { |c| c.strip.downcase.to_sym }.reject(&:empty?)
+          unknown = codes - Config::Defaults::ALL_SOURCES
+          unless unknown.empty?
+            raise Thor::Error,
+                  "Unknown sources in --allow-empty: #{unknown.join(', ')}. " \
+                  "Valid: #{Config::Defaults::ALL_SOURCES.join(', ')}"
+          end
+          codes
+        end
       end
 
       # Write the per-source JSON-LD aggregate (sources/<code>.jsonld)

--- a/lib/ammitto/cli/harmonize_command.rb
+++ b/lib/ammitto/cli/harmonize_command.rb
@@ -121,8 +121,11 @@ module Ammitto
       # Health gates: a run that produced no data or swallowed errors must
       # exit nonzero so cron/CI cannot publish empty artifacts as success.
       # Strict by default; the caller opts individual sources out of the
-      # zero-entity requirement with --allow-empty (the raise-or-silence
-      # policy belongs to the invoking workflow, not to a hardcoded list).
+      # source-error, zero-entity, and missing-aggregate checks with
+      # --allow-empty (the raise-or-silence policy belongs to the invoking
+      # workflow, not to a hardcoded list). Per-file transform errors are
+      # never exempt: a file that exists but fails to transform is a data
+      # defect regardless of the source's status.
       # @param results [Array<Hash>] per-source results
       # @return [void]
       def enforce_health_gates(results)
@@ -133,13 +136,14 @@ module Ammitto
 
         results.each do |r|
           code = r[:code]
-          if r[:status] == :error
+          # Per-file errors are checked first and are never exempt
+          if r[:errors]&.any?
+            failures << "#{code}: #{r[:errors].length} file(s) failed to transform " \
+                        "(first: #{r[:errors].first})"
+          elsif r[:status] == :error
             failures << "#{code}: #{r[:error]}" unless allowed_empty.include?(code)
           elsif r[:entities].to_i.zero? && !allowed_empty.include?(code)
             failures << "#{code}: produced 0 entities"
-          elsif r[:errors]&.any?
-            failures << "#{code}: #{r[:errors].length} file(s) failed to transform " \
-                        "(first: #{r[:errors].first})"
           elsif !allowed_empty.include?(code) &&
                 !File.exist?(File.join(output_dir, 'sources', "#{code}.jsonld"))
             failures << "#{code}: per-source aggregate sources/#{code}.jsonld was not written"

--- a/lib/ammitto/cli/harmonize_command.rb
+++ b/lib/ammitto/cli/harmonize_command.rb
@@ -156,11 +156,13 @@ module Ammitto
               "Harmonize health gate failed:\n  #{failures.join("\n  ")}"
       end
 
-      # Sources the caller allows to produce zero entities (--allow-empty)
+      # Sources the caller exempts from the source-error, zero-entity, and
+      # missing-aggregate gates (--allow-empty). Per-file transform errors
+      # are never exempt.
       # @return [Array<Symbol>] validated source codes
       def allowed_empty_sources
         @allowed_empty_sources ||= begin
-          codes = options[:allow_empty].to_s.split(',').map { |c| c.strip.downcase.to_sym }.reject(&:empty?)
+          codes = options[:allow_empty].to_s.split(',').map { |c| c.strip.downcase.to_sym }.reject(&:empty?).uniq
           unknown = codes - Config::Defaults::ALL_SOURCES
           unless unknown.empty?
             raise Thor::Error,

--- a/lib/ammitto/config/defaults.rb
+++ b/lib/ammitto/config/defaults.rb
@@ -34,12 +34,6 @@ module Ammitto
       # All available sources
       ALL_SOURCES = %i[eu un us wb uk au ca ch cn ru tr nz jp eu_vessels un_vessels].freeze
 
-      # Dormant sources: no working automated parse path yet (jp/un_vessels
-      # are PDF-based placeholders; cn/ru scrape HTML but have no YAML
-      # persistence). Health gates do not require entities from these, and
-      # they are excluded from zero-entity failure checks.
-      DORMANT_SOURCES = %i[jp un_vessels cn ru].freeze
-
       # Default output format
       DEFAULT_OUTPUT_FORMAT = 'jsonld'
 

--- a/spec/integration/harmonize_pipeline_spec.rb
+++ b/spec/integration/harmonize_pipeline_spec.rb
@@ -152,6 +152,62 @@ RSpec.describe 'harmonize pipeline (integration)' do
     expect(Dir.exist?(out)).to be(false) # failed fast: nothing was written
   end
 
+  it 'treats a nil, empty, or whitespace flag as fully strict' do
+    [nil, '', '  ', ',,'].each do |value|
+      cmd = Ammitto::Cmd::HarmonizeCommand.new(
+        { output_dir: File.join(@workdir, 'api', 'v1'), allow_empty: value }, ['uk']
+      )
+      expect(cmd.send(:allowed_empty_sources)).to eq([])
+    end
+  end
+
+  it 'parses mixed case, whitespace, and stray commas in --allow-empty' do
+    cmd = Ammitto::Cmd::HarmonizeCommand.new(
+      { output_dir: File.join(@workdir, 'api', 'v1'), allow_empty: ' CN ,, ru , ' }, ['uk']
+    )
+    expect(cmd.send(:allowed_empty_sources)).to eq(%i[cn ru])
+  end
+
+  it 'fails on a missing aggregate for sources not in --allow-empty' do
+    cmd = Ammitto::Cmd::HarmonizeCommand.new(
+      { output_dir: File.join(@workdir, 'api', 'v1') }, ['uk']
+    )
+    produced_without_aggregate = [{ code: :uk, status: :success, entities: 3, entries: 3 }]
+    expect { cmd.send(:enforce_health_gates, produced_without_aggregate) }
+      .to raise_error(Thor::Error, /uk: per-source aggregate/)
+  end
+
+  it 'never exempts per-file transform errors, even for allowed sources' do
+    cmd = Ammitto::Cmd::HarmonizeCommand.new(
+      { output_dir: File.join(@workdir, 'api', 'v1'), allow_empty: 'jp' }, ['jp']
+    )
+    with_errors = [{ code: :jp, status: :success, entities: 2, entries: 2,
+                     errors: ['x.yaml: transform produced incomplete entity/entry pair'] }]
+    expect { cmd.send(:enforce_health_gates, with_errors) }
+      .to raise_error(Thor::Error, /jp: 1 file\(s\) failed to transform/)
+
+    error_status_with_errors = [{ code: :jp, status: :error, error: 'partial',
+                                  errors: ['y.yaml: transform produced invalid result (String)'] }]
+    expect { cmd.send(:enforce_health_gates, error_status_with_errors) }
+      .to raise_error(Thor::Error, /jp: 1 file\(s\) failed to transform/)
+  end
+
+  it 'wires --allow-empty through the real CLI (rejection path)' do
+    expect do
+      expect { Ammitto::CLI.start(%w[harmonize eu --allow-empty zz]) }
+        .to raise_error(SystemExit)
+    end.to output(/Unknown sources in --allow-empty: zz/).to_stderr
+  end
+
+  it 'wires --allow-empty through the real CLI (exemption path)' do
+    FileUtils.mkdir_p(File.join(@workdir, 'data-jp', 'processed'))
+    out = File.join(@workdir, 'api', 'v1')
+    expect do
+      Ammitto::CLI.start(['harmonize', 'jp', '--allow-empty', 'jp',
+                          '--sources-dir', @workdir, '--output-dir', out])
+    end.not_to raise_error
+  end
+
   it 'exempts allowed sources from error-status and aggregate checks too' do
     cmd = Ammitto::Cmd::HarmonizeCommand.new(
       { output_dir: File.join(@workdir, 'api', 'v1'), allow_empty: 'jp' }, ['jp']

--- a/spec/integration/harmonize_pipeline_spec.rb
+++ b/spec/integration/harmonize_pipeline_spec.rb
@@ -120,20 +120,47 @@ RSpec.describe 'harmonize pipeline (integration)' do
       .to raise_error(Thor::Error, /uk/)
   end
 
-  it 'does not fail the health gate for dormant sources' do
-    dormant = Ammitto::Config::Defaults::DORMANT_SOURCES
-    expect(dormant).to include(:jp, :un_vessels, :cn, :ru)
-  end
-
-  it 'exempts dormant zero-entity runs from every gate, including aggregates' do
+  it 'is strict by default: any zero-entity source fails the gate' do
     cmd = Ammitto::Cmd::HarmonizeCommand.new(
       { output_dir: File.join(@workdir, 'api', 'v1') }, ['jp']
     )
-    dormant_ok = [{ code: :jp, status: :success, entities: 0, entries: 0 }]
-    expect { cmd.send(:enforce_health_gates, dormant_ok) }.not_to raise_error
+    zero = [{ code: :jp, status: :success, entities: 0, entries: 0 }]
+    expect { cmd.send(:enforce_health_gates, zero) }
+      .to raise_error(Thor::Error, /jp: produced 0 entities/)
+  end
 
-    active_zero = [{ code: :uk, status: :success, entities: 0, entries: 0 }]
-    expect { cmd.send(:enforce_health_gates, active_zero) }
+  it 'exempts only the sources named in --allow-empty' do
+    cmd = Ammitto::Cmd::HarmonizeCommand.new(
+      { output_dir: File.join(@workdir, 'api', 'v1'), allow_empty: 'jp,cn' }, ['jp']
+    )
+    allowed = [{ code: :jp, status: :success, entities: 0, entries: 0 }]
+    expect { cmd.send(:enforce_health_gates, allowed) }.not_to raise_error
+
+    unlisted = [{ code: :uk, status: :success, entities: 0, entries: 0 }]
+    expect { cmd.send(:enforce_health_gates, unlisted) }
       .to raise_error(Thor::Error, /uk: produced 0 entities/)
+  end
+
+  it 'rejects unknown source codes in --allow-empty before any processing' do
+    write_eu_fixture(@workdir)
+    out = File.join(@workdir, 'api', 'v1')
+    cmd = Ammitto::Cmd::HarmonizeCommand.new(
+      { sources_dir: @workdir, output_dir: out, allow_empty: 'zz' }, ['eu']
+    )
+    expect { cmd.run }
+      .to raise_error(Thor::Error, /Unknown sources in --allow-empty: zz/)
+    expect(Dir.exist?(out)).to be(false) # failed fast: nothing was written
+  end
+
+  it 'exempts allowed sources from error-status and aggregate checks too' do
+    cmd = Ammitto::Cmd::HarmonizeCommand.new(
+      { output_dir: File.join(@workdir, 'api', 'v1'), allow_empty: 'jp' }, ['jp']
+    )
+    errored = [{ code: :jp, status: :error, error: 'No YAML files found' }]
+    expect { cmd.send(:enforce_health_gates, errored) }.not_to raise_error
+
+    produced_without_aggregate = [{ code: :jp, status: :success, entities: 3, entries: 3 }]
+    expect { cmd.send(:enforce_health_gates, produced_without_aggregate) }
+      .not_to raise_error
   end
 end


### PR DESCRIPTION
Added **`--allow-empty`** to `harmonize` — the health gates (zero entities, source errors, missing aggregates) are now strict for every source by default, and the invoking workflow names its own exemptions. Removes the hardcoded `DORMANT_SOURCES` list, since all fifteen sources now harmonize from committed YAML.

Depends on #18
