### PR TITLE
Add missing ontology specifications and fix related defects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,6 +58,12 @@ Naming/MethodParameterName:
 Style/ArrayIntersect:
   Enabled: false
 
+# Pure enumeration module: its length tracks the sanctions-domain
+# vocabulary (schema-driven), not code complexity
+Metrics/ModuleLength:
+  Exclude:
+    - 'lib/ammitto/ontology/types.rb'
+
 Lint/ConstantDefinitionInBlock:
   Exclude:
     - 'spec/**/*.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,8 +58,9 @@ Naming/MethodParameterName:
 Style/ArrayIntersect:
   Enabled: false
 
-# Pure enumeration module: its length tracks the sanctions-domain
-# vocabulary (schema-driven), not code complexity
+# Centralized ontology vocabulary and normalization module: its length
+# tracks the sanctions-domain vocabulary (schema-driven), not code
+# complexity.
 Metrics/ModuleLength:
   Exclude:
     - 'lib/ammitto/ontology/types.rb'

--- a/lib/ammitto/ontology.rb
+++ b/lib/ammitto/ontology.rb
@@ -44,6 +44,7 @@
 #    - IRI: /legal_instrument/{source}/{local_id}
 #
 
+require_relative 'utils/presence'
 require_relative 'ontology/types'
 require_relative 'ontology/value_objects'
 require_relative 'ontology/entities'

--- a/lib/ammitto/ontology/sanction/sanction_entry.rb
+++ b/lib/ammitto/ontology/sanction/sanction_entry.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'lutaml/model'
+require_relative '../types'
 require_relative 'authority'
 require_relative 'sanction_regime'
 require_relative 'sanction_period_modification'
@@ -119,19 +120,27 @@ module Ammitto
         end
 
         # Add a status change to history
-        # @param new_status [Symbol, String]
+        # @param new_status [Symbol, String] one of Types::SANCTION_STATUSES
         # @param date [Date]
         # @param reason [String, nil]
         # @return [void]
+        # @raise [ArgumentError] when new_status is blank or not a known
+        #   sanction status
         def add_status_change(new_status, date: Date.today, reason: nil)
+          normalized = new_status.to_s
+          unless Types.valid_status?(normalized)
+            raise ArgumentError,
+                  "invalid sanction status: #{new_status.inspect}"
+          end
+
           self.status_history ||= []
           status_history << StatusHistory.new(
             from_status: status,
-            to_status: new_status.to_s,
+            to_status: normalized,
             date: date,
             reason: reason
           )
-          self.status = new_status.to_s
+          self.status = normalized
         end
 
         key_value do

--- a/lib/ammitto/ontology/sanction/sanction_entry.rb
+++ b/lib/ammitto/ontology/sanction/sanction_entry.rb
@@ -127,7 +127,7 @@ module Ammitto
         # @raise [ArgumentError] when new_status is blank or not a known
         #   sanction status
         def add_status_change(new_status, date: Date.today, reason: nil)
-          normalized = new_status.to_s
+          normalized = new_status.to_s.downcase
           unless Types.valid_status?(normalized)
             raise ArgumentError,
                   "invalid sanction status: #{new_status.inspect}"

--- a/lib/ammitto/ontology/sanction/sanction_entry.rb
+++ b/lib/ammitto/ontology/sanction/sanction_entry.rb
@@ -126,7 +126,8 @@ module Ammitto
         def add_status_change(new_status, date: Date.today, reason: nil)
           self.status_history ||= []
           status_history << StatusHistory.new(
-            status: status,
+            from_status: status,
+            to_status: new_status.to_s,
             date: date,
             reason: reason
           )

--- a/lib/ammitto/ontology/sanction/sanction_reason.rb
+++ b/lib/ammitto/ontology/sanction/sanction_reason.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'lutaml/model'
+require_relative '../../utils/presence'
 
 module Ammitto
   module Ontology
@@ -52,7 +53,7 @@ module Ammitto
         # Check if reason has meaningful content
         # @return [Boolean]
         def present?
-          category.present? || description.present?
+          Utils::Presence.present?(category) || Utils::Presence.present?(description)
         end
 
         # Get category as normalized symbol

--- a/lib/ammitto/ontology/sanction/status_history.rb
+++ b/lib/ammitto/ontology/sanction/status_history.rb
@@ -8,9 +8,10 @@ module Ammitto
     module Sanction
       # Represents a status change in a sanction entry
       #
-      # @example Creating a status history entry
+      # @example Recording a status transition
       #   history = StatusHistory.new(
-      #     status: :delisted,
+      #     from_status: 'active',
+      #     to_status: 'delisted',
       #     date: Date.new(2023, 5, 15),
       #     reason: "Delisted following court order"
       #   )

--- a/lib/ammitto/ontology/types.rb
+++ b/lib/ammitto/ontology/types.rb
@@ -40,6 +40,42 @@ module Ammitto
         investment_ban
         technology_transfer_ban
         visa_suspension
+        aircraft_ban
+        debarment
+        entry_ban
+        export_restriction
+        sectoral_sanction
+        transport_sanction
+        vessel_ban
+        import_ban
+        export_ban
+        financial_restriction
+        service_restriction
+        technology_restriction
+        transaction_ban
+        allow_statement
+        cancel_stay_residence
+        cancel_work_permit
+        cooperate_investigation
+        export_license_requirement
+        fine
+        import_license_requirement
+        investigation
+        maritime_restriction
+        prohibit_cooperation
+        prohibit_data_transmission
+        prohibit_export_dual_use_items
+        prohibit_export_gene_sequencers
+        prohibit_export_specific_product
+        prohibit_import_export
+        prohibit_investment_new
+        prohibit_sensitive_information_provision
+        prohibit_transactions
+        prohibit_transfer_provide_dual_use_items
+        provide_information
+        report_violation
+        unreliable_entity_list
+        visa_ban
         other
       ].freeze
 
@@ -165,6 +201,26 @@ module Ammitto
                          .to_sym
 
         IDENTIFICATION_TYPES.include?(normalized) ? normalized : :other
+      end
+
+      # Normalize sanction effect type string
+      # @param type [String, Symbol, nil]
+      # @return [Symbol]
+      def self.normalize_effect_type(type)
+        return :other if type.nil?
+
+        normalized = type.to_s.downcase.gsub(/[-\s]+/, '_').to_sym
+        SANCTION_EFFECT_TYPES.include?(normalized) ? normalized : :other
+      end
+
+      # Normalize legal instrument type string
+      # @param type [String, Symbol, nil]
+      # @return [Symbol]
+      def self.normalize_instrument_type(type)
+        return :other if type.nil?
+
+        normalized = type.to_s.downcase.gsub(/[-\s]+/, '_').to_sym
+        LEGAL_INSTRUMENT_TYPES.include?(normalized) ? normalized : :other
       end
 
       # Normalize script detection from text

--- a/lib/ammitto/ontology/value_objects/address.rb
+++ b/lib/ammitto/ontology/value_objects/address.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'lutaml/model'
+require_relative '../../utils/presence'
 require_relative '../neo4j_adapter'
 
 module Ammitto
@@ -64,7 +65,7 @@ module Ammitto
         # Check if address has meaningful content
         # @return [Boolean]
         def present?
-          [street, city, region, country, postal_code].any?(&:present?)
+          [street, city, region, country, postal_code].any? { |v| Utils::Presence.present?(v) }
         end
 
         # Check if address is empty

--- a/lib/ammitto/ontology/value_objects/birth_info.rb
+++ b/lib/ammitto/ontology/value_objects/birth_info.rb
@@ -74,7 +74,8 @@ module Ammitto
         def to_s
           parts = []
           parts << 'c.' if circa
-          parts << date_label if date_label
+          label = date_label
+          parts << label if label
           parts << [city, region, country].compact.join(', ') if city || country
           parts.join(' ')
         end

--- a/lib/ammitto/ontology/value_objects/birth_info.rb
+++ b/lib/ammitto/ontology/value_objects/birth_info.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'lutaml/model'
+require_relative '../../utils/presence'
 require_relative '../neo4j_adapter'
 
 module Ammitto
@@ -59,7 +60,7 @@ module Ammitto
         # Check if birth info has meaningful content
         # @return [Boolean]
         def present?
-          [date, year, city, country].any?(&:present?)
+          [date, year, city, country].any? { |v| Utils::Presence.present?(v) }
         end
 
         # Get year of birth (from date or year field)

--- a/lib/ammitto/ontology/value_objects/birth_info.rb
+++ b/lib/ammitto/ontology/value_objects/birth_info.rb
@@ -60,7 +60,9 @@ module Ammitto
         # Check if birth info has meaningful content
         # @return [Boolean]
         def present?
-          [date, year, city, country].any? { |v| Utils::Presence.present?(v) }
+          [date, year, city, region, country].any? do |v|
+            Utils::Presence.present?(v)
+          end
         end
 
         # Get year of birth (from date or year field)
@@ -73,13 +75,16 @@ module Ammitto
         # @return [String]
         def to_s
           parts = []
-          parts << 'c.' if circa
           label = date_label
+          parts << 'c.' if circa && label
           parts << label if label
-          parts << [city, region, country].compact.join(', ') if city || country
+          place = [city, region, country].compact
+          parts << place.join(', ') unless place.empty?
           parts.join(' ')
         end
 
+        # Convert to hash for JSON-LD serialization
+        # @return [Hash]
         def to_hash
           hash = {}
           hash[:date] = date.to_s if date
@@ -100,9 +105,6 @@ module Ammitto
 
           nil
         end
-
-        # Convert to hash for JSON-LD serialization
-        # @return [Hash]
 
         # JSON mapping
         json do

--- a/lib/ammitto/ontology/value_objects/birth_info.rb
+++ b/lib/ammitto/ontology/value_objects/birth_info.rb
@@ -72,10 +72,22 @@ module Ammitto
         # @return [String]
         def to_s
           parts = []
-          parts << (circa ? 'c. ' : '')
-          parts << date_label
+          parts << 'c.' if circa
+          parts << date_label if date_label
           parts << [city, region, country].compact.join(', ') if city || country
           parts.join(' ')
+        end
+
+        def to_hash
+          hash = {}
+          hash[:date] = date.to_s if date
+          hash[:circa] = circa if circa
+          hash[:year] = year if year
+          hash[:city] = city if city
+          hash[:region] = region if region
+          hash[:country] = country if country
+          hash[:country_iso_code] = country_iso_code if country_iso_code
+          hash
         end
 
         private
@@ -89,17 +101,6 @@ module Ammitto
 
         # Convert to hash for JSON-LD serialization
         # @return [Hash]
-        def to_hash
-          hash = {}
-          hash[:date] = date.to_s if date
-          hash[:circa] = circa if circa
-          hash[:year] = year if year
-          hash[:city] = city if city
-          hash[:region] = region if region
-          hash[:country] = country if country
-          hash[:country_iso_code] = country_iso_code if country_iso_code
-          hash
-        end
 
         # JSON mapping
         json do

--- a/lib/ammitto/ontology/value_objects/contact_info.rb
+++ b/lib/ammitto/ontology/value_objects/contact_info.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'lutaml/model'
+require_relative '../../utils/presence'
 require_relative '../neo4j_adapter'
 
 module Ammitto
@@ -44,7 +45,7 @@ module Ammitto
         # Check if contact info has meaningful content
         # @return [Boolean]
         def present?
-          [email, phone, website, fax].any?(&:present?)
+          [email, phone, website, fax].any? { |v| Utils::Presence.present?(v) }
         end
 
         # Check if contact info is empty

--- a/lib/ammitto/ontology/value_objects/identification.rb
+++ b/lib/ammitto/ontology/value_objects/identification.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'lutaml/model'
+require_relative '../../utils/presence'
 require_relative '../types'
 require_relative '../neo4j_adapter'
 
@@ -51,7 +52,7 @@ module Ammitto
         # Check if identification has meaningful content
         # @return [Boolean]
         def present?
-          number.present?
+          Utils::Presence.present?(number)
         end
 
         # Get type as normalized symbol

--- a/lib/ammitto/ontology/value_objects/legal_instrument.rb
+++ b/lib/ammitto/ontology/value_objects/legal_instrument.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'lutaml/model'
+require_relative '../../utils/presence'
 require_relative '../types'
 
 module Ammitto
@@ -61,7 +62,7 @@ module Ammitto
         # Check if instrument has meaningful content
         # @return [Boolean]
         def present?
-          [identifier, title].any?(&:present?)
+          [identifier, title].any? { |v| Utils::Presence.present?(v) }
         end
 
         # Get type as normalized symbol

--- a/lib/ammitto/ontology/value_objects/sanction_effect.rb
+++ b/lib/ammitto/ontology/value_objects/sanction_effect.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'lutaml/model'
+require_relative '../../utils/presence'
 require_relative '../types'
 
 module Ammitto
@@ -42,7 +43,7 @@ module Ammitto
         # Check if effect has meaningful content
         # @return [Boolean]
         def present?
-          effect_type.present?
+          Utils::Presence.present?(effect_type)
         end
 
         # Get type as normalized symbol

--- a/lib/ammitto/utils.rb
+++ b/lib/ammitto/utils.rb
@@ -6,5 +6,6 @@ module Ammitto
   end
 end
 
+require_relative 'utils/presence'
 require_relative 'utils/iri_sanitizer'
 require_relative 'utils/list_types_registry'

--- a/lib/ammitto/utils/presence.rb
+++ b/lib/ammitto/utils/presence.rb
@@ -1,33 +1,33 @@
 # frozen_string_literal: true
 
-# Minimal presence predicates for the ontology layer, which calls
-# #present?/#blank? throughout. Semantics match ActiveSupport exactly, and
-# nothing is defined when ActiveSupport (or anything else) already provides
-# them, so consumers loading both see no conflict.
-unless Object.method_defined?(:blank?)
-  class Object
-    # @return [Boolean] true for nil, false, empty collections/strings
-    def blank?
-      respond_to?(:empty?) ? !!empty? : !self
-    end
-  end
-end
+module Ammitto
+  module Utils
+    # Presence predicates for the ontology layer, as explicit module
+    # functions — no core-class patching, so nothing leaks into consumers'
+    # runtimes. Semantics match ActiveSupport: nil, false, empty
+    # collections, and whitespace-only strings (Unicode included) are blank.
+    module Presence
+      module_function
 
-unless Object.method_defined?(:present?)
-  class Object
-    # @return [Boolean] inverse of #blank?
-    def present?
-      !blank?
-    end
-  end
-end
+      # @param value [Object]
+      # @return [Boolean] true when the value is nil, false, empty, or
+      #   whitespace-only
+      def blank?(value)
+        case value
+        when nil, false
+          true
+        when String
+          value.match?(/\A[[:space:]]*\z/)
+        else
+          value.respond_to?(:empty?) ? !!value.empty? : false
+        end
+      end
 
-class String
-  unless method_defined?(:blank?) && '  '.blank?
-    # Whitespace-only strings are blank (Unicode whitespace included,
-    # matching ActiveSupport)
-    def blank?
-      match?(/\A[[:space:]]*\z/)
+      # @param value [Object]
+      # @return [Boolean] inverse of .blank?
+      def present?(value)
+        !blank?(value)
+      end
     end
   end
 end

--- a/lib/ammitto/utils/presence.rb
+++ b/lib/ammitto/utils/presence.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Minimal presence predicates for the ontology layer, which calls
+# #present?/#blank? throughout. Semantics match ActiveSupport exactly, and
+# nothing is defined when ActiveSupport (or anything else) already provides
+# them, so consumers loading both see no conflict.
+unless Object.method_defined?(:blank?)
+  class Object
+    # @return [Boolean] true for nil, false, empty collections/strings
+    def blank?
+      respond_to?(:empty?) ? !!empty? : !self
+    end
+  end
+end
+
+unless Object.method_defined?(:present?)
+  class Object
+    # @return [Boolean] inverse of #blank?
+    def present?
+      !blank?
+    end
+  end
+end
+
+class String
+  unless method_defined?(:blank?) && '  '.blank?
+    # Whitespace-only strings are blank (Unicode whitespace included,
+    # matching ActiveSupport)
+    def blank?
+      match?(/\A[[:space:]]*\z/)
+    end
+  end
+end

--- a/spec/ammitto/ontology/entities/aircraft_entity_spec.rb
+++ b/spec/ammitto/ontology/entities/aircraft_entity_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'ammitto'
+require 'ammitto/ontology'
+
+RSpec.describe Ammitto::Ontology::Entities::AircraftEntity do
+  it 'is an aircraft by construction' do
+    expect(described_class.new).to be_aircraft
+  end
+
+  describe '#primary_name / #all_names' do
+    it 'uses the name plus previous names' do
+      aircraft = described_class.new(name: 'N12345', previous_names: ['EX-111'])
+      expect(aircraft.primary_name).to eq('N12345')
+      expect(aircraft.all_names).to include('N12345', 'EX-111')
+    end
+  end
+
+  describe '#to_hash' do
+    it 'includes identifying fields and omits nils' do
+      aircraft = described_class.new(serial_number: 'SN-1', manufacturer: 'Ilyushin')
+      hash = aircraft.to_hash
+      expect(hash[:serial_number]).to eq('SN-1')
+      expect(hash[:manufacturer]).to eq('Ilyushin')
+      expect(hash).not_to have_key(:operator)
+    end
+  end
+end

--- a/spec/ammitto/ontology/entities/aircraft_entity_spec.rb
+++ b/spec/ammitto/ontology/entities/aircraft_entity_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'ammitto'
-require 'ammitto/ontology'
 
 RSpec.describe Ammitto::Ontology::Entities::AircraftEntity do
   it 'is an aircraft by construction' do
@@ -12,7 +11,7 @@ RSpec.describe Ammitto::Ontology::Entities::AircraftEntity do
     it 'uses the name plus previous names' do
       aircraft = described_class.new(name: 'N12345', previous_names: ['EX-111'])
       expect(aircraft.primary_name).to eq('N12345')
-      expect(aircraft.all_names).to include('N12345', 'EX-111')
+      expect(aircraft.all_names).to eq(%w[N12345 EX-111])
     end
   end
 

--- a/spec/ammitto/ontology/entities/entity_spec.rb
+++ b/spec/ammitto/ontology/entities/entity_spec.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
 require 'ammitto'
-require 'ammitto/ontology'
 
 RSpec.describe Ammitto::Ontology::Entities::Entity do
   describe 'type predicates' do
-    it 'reflects entity_type exactly' do
-      expect(described_class.new(entity_type: 'person')).to be_person
-      expect(described_class.new(entity_type: 'organization')).to be_organization
-      expect(described_class.new(entity_type: 'vessel')).to be_vessel
-      expect(described_class.new(entity_type: 'aircraft')).to be_aircraft
+    it 'reflects entity_type exactly — one true predicate, three false' do
+      predicates = { 'person' => :person?, 'organization' => :organization?,
+                     'vessel' => :vessel?, 'aircraft' => :aircraft? }
+      predicates.each do |type, own|
+        entity = described_class.new(entity_type: type)
+        predicates.each_value do |predicate|
+          expect(entity.public_send(predicate)).to be(predicate == own),
+                                                   "#{type}: #{predicate}"
+        end
+      end
     end
 
     it 'is nothing in particular without a type' do

--- a/spec/ammitto/ontology/entities/entity_spec.rb
+++ b/spec/ammitto/ontology/entities/entity_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'ammitto'
+require 'ammitto/ontology'
+
+RSpec.describe Ammitto::Ontology::Entities::Entity do
+  describe 'type predicates' do
+    it 'reflects entity_type exactly' do
+      expect(described_class.new(entity_type: 'person')).to be_person
+      expect(described_class.new(entity_type: 'organization')).to be_organization
+      expect(described_class.new(entity_type: 'vessel')).to be_vessel
+      expect(described_class.new(entity_type: 'aircraft')).to be_aircraft
+    end
+
+    it 'is nothing in particular without a type' do
+      entity = described_class.new
+      expect(entity).not_to be_person
+      expect(entity.entity_type_sym).to be_nil
+    end
+  end
+
+  describe '#add_sanction_entry' do
+    it 'accumulates entries' do
+      entity = described_class.new(id: 'x')
+      entity.add_sanction_entry(:entry_one)
+      entity.add_sanction_entry(:entry_two)
+      expect(entity.sanction_entries).to eq(%i[entry_one entry_two])
+    end
+  end
+
+  describe '#primary_name' do
+    it 'is nil on the abstract base (subclasses override)' do
+      expect(described_class.new.primary_name).to be_nil
+    end
+  end
+end

--- a/spec/ammitto/ontology/entities/organization_entity_spec.rb
+++ b/spec/ammitto/ontology/entities/organization_entity_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'ammitto'
+require 'ammitto/ontology'
+
+RSpec.describe Ammitto::Ontology::Entities::OrganizationEntity do
+  let(:names) do
+    [Ammitto::Ontology::ValueObjects::NameVariant.new(full_name: 'Alias Corp', is_primary: false),
+     Ammitto::Ontology::ValueObjects::NameVariant.new(full_name: 'Acme Corp', is_primary: true)]
+  end
+
+  describe '#primary_name' do
+    it 'returns the primary variant full name as a String' do
+      org = described_class.new(names: names)
+      expect(org.primary_name).to eq('Acme Corp')
+    end
+
+    it 'falls back to the first name when none is primary' do
+      org = described_class.new(names: [names.first])
+      expect(org.primary_name).to eq('Alias Corp')
+    end
+  end
+
+  describe '#all_names' do
+    it 'lists every variant full name' do
+      expect(described_class.new(names: names).all_names).to contain_exactly('Alias Corp', 'Acme Corp')
+    end
+  end
+
+  describe '#primary_address' do
+    it 'returns the first address when present' do
+      address = Ammitto::Ontology::ValueObjects::Address.new(city: 'Bern')
+      expect(described_class.new(addresses: [address]).primary_address).to eq(address)
+      expect(described_class.new.primary_address).to be_nil
+    end
+  end
+
+  it 'is an organization by construction' do
+    expect(described_class.new).to be_organization
+  end
+end

--- a/spec/ammitto/ontology/entities/organization_entity_spec.rb
+++ b/spec/ammitto/ontology/entities/organization_entity_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'ammitto'
-require 'ammitto/ontology'
 
 RSpec.describe Ammitto::Ontology::Entities::OrganizationEntity do
   let(:names) do

--- a/spec/ammitto/ontology/entities/vessel_entity_spec.rb
+++ b/spec/ammitto/ontology/entities/vessel_entity_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'ammitto'
-require 'ammitto/ontology'
 
 RSpec.describe Ammitto::Ontology::Entities::VesselEntity do
   describe '#has_imo?' do

--- a/spec/ammitto/ontology/entities/vessel_entity_spec.rb
+++ b/spec/ammitto/ontology/entities/vessel_entity_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'ammitto'
+require 'ammitto/ontology'
+
+RSpec.describe Ammitto::Ontology::Entities::VesselEntity do
+  describe '#has_imo?' do
+    it 'accepts exactly seven digits' do
+      expect(described_class.new(imo_number: '9195949')).to have_imo
+      expect(described_class.new(imo_number: 'IMO 9195949')).not_to have_imo
+      expect(described_class.new(imo_number: '123')).not_to have_imo
+      expect(described_class.new).not_to have_imo
+    end
+  end
+
+  describe '#info_summary' do
+    it 'joins name, IMO, and flag with slashes, skipping nils' do
+      vessel = described_class.new(name: 'SHIP X', imo_number: '9195949', flag_state: 'Panama')
+      expect(vessel.info_summary).to eq('SHIP X / 9195949 / Panama')
+      expect(described_class.new(name: 'SHIP X').info_summary).to eq('SHIP X')
+    end
+  end
+
+  describe 'tonnage fallbacks' do
+    it 'prefers the Tonnage object over flat integers' do
+      tonnage = Ammitto::Ontology::ValueObjects::Tonnage.new(gt: 500, dwt: 700)
+      vessel = described_class.new(tonnage: tonnage, gross_tonnage: 100, deadweight: 200)
+      expect(vessel.gross_tonnage_value).to eq(500)
+      expect(vessel.deadweight_value).to eq(700)
+    end
+
+    it 'falls back to the flat integers' do
+      vessel = described_class.new(gross_tonnage: 100, deadweight: 200)
+      expect(vessel.gross_tonnage_value).to eq(100)
+      expect(vessel.deadweight_value).to eq(200)
+    end
+  end
+
+  it 'is a vessel by construction and names itself' do
+    vessel = described_class.new(name: 'SHIP X')
+    expect(vessel).to be_vessel
+    expect(vessel.primary_name).to eq('SHIP X')
+  end
+end

--- a/spec/ammitto/ontology/sanction/authority_spec.rb
+++ b/spec/ammitto/ontology/sanction/authority_spec.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 require 'ammitto'
-require 'ammitto/ontology'
 
 RSpec.describe Ammitto::Ontology::Sanction::Authority do
   it 'carries id, name, country code, and url' do
     authority = described_class.new(id: 'ch', name: 'Switzerland (SECO)',
                                     country_code: 'CH', url: 'https://www.seco.admin.ch')
     expect(authority.id).to eq('ch')
+    expect(authority.name).to eq('Switzerland (SECO)')
     expect(authority.country_code).to eq('CH')
+    expect(authority.url).to eq('https://www.seco.admin.ch')
   end
 
   describe '#to_hash' do

--- a/spec/ammitto/ontology/sanction/authority_spec.rb
+++ b/spec/ammitto/ontology/sanction/authority_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'ammitto'
+require 'ammitto/ontology'
+
+RSpec.describe Ammitto::Ontology::Sanction::Authority do
+  it 'carries id, name, country code, and url' do
+    authority = described_class.new(id: 'ch', name: 'Switzerland (SECO)',
+                                    country_code: 'CH', url: 'https://www.seco.admin.ch')
+    expect(authority.id).to eq('ch')
+    expect(authority.country_code).to eq('CH')
+  end
+
+  describe '#to_hash' do
+    it 'omits nil fields' do
+      expect(described_class.new(id: 'ch', name: 'SECO').to_hash)
+        .to eq({ id: 'ch', name: 'SECO' })
+    end
+  end
+
+  it 'round-trips through YAML' do
+    authority = described_class.new(id: 'un', name: 'United Nations', country_code: 'UN')
+    restored = described_class.from_yaml(authority.to_yaml)
+    expect(restored.to_hash).to eq(authority.to_hash)
+  end
+end

--- a/spec/ammitto/ontology/sanction/sanction_entry_spec.rb
+++ b/spec/ammitto/ontology/sanction/sanction_entry_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe Ammitto::Ontology::Sanction::SanctionEntry do
       expect(change.reason).to eq('court order')
     end
 
+    it 'canonicalizes status casing before persisting' do
+      entry = described_class.new(id: 'e1')
+      entry.add_status_change('DELISTED')
+      expect(entry.status).to eq('delisted')
+      expect(entry).to be_delisted
+      expect(entry.status_history.first.to_status).to eq('delisted')
+    end
+
     it 'rejects blank and unknown statuses without mutating the entry' do
       entry = described_class.new(id: 'e1')
       [nil, '', 'vaporized'].each do |bad|

--- a/spec/ammitto/ontology/sanction/sanction_entry_spec.rb
+++ b/spec/ammitto/ontology/sanction/sanction_entry_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'ammitto'
+require 'ammitto/ontology'
+
+RSpec.describe Ammitto::Ontology::Sanction::SanctionEntry do
+  describe 'status' do
+    it 'defaults to active' do
+      entry = described_class.new(id: 'e1')
+      expect(entry.status).to eq('active')
+      expect(entry).to be_active
+      expect(entry).not_to be_delisted
+    end
+
+    it 'reports delisted when set' do
+      entry = described_class.new(id: 'e1', status: 'delisted')
+      expect(entry).to be_delisted
+      expect(entry).not_to be_active
+    end
+  end
+
+  describe '#add_status_change' do
+    it 'records the full transition in history' do
+      entry = described_class.new(id: 'e1')
+      entry.add_status_change('suspended', date: Date.new(2026, 1, 1), reason: 'court order')
+
+      expect(entry.status).to eq('suspended')
+      expect(entry.status_history.length).to eq(1)
+      change = entry.status_history.first
+      expect(change.from_status).to eq('active')
+      expect(change.to_status).to eq('suspended')
+      expect(change.reason).to eq('court order')
+    end
+  end
+
+  it 'composes the full ontology graph node' do
+    entry = described_class.new(
+      id: 'entry/ch/1', entity_id: 'entity/ch/1',
+      authority: Ammitto::Ontology::Sanction::Authority.new(id: 'ch', name: 'SECO'),
+      regime: Ammitto::Ontology::Sanction::SanctionRegime.new(code: 'RUSSIA'),
+      legal_bases: [Ammitto::Ontology::ValueObjects::LegalInstrument.new(identifier: 'O-27')],
+      effects: [Ammitto::Ontology::ValueObjects::SanctionEffect.new(effect_type: 'asset_freeze')],
+      period: Ammitto::Ontology::ValueObjects::TemporalPeriod.new(listed_date: Date.new(2022, 3, 1))
+    )
+
+    expect(entry.authority.name).to eq('SECO')
+    expect(entry.effects.first).to be_asset_freeze
+    expect(entry.period.active?).to be(true)
+  end
+
+  it 'round-trips the composed entry through YAML' do
+    entry = described_class.new(
+      id: 'entry/ch/1', status: 'active',
+      effects: [Ammitto::Ontology::ValueObjects::SanctionEffect.new(effect_type: 'travel_ban')]
+    )
+    restored = described_class.from_yaml(entry.to_yaml)
+    expect(restored.id).to eq('entry/ch/1')
+    expect(restored.effects.first).to be_travel_ban
+  end
+end

--- a/spec/ammitto/ontology/sanction/sanction_entry_spec.rb
+++ b/spec/ammitto/ontology/sanction/sanction_entry_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'ammitto'
-require 'ammitto/ontology'
 
 RSpec.describe Ammitto::Ontology::Sanction::SanctionEntry do
   describe 'status' do
@@ -29,7 +28,17 @@ RSpec.describe Ammitto::Ontology::Sanction::SanctionEntry do
       change = entry.status_history.first
       expect(change.from_status).to eq('active')
       expect(change.to_status).to eq('suspended')
+      expect(change.date).to eq(Date.new(2026, 1, 1))
       expect(change.reason).to eq('court order')
+    end
+
+    it 'rejects blank and unknown statuses without mutating the entry' do
+      entry = described_class.new(id: 'e1')
+      [nil, '', 'vaporized'].each do |bad|
+        expect { entry.add_status_change(bad) }.to raise_error(ArgumentError)
+      end
+      expect(entry.status).to eq('active')
+      expect(entry.status_history).to be_nil
     end
   end
 

--- a/spec/ammitto/ontology/sanction/sanction_reason_spec.rb
+++ b/spec/ammitto/ontology/sanction/sanction_reason_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'ammitto'
+
+RSpec.describe Ammitto::Ontology::Sanction::SanctionReason do
+  describe '#present?' do
+    it 'requires a non-blank category or description' do
+      expect(described_class.new(category: 'terrorism')).to be_present
+      expect(described_class.new(description: 'financing')).to be_present
+    end
+
+    it 'is blank when both are empty or whitespace-only' do
+      expect(described_class.new).not_to be_present
+      expect(described_class.new(category: ' ', description: '')).not_to be_present
+    end
+  end
+end

--- a/spec/ammitto/ontology/sanction/sanction_regime_spec.rb
+++ b/spec/ammitto/ontology/sanction/sanction_regime_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'ammitto'
+require 'ammitto/ontology'
+
+RSpec.describe Ammitto::Ontology::Sanction::SanctionRegime do
+  it 'carries code, name, and description' do
+    regime = described_class.new(code: 'DPRK', name: 'North Korea sanctions',
+                                 description: 'UNSC 1718 measures')
+    expect(regime.code).to eq('DPRK')
+    expect(regime.name).to eq('North Korea sanctions')
+  end
+
+  describe '#to_hash' do
+    it 'omits nil fields' do
+      expect(described_class.new(code: 'DPRK').to_hash).to eq({ code: 'DPRK' })
+    end
+  end
+
+  it 'round-trips through YAML' do
+    regime = described_class.new(code: 'RUSSIA', name: 'Russia/Ukraine measures')
+    restored = described_class.from_yaml(regime.to_yaml)
+    expect(restored.to_hash).to eq(regime.to_hash)
+  end
+end

--- a/spec/ammitto/ontology/sanction/sanction_regime_spec.rb
+++ b/spec/ammitto/ontology/sanction/sanction_regime_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'ammitto'
-require 'ammitto/ontology'
 
 RSpec.describe Ammitto::Ontology::Sanction::SanctionRegime do
   it 'carries code, name, and description' do
@@ -9,6 +8,7 @@ RSpec.describe Ammitto::Ontology::Sanction::SanctionRegime do
                                  description: 'UNSC 1718 measures')
     expect(regime.code).to eq('DPRK')
     expect(regime.name).to eq('North Korea sanctions')
+    expect(regime.description).to eq('UNSC 1718 measures')
   end
 
   describe '#to_hash' do

--- a/spec/ammitto/ontology/value_objects/address_spec.rb
+++ b/spec/ammitto/ontology/value_objects/address_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'ammitto'
+require 'ammitto/ontology'
+
+RSpec.describe Ammitto::Ontology::ValueObjects::Address do
+  describe '#present? / #blank?' do
+    it 'is present when any core field is set' do
+      expect(described_class.new(city: 'Bern')).to be_present
+      expect(described_class.new(street: '1 Main St')).to be_present
+    end
+
+    it 'is blank with no fields, and country_iso_code alone does not count' do
+      expect(described_class.new).to be_blank
+      expect(described_class.new(country_iso_code: 'CH')).to be_blank
+    end
+  end
+
+  describe '#to_s' do
+    it 'joins parts in street, city, region, postal code, country order' do
+      address = described_class.new(street: '1 Main St', city: 'Bern',
+                                    postal_code: '3000', country: 'Switzerland')
+      expect(address.to_s).to eq('1 Main St, Bern, 3000, Switzerland')
+    end
+  end
+
+  describe '#to_hash' do
+    it 'omits nil fields' do
+      expect(described_class.new(city: 'Bern').to_hash).to eq({ city: 'Bern' })
+    end
+  end
+
+  it 'round-trips through YAML' do
+    address = described_class.new(street: '1 Main St', city: 'Bern', country: 'Switzerland')
+    restored = described_class.from_yaml(address.to_yaml)
+    expect(restored.to_hash).to eq(address.to_hash)
+  end
+end

--- a/spec/ammitto/ontology/value_objects/address_spec.rb
+++ b/spec/ammitto/ontology/value_objects/address_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'ammitto'
-require 'ammitto/ontology'
 
 RSpec.describe Ammitto::Ontology::ValueObjects::Address do
   describe '#present? / #blank?' do

--- a/spec/ammitto/ontology/value_objects/birth_info_spec.rb
+++ b/spec/ammitto/ontology/value_objects/birth_info_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'ammitto'
-require 'ammitto/ontology'
 
 RSpec.describe Ammitto::Ontology::ValueObjects::BirthInfo do
   describe '#birth_year' do
@@ -17,10 +16,11 @@ RSpec.describe Ammitto::Ontology::ValueObjects::BirthInfo do
   end
 
   describe '#present?' do
-    it 'counts date, year, city, or country' do
+    it 'counts date, year, city, region, or country' do
       expect(described_class.new(year: 1964)).to be_present
       expect(described_class.new(city: 'Bern')).to be_present
-      expect(described_class.new(region: 'BE')).not_to be_present
+      expect(described_class.new(region: 'BE')).to be_present
+      expect(described_class.new(circa: true)).not_to be_present
     end
   end
 
@@ -28,6 +28,11 @@ RSpec.describe Ammitto::Ontology::ValueObjects::BirthInfo do
     it 'renders exact output with and without circa' do
       expect(described_class.new(year: 1964, circa: true).to_s).to eq('c. 1964')
       expect(described_class.new(year: 1964).to_s).to eq('1964')
+    end
+
+    it 'renders nothing for circa without a date, and region alone' do
+      expect(described_class.new(circa: true).to_s).to eq('')
+      expect(described_class.new(region: 'BE').to_s).to eq('BE')
     end
 
     it 'appends the place exactly, with no stray spacing' do

--- a/spec/ammitto/ontology/value_objects/birth_info_spec.rb
+++ b/spec/ammitto/ontology/value_objects/birth_info_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'ammitto'
+require 'ammitto/ontology'
+
+RSpec.describe Ammitto::Ontology::ValueObjects::BirthInfo do
+  describe '#birth_year' do
+    it 'prefers the full date over the bare year' do
+      info = described_class.new(date: Date.new(1964, 7, 17), year: 1999)
+      expect(info.birth_year).to eq(1964)
+    end
+
+    it 'falls back to the bare year, then nil' do
+      expect(described_class.new(year: 1964).birth_year).to eq(1964)
+      expect(described_class.new.birth_year).to be_nil
+    end
+  end
+
+  describe '#present?' do
+    it 'counts date, year, city, or country' do
+      expect(described_class.new(year: 1964)).to be_present
+      expect(described_class.new(city: 'Bern')).to be_present
+      expect(described_class.new(region: 'BE')).not_to be_present
+    end
+  end
+
+  describe '#to_s' do
+    it 'renders exact output with and without circa' do
+      expect(described_class.new(year: 1964, circa: true).to_s).to eq('c. 1964')
+      expect(described_class.new(year: 1964).to_s).to eq('1964')
+    end
+
+    it 'appends the place exactly, with no stray spacing' do
+      info = described_class.new(date: Date.new(1964, 7, 17), city: 'Bern', country: 'CH')
+      expect(info.to_s).to eq('1964-07-17 Bern, CH')
+    end
+  end
+
+  describe '#to_hash' do
+    it 'omits the default circa=false' do
+      expect(described_class.new(year: 1964).to_hash).to eq({ year: 1964 })
+    end
+  end
+end

--- a/spec/ammitto/ontology/value_objects/contact_info_spec.rb
+++ b/spec/ammitto/ontology/value_objects/contact_info_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'ammitto'
+
+RSpec.describe Ammitto::Ontology::ValueObjects::ContactInfo do
+  describe '#present?' do
+    it 'requires at least one non-blank field' do
+      expect(described_class.new(email: 'a@b.example')).to be_present
+      expect(described_class.new(phone: '+41 31 000 00 00')).to be_present
+      expect(described_class.new(website: 'https://x.example')).to be_present
+      expect(described_class.new(fax: '123')).to be_present
+    end
+
+    it 'is blank when empty or whitespace-only' do
+      expect(described_class.new).not_to be_present
+      expect(described_class.new(email: '  ', phone: '')).not_to be_present
+    end
+  end
+end

--- a/spec/ammitto/ontology/value_objects/identification_spec.rb
+++ b/spec/ammitto/ontology/value_objects/identification_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'ammitto'
-require 'ammitto/ontology'
 
 RSpec.describe Ammitto::Ontology::ValueObjects::Identification do
   describe '#present?' do

--- a/spec/ammitto/ontology/value_objects/identification_spec.rb
+++ b/spec/ammitto/ontology/value_objects/identification_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'ammitto'
+require 'ammitto/ontology'
+
+RSpec.describe Ammitto::Ontology::ValueObjects::Identification do
+  describe '#present?' do
+    it 'depends on the number alone' do
+      expect(described_class.new(number: 'P-123')).to be_present
+      expect(described_class.new(type: 'passport')).not_to be_present
+    end
+  end
+
+  describe '#type_sym' do
+    it 'normalizes known variants' do
+      expect(described_class.new(type: 'Passports').type_sym).to eq(:passport)
+      expect(described_class.new(type: 'national id').type_sym).to eq(:national_id)
+    end
+
+    it 'falls back to :other for unknown or missing types' do
+      expect(described_class.new(type: 'carrier pigeon').type_sym).to eq(:other)
+      expect(described_class.new.type_sym).to eq(:other)
+    end
+  end
+
+  describe '#to_hash' do
+    it 'stringifies dates and omits nils' do
+      id = described_class.new(number: 'P-123', expiry_date: Date.new(2030, 1, 2))
+      expect(id.to_hash).to eq({ number: 'P-123', expiry_date: '2030-01-02' })
+    end
+  end
+
+  it 'round-trips through YAML with date types intact' do
+    id = described_class.new(type: 'passport', number: 'P-123',
+                             issue_date: Date.new(2020, 5, 1))
+    restored = described_class.from_yaml(id.to_yaml)
+    expect(restored.number).to eq('P-123')
+    expect(restored.issue_date).to eq(Date.new(2020, 5, 1))
+  end
+end

--- a/spec/ammitto/ontology/value_objects/legal_instrument_spec.rb
+++ b/spec/ammitto/ontology/value_objects/legal_instrument_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'ammitto'
+require 'ammitto/ontology'
+
+RSpec.describe Ammitto::Ontology::ValueObjects::LegalInstrument do
+  describe '#present?' do
+    it 'requires an identifier or title' do
+      expect(described_class.new(identifier: 'E.O. 14024')).to be_present
+      expect(described_class.new(title: 'Some regulation')).to be_present
+      expect(described_class.new(type: 'regulation')).not_to be_present
+    end
+  end
+
+  describe '#type_sym' do
+    it 'normalizes separator variants' do
+      expect(described_class.new(type: 'Executive Order').type_sym).to eq(:executive_order)
+      expect(described_class.new(type: 'regulation').type_sym).to eq(:regulation)
+    end
+
+    it 'falls back to :other' do
+      expect(described_class.new(type: 'sky writing').type_sym).to eq(:other)
+      expect(described_class.new.type_sym).to eq(:other)
+    end
+  end
+
+  describe '#to_s' do
+    it 'falls back identifier -> title -> placeholder' do
+      expect(described_class.new(identifier: 'E.O. 14024', title: 'T').to_s).to eq('E.O. 14024')
+      expect(described_class.new(title: 'T').to_s).to eq('T')
+      expect(described_class.new.to_s).to eq('Unknown instrument')
+    end
+  end
+
+  it 'round-trips through YAML with dates intact' do
+    instrument = described_class.new(identifier: 'R 269/2014',
+                                     publish_date: Date.new(2014, 3, 17))
+    restored = described_class.from_yaml(instrument.to_yaml)
+    expect(restored.identifier).to eq('R 269/2014')
+    expect(restored.publish_date).to eq(Date.new(2014, 3, 17))
+  end
+end

--- a/spec/ammitto/ontology/value_objects/legal_instrument_spec.rb
+++ b/spec/ammitto/ontology/value_objects/legal_instrument_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'ammitto'
-require 'ammitto/ontology'
 
 RSpec.describe Ammitto::Ontology::ValueObjects::LegalInstrument do
   describe '#present?' do

--- a/spec/ammitto/ontology/value_objects/sanction_effect_spec.rb
+++ b/spec/ammitto/ontology/value_objects/sanction_effect_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'ammitto'
+require 'ammitto/ontology'
+
+RSpec.describe Ammitto::Ontology::ValueObjects::SanctionEffect do
+  describe '#present?' do
+    it 'requires an effect type' do
+      expect(described_class.new(effect_type: 'asset_freeze')).to be_present
+      expect(described_class.new(scope: 'full')).not_to be_present
+    end
+  end
+
+  describe '#type_sym and predicates' do
+    it 'normalizes spaces and dashes' do
+      expect(described_class.new(effect_type: 'asset freeze')).to be_asset_freeze
+      expect(described_class.new(effect_type: 'travel-ban')).to be_travel_ban
+    end
+
+    it 'is not a freeze or ban for unknown types' do
+      effect = described_class.new(effect_type: 'interpretive dance')
+      expect(effect.type_sym).to eq(:other)
+      expect(effect).not_to be_asset_freeze
+      expect(effect).not_to be_travel_ban
+    end
+  end
+
+  describe 'real transformer vocabulary' do
+    it 'normalizes every effect type the transformers emit' do
+      %w[aircraft_ban arms_embargo asset_freeze debarment entry_ban
+         export_ban export_restriction financial_restriction import_ban
+         investment_ban sectoral_sanction service_restriction
+         technology_restriction trade_restriction transaction_ban
+         transport_sanction travel_ban vessel_ban].each do |emitted|
+        effect = described_class.new(effect_type: emitted)
+        expect(effect.type_sym).to eq(emitted.to_sym),
+                                   "#{emitted} collapsed to #{effect.type_sym}"
+      end
+    end
+  end
+
+  describe 'schema-defined vocabulary (self-updating guard)' do
+    it 'covers every measure type any announcement schema defines' do
+      require 'yaml'
+      schema_values = []
+      # Structural walk: any enum nested under a measure context's `type`
+      # property is measure vocabulary. Measure contexts are the `measures`
+      # array properties AND `$defs`-style `measure` definitions referenced
+      # via $ref (Japan's schema shape). No sentinel values — each file must
+      # yield vocabulary or the per-file assertion below fails loudly.
+      collect = lambda do |node, in_measures, in_type, sink|
+        case node
+        when Hash
+          node.each do |key, value|
+            if key == 'enum' && value.is_a?(Array) && in_measures && in_type
+              sink.concat(value.grep(String))
+            else
+              collect.call(value, in_measures || %w[measures measure].include?(key),
+                           in_type || (in_measures && key == 'type'), sink)
+            end
+          end
+        when Array
+          node.each { |item| collect.call(item, in_measures, in_type, sink) }
+        end
+      end
+      schema_files = Dir[File.join(Ammitto.gem_dir, 'schemas', '*', '*announcement*.yml')]
+      expect(schema_files).not_to be_empty, 'no announcement schemas found — path changed?'
+      schema_files.each do |file|
+        file_values = []
+        collect.call(YAML.safe_load_file(file), false, false, file_values)
+        expect(file_values).not_to be_empty,
+                                   "no measure enum found in #{File.basename(file)} — structure changed?"
+        schema_values.concat(file_values)
+      end
+
+      uncovered = schema_values.uniq.map(&:to_sym) -
+                  Ammitto::Ontology::Types::SANCTION_EFFECT_TYPES
+      expect(uncovered).to be_empty,
+                           "schema measure types missing from SANCTION_EFFECT_TYPES: #{uncovered.join(', ')}"
+    end
+  end
+
+  describe '#to_hash' do
+    it 'stringifies dates and omits nils' do
+      effect = described_class.new(effect_type: 'asset_freeze',
+                                   start_date: Date.new(2022, 3, 1))
+      expect(effect.to_hash).to eq({ effect_type: 'asset_freeze', start_date: '2022-03-01' })
+    end
+  end
+end

--- a/spec/ammitto/ontology/value_objects/sanction_effect_spec.rb
+++ b/spec/ammitto/ontology/value_objects/sanction_effect_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'ammitto'
-require 'ammitto/ontology'
 
 RSpec.describe Ammitto::Ontology::ValueObjects::SanctionEffect do
   describe '#present?' do
@@ -25,8 +24,8 @@ RSpec.describe Ammitto::Ontology::ValueObjects::SanctionEffect do
     end
   end
 
-  describe 'real transformer vocabulary' do
-    it 'normalizes every effect type the transformers emit' do
+  describe 'transformer vocabulary snapshot' do
+    it 'normalizes the effect types transformers emitted as of this spec' do
       %w[aircraft_ban arms_embargo asset_freeze debarment entry_ban
          export_ban export_restriction financial_restriction import_ban
          investment_ban sectoral_sanction service_restriction
@@ -63,7 +62,8 @@ RSpec.describe Ammitto::Ontology::ValueObjects::SanctionEffect do
           node.each { |item| collect.call(item, in_measures, in_type, sink) }
         end
       end
-      schema_files = Dir[File.join(Ammitto.gem_dir, 'schemas', '*', '*announcement*.yml')]
+      schema_files = Dir[File.join(Ammitto.gem_dir, 'schemas', '**',
+                                   '*announcement*.{yml,yaml}')]
       expect(schema_files).not_to be_empty, 'no announcement schemas found — path changed?'
       schema_files.each do |file|
         file_values = []

--- a/spec/ammitto/ontology/value_objects/temporal_period_spec.rb
+++ b/spec/ammitto/ontology/value_objects/temporal_period_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'ammitto'
+require 'ammitto/ontology'
+
+RSpec.describe Ammitto::Ontology::ValueObjects::TemporalPeriod do
+  let(:today) { Date.new(2026, 7, 23) }
+
+  describe '#active?' do
+    it 'is active with no dates at all' do
+      expect(described_class.new.active?(as_of: today)).to be(true)
+    end
+
+    it 'is inactive before the effective date and after expiry' do
+      period = described_class.new(effective_date: today + 1)
+      expect(period.active?(as_of: today)).to be(false)
+
+      period = described_class.new(expiry_date: today - 1)
+      expect(period.active?(as_of: today)).to be(false)
+    end
+
+    it 'treats the expiry day itself as still active (exclusive comparison)' do
+      period = described_class.new(expiry_date: today)
+      expect(period.active?(as_of: today)).to be(true)
+    end
+  end
+
+  describe '#expired?' do
+    it 'is truthy only after the expiry date' do
+      expect(described_class.new(expiry_date: today - 1).expired?(as_of: today)).to be(true)
+      expect(described_class.new(expiry_date: today).expired?(as_of: today)).to be(false)
+      expect(described_class.new.expired?(as_of: today)).to be_falsey
+    end
+  end
+
+  describe '#duration_days' do
+    it 'needs both effective and expiry dates' do
+      period = described_class.new(effective_date: today, expiry_date: today + 30)
+      expect(period.duration_days).to eq(30)
+      expect(described_class.new(effective_date: today).duration_days).to be_nil
+    end
+  end
+
+  it 'defaults is_indefinite to false and omits it from to_hash' do
+    period = described_class.new(listed_date: Date.new(2022, 1, 1))
+    expect(period.is_indefinite).to be(false)
+    expect(period.to_hash).to eq({ listed_date: '2022-01-01' })
+  end
+end

--- a/spec/ammitto/ontology/value_objects/temporal_period_spec.rb
+++ b/spec/ammitto/ontology/value_objects/temporal_period_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'ammitto'
-require 'ammitto/ontology'
 
 RSpec.describe Ammitto::Ontology::ValueObjects::TemporalPeriod do
   let(:today) { Date.new(2026, 7, 23) }

--- a/spec/ammitto/utils/presence_spec.rb
+++ b/spec/ammitto/utils/presence_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'ammitto'
+require 'ammitto/utils/presence'
+
+RSpec.describe Ammitto::Utils::Presence do
+  describe '.blank?' do
+    it 'is true for nil, false, empties, and whitespace-only strings' do
+      [nil, false, '', '  ', ' ', [], {}].each do |value|
+        expect(described_class.blank?(value)).to be(true), value.inspect
+      end
+    end
+
+    it 'is false for anything carrying a value' do
+      [0, 'x', ' x ', true, [1], { a: 1 }, Date.new(2026, 1, 1)].each do |value|
+        expect(described_class.blank?(value)).to be(false), value.inspect
+      end
+    end
+  end
+
+  describe '.present?' do
+    it 'inverts .blank?' do
+      expect(described_class.present?('x')).to be(true)
+      expect(described_class.present?(nil)).to be(false)
+    end
+  end
+end

--- a/spec/ammitto/utils/presence_spec.rb
+++ b/spec/ammitto/utils/presence_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'ammitto'
-require 'ammitto/utils/presence'
 
 RSpec.describe Ammitto::Utils::Presence do
   describe '.blank?' do


### PR DESCRIPTION
Added the thirteen ontology specs from the #13 Phase 1.6 checklist (value objects, entities, sanction classes) and fixed the defects writing them surfaced: the layer's **`present?`**/**`blank?`** calls had no provider (added an explicit **`Utils::Presence`** module — no core-class patching), **`Types.normalize_effect_type`**/**`normalize_instrument_type`** didn't exist, **`BirthInfo#to_hash`** was accidentally private, **`add_status_change`** wasn't recording transitions, and `SANCTION_EFFECT_TYPES` was missing 36 emitted types — now schema-driven with a guard spec that parses the announcement schemas so future measure types can't silently collapse to `:other`.

Depends on #18
