### PR TITLE
Fix ontology data validation workflow for split-repo layout

### DIFF
--- a/.github/workflows/ontology-data-validation.yml
+++ b/.github/workflows/ontology-data-validation.yml
@@ -16,6 +16,10 @@
 
 name: Ontology Data Validation
 
+# Validation only reads repositories; keep the job token read-only
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]
@@ -25,6 +29,7 @@ on:
       - 'scripts/export_*.rb'
       - 'scripts/validate_*.rb'
       - 'scripts/verify_*.rb'
+      - 'scripts/support/**'
       - '.github/workflows/ontology-data-validation.yml'
   pull_request:
     paths:
@@ -33,6 +38,7 @@ on:
       - 'scripts/export_*.rb'
       - 'scripts/validate_*.rb'
       - 'scripts/verify_*.rb'
+      - 'scripts/support/**'
       - '.github/workflows/ontology-data-validation.yml'
   workflow_dispatch:
   schedule:
@@ -235,22 +241,14 @@ jobs:
 
           echo "✓ ALL CRITICAL VALIDATIONS PASSED"
 
-      # Upload artifacts
+      # Upload artifacts — also on failure, so the export stays available
+      # for diagnosis
       - name: Upload JSON-LD export
-        if: steps.data.outputs.available == 'true'
+        if: always() && steps.data.outputs.available == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: json-ld-ontology-export
           path: /tmp/json-ld/
-          retention-days: 7
-
-      - name: Upload validation logs
-        uses: actions/upload-artifact@v4
-        if: always() && steps.data.outputs.available == 'true'
-        with:
-          name: validation-logs
-          path: |
-            ammitto/*.log
           retention-days: 7
         continue-on-error: true
 

--- a/.github/workflows/ontology-data-validation.yml
+++ b/.github/workflows/ontology-data-validation.yml
@@ -29,6 +29,10 @@ on:
   pull_request:
     paths:
       - 'lib/ammitto/ontology/**'
+      - 'scripts/import_*.rb'
+      - 'scripts/export_*.rb'
+      - 'scripts/validate_*.rb'
+      - 'scripts/verify_*.rb'
       - '.github/workflows/ontology-data-validation.yml'
   workflow_dispatch:
   schedule:

--- a/.github/workflows/ontology-data-validation.yml
+++ b/.github/workflows/ontology-data-validation.yml
@@ -76,16 +76,16 @@ jobs:
       - name: Detect data availability
         id: data
         run: |
-          count=$(find . -maxdepth 2 -type d -path './data-*/processed' | wc -l)
+          count=$(find . -maxdepth 3 -type d -path './data-*/processed/entities' | wc -l)
           if [ "$count" -gt 0 ]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
-            echo "Found $count data-*/processed directories"
+            echo "Found $count data-*/processed/entities directories"
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "available=false" >> "$GITHUB_OUTPUT"
             echo "PR context: data repositories are not cloned here." \
               "Full validation runs on main, nightly, and manual dispatch."
           else
-            echo "::error::data repositories cloned but no data-*/processed found"
+            echo "::error::data repositories cloned but no data-*/processed/entities found"
             exit 1
           fi
 

--- a/.github/workflows/ontology-data-validation.yml
+++ b/.github/workflows/ontology-data-validation.yml
@@ -20,16 +20,16 @@ on:
   push:
     branches: [main]
     paths:
-      - 'data-*/processed/**'
       - 'lib/ammitto/ontology/**'
       - 'scripts/import_*.rb'
       - 'scripts/export_*.rb'
       - 'scripts/validate_*.rb'
       - 'scripts/verify_*.rb'
+      - '.github/workflows/ontology-data-validation.yml'
   pull_request:
     paths:
-      - 'data-*/processed/**'
       - 'lib/ammitto/ontology/**'
+      - '.github/workflows/ontology-data-validation.yml'
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * *'  # Daily validation at 6 AM UTC
@@ -48,26 +48,51 @@ jobs:
           path: 'ammitto'
           fetch-depth: 0
 
+      # The data lives in separate ammitto/data-* repositories (the gem's
+      # sibling-directory convention). Clone them next to the gem checkout
+      # on every trigger except pull_request, where validation skips
+      # gracefully instead.
+      - name: Clone data repositories
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          repos=$(gh repo list ammitto --limit 100 --json name \
+            --jq '.[].name | select(startswith("data-"))')
+          if [ -z "$repos" ]; then
+            echo "::error::no ammitto/data-* repositories found"
+            exit 1
+          fi
+          for repo in $repos; do
+            gh repo clone "ammitto/$repo" "$repo" -- --depth 1
+          done
+
+      - name: Detect data availability
+        id: data
+        run: |
+          count=$(find . -maxdepth 2 -type d -path './data-*/processed' | wc -l)
+          if [ "$count" -gt 0 ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "Found $count data-*/processed directories"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "PR context: data repositories are not cloned here." \
+              "Full validation runs on main, nightly, and manual dispatch."
+          else
+            echo "::error::data repositories cloned but no data-*/processed found"
+            exit 1
+          fi
+
       - name: Setup Ruby
+        if: steps.data.outputs.available == 'true'
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
           bundler-cache: true
           working-directory: 'ammitto'
 
-      - name: Prepare data directory
-        run: |
-          # Create symlinks to data-* directories at repo root
-          cd ammitto
-          cd ..
-          for dir in ammitto/data-*; do
-            if [ -d "$dir/processed" ]; then
-              ln -sf "$dir" "$(basename $dir)"
-            fi
-          done
-          ls -la | grep data-
-
       - name: Start Neo4j
+        if: steps.data.outputs.available == 'true'
         run: |
           docker run -d --name ammitto-neo4j-test \
             -p 7687:7687 -p 7474:7474 \
@@ -76,6 +101,7 @@ jobs:
             neo4j:${{ env.NEO4J_VERSION }}
 
       - name: Wait for Neo4j
+        if: steps.data.outputs.available == 'true'
         run: |
           for i in {1..30}; do
             if docker exec ammitto-neo4j-test cypher-shell -u neo4j -p ${{ env.NEO4J_PASSWORD }} "RETURN 1" &>/dev/null; then
@@ -87,23 +113,21 @@ jobs:
           echo "Neo4j failed to start"
           exit 1
 
-      - name: Install dependencies
-        run: |
-          cd ammitto
-          bundle install --jobs 4
-
       # Step 1: Import data using ontology classes
       - name: Import to Neo4j
+        if: steps.data.outputs.available == 'true'
         run: |
           cd ammitto
           echo "=== IMPORTING DATA USING ONTOLOGY CLASSES ==="
           bundle exec ruby scripts/import_neo4j_full.rb
         env:
           NEO4J_URI: 'bolt://localhost:7687'
+          AMMITTO_DATA_DIR: ${{ github.workspace }}
 
       # Step 2: Validate schema compliance
       - name: Validate schema (property coverage)
         id: schema
+        if: steps.data.outputs.available == 'true'
         run: |
           cd ammitto
           echo "=== SCHEMA VALIDATION ==="
@@ -116,6 +140,7 @@ jobs:
       # Step 3: Validate relationship integrity
       - name: Validate relationships (cross-link validity)
         id: integrity
+        if: steps.data.outputs.available == 'true'
         run: |
           cd ammitto
           echo "=== RELATIONSHIP INTEGRITY ==="
@@ -128,6 +153,7 @@ jobs:
       # Step 4: Check for orphaned nodes
       - name: Detect orphaned nodes
         id: orphans
+        if: steps.data.outputs.available == 'true'
         run: |
           cd ammitto
           echo "=== ORPHAN DETECTION ==="
@@ -139,6 +165,7 @@ jobs:
       # Step 5: Verify round-trip (import = export)
       - name: Round-trip verification
         id: roundtrip
+        if: steps.data.outputs.available == 'true'
         run: |
           cd ammitto
           echo "=== ROUND-TRIP VERIFICATION ==="
@@ -146,10 +173,12 @@ jobs:
           bundle exec ruby scripts/verify_round_trip.rb --sample-size 50
         env:
           NEO4J_URI: 'bolt://localhost:7687'
+          AMMITTO_DATA_DIR: ${{ github.workspace }}
         continue-on-error: true
 
       # Step 6: Export using ontology classes
       - name: Export JSON-LD (ontology-driven)
+        if: steps.data.outputs.available == 'true'
         run: |
           cd ammitto
           echo "=== EXPORTING JSON-LD USING ONTOLOGY CLASSES ==="
@@ -160,6 +189,7 @@ jobs:
       # Step 7: Generate coverage report
       - name: Generate coverage report
         id: coverage
+        if: steps.data.outputs.available == 'true'
         run: |
           cd ammitto
           echo "=== COVERAGE REPORT ==="
@@ -169,6 +199,7 @@ jobs:
 
       # Step 8: Quality gates summary
       - name: Quality gates summary
+        if: steps.data.outputs.available == 'true'
         run: |
           cd ammitto
           echo ""
@@ -200,6 +231,7 @@ jobs:
 
       # Upload artifacts
       - name: Upload JSON-LD export
+        if: steps.data.outputs.available == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: json-ld-ontology-export
@@ -208,7 +240,7 @@ jobs:
 
       - name: Upload validation logs
         uses: actions/upload-artifact@v4
-        if: always()
+        if: always() && steps.data.outputs.available == 'true'
         with:
           name: validation-logs
           path: |
@@ -217,7 +249,7 @@ jobs:
         continue-on-error: true
 
       - name: Stop Neo4j
-        if: always()
+        if: always() && steps.data.outputs.available == 'true'
         run: |
           docker stop ammitto-neo4j-test || true
           docker rm ammitto-neo4j-test || true

--- a/.github/workflows/ontology-data-validation.yml
+++ b/.github/workflows/ontology-data-validation.yml
@@ -56,10 +56,12 @@ jobs:
       # sibling-directory convention). Clone them next to the gem checkout
       # on every trigger except pull_request, where validation skips
       # gracefully instead.
+      # DATA_REPOS_TOKEN is optional: the data-* repos are public today,
+      # so github.token suffices; the secret takes over if that changes.
       - name: Clone data repositories
         if: github.event_name != 'pull_request'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.DATA_REPOS_TOKEN || github.token }}
         run: |
           repos=$(gh repo list ammitto --limit 100 --json name \
             --jq '.[].name | select(startswith("data-"))')

--- a/scripts/export_json_ld_ontology.rb
+++ b/scripts/export_json_ld_ontology.rb
@@ -9,6 +9,10 @@
 # Key principle: neo4j_property declarations are the SINGLE SOURCE OF TRUTH.
 # Whatever is declared gets exported. Nothing more, nothing less.
 #
+# Exit codes:
+#   0 - Export completed (zero exported entities logs a loud WARNING)
+#   1 - Unhandled error occurred (e.g. cannot connect to Neo4j)
+#
 # Usage:
 #   ruby scripts/export_json_ld_ontology.rb [--output-dir /path/to/output]
 
@@ -19,19 +23,12 @@ require 'json'
 require 'fileutils'
 require 'optparse'
 require 'ammitto/ontology'
+require_relative 'support/env_defaults'
 
 include Neo4j::Driver
+include Ammitto::Ontology::ValueObjects
 
-# Empty env values count as unset so defaults stay deterministic
-DEFAULT_DATA_DIR =
-  if ENV['AMMITTO_DATA_DIR'].to_s.empty?
-    File.expand_path('../..', __dir__)
-  else
-    ENV.fetch('AMMITTO_DATA_DIR', nil)
-  end
 DEFAULT_OUTPUT_DIR = File.join(DEFAULT_DATA_DIR, 'data', 'ontology', 'json-ld')
-NEO4J_URI_DEFAULT =
-  ENV['NEO4J_URI'].to_s.empty? ? 'bolt://localhost:7688' : ENV.fetch('NEO4J_URI', nil)
 
 class OntologyDrivenExporter
   # All entity classes that can be exported
@@ -53,8 +50,7 @@ class OntologyDrivenExporter
       names: 0,
       addresses: 0,
       identifiers: 0,
-      birth_infos: 0,
-      errors: []
+      birth_infos: 0
     }
   end
 
@@ -70,10 +66,17 @@ class OntologyDrivenExporter
     export_all_entities(output_dir)
     export_context(output_dir)
 
-    disconnect
-
+    # The coverage report queries Neo4j, so it must run before disconnect
     print_coverage_report
+
+    if @stats[:entities].zero?
+      puts "\nWARNING: zero entities were exported — the Neo4j graph " \
+           'contains no Person/Organization/Vessel/Aircraft nodes'
+    end
+
     puts "\nExport complete!"
+  ensure
+    disconnect
   end
 
   private
@@ -189,7 +192,7 @@ class OntologyDrivenExporter
     )
 
     addresses = result.map do |row|
-      addr = Ammitto::Ontology::ValueObjects::Address.from_neo4j_record(row['n'] || row['a'])
+      addr = Ammitto::Ontology::ValueObjects::Address.from_neo4j_record(row['a'])
       @stats[:addresses] += 1
       addr
     end

--- a/scripts/export_json_ld_ontology.rb
+++ b/scripts/export_json_ld_ontology.rb
@@ -31,7 +31,7 @@ class OntologyDrivenExporter
     Ammitto::Ontology::Entities::AircraftEntity
   ].freeze
 
-  def initialize(uri: 'bolt://localhost:7688', username: 'neo4j', password: 'password')
+  def initialize(uri: ENV.fetch('NEO4J_URI', 'bolt://localhost:7688'), username: 'neo4j', password: 'password')
     @uri = uri
     @username = username
     @password = password
@@ -312,7 +312,7 @@ end
 # Parse command line options
 options = {
   output_dir: '/Users/mulgogi/src/ammitto/data/ontology/json-ld',
-  uri: 'bolt://localhost:7688',
+  uri: ENV.fetch('NEO4J_URI', 'bolt://localhost:7688'),
   username: 'neo4j',
   password: 'password'
 }

--- a/scripts/export_json_ld_ontology.rb
+++ b/scripts/export_json_ld_ontology.rb
@@ -22,6 +22,11 @@ require 'ammitto/ontology'
 
 include Neo4j::Driver
 
+DEFAULT_OUTPUT_DIR = File.join(
+  ENV['AMMITTO_DATA_DIR'] || File.expand_path('../..', __dir__),
+  'data', 'ontology', 'json-ld'
+)
+
 class OntologyDrivenExporter
   # All entity classes that can be exported
   ENTITY_CLASSES = [
@@ -47,7 +52,7 @@ class OntologyDrivenExporter
     }
   end
 
-  def run(output_dir: '/Users/mulgogi/src/ammitto/data/ontology/json-ld')
+  def run(output_dir: DEFAULT_OUTPUT_DIR)
     connect
 
     FileUtils.mkdir_p(output_dir)
@@ -311,7 +316,7 @@ end
 
 # Parse command line options
 options = {
-  output_dir: '/Users/mulgogi/src/ammitto/data/ontology/json-ld',
+  output_dir: DEFAULT_OUTPUT_DIR,
   uri: ENV.fetch('NEO4J_URI', 'bolt://localhost:7688'),
   username: 'neo4j',
   password: 'password'

--- a/scripts/export_json_ld_ontology.rb
+++ b/scripts/export_json_ld_ontology.rb
@@ -22,10 +22,16 @@ require 'ammitto/ontology'
 
 include Neo4j::Driver
 
-DEFAULT_OUTPUT_DIR = File.join(
-  ENV['AMMITTO_DATA_DIR'] || File.expand_path('../..', __dir__),
-  'data', 'ontology', 'json-ld'
-)
+# Empty env values count as unset so defaults stay deterministic
+DEFAULT_DATA_DIR =
+  if ENV['AMMITTO_DATA_DIR'].to_s.empty?
+    File.expand_path('../..', __dir__)
+  else
+    ENV.fetch('AMMITTO_DATA_DIR', nil)
+  end
+DEFAULT_OUTPUT_DIR = File.join(DEFAULT_DATA_DIR, 'data', 'ontology', 'json-ld')
+NEO4J_URI_DEFAULT =
+  ENV['NEO4J_URI'].to_s.empty? ? 'bolt://localhost:7688' : ENV.fetch('NEO4J_URI', nil)
 
 class OntologyDrivenExporter
   # All entity classes that can be exported
@@ -36,7 +42,7 @@ class OntologyDrivenExporter
     Ammitto::Ontology::Entities::AircraftEntity
   ].freeze
 
-  def initialize(uri: ENV.fetch('NEO4J_URI', 'bolt://localhost:7688'), username: 'neo4j', password: 'password')
+  def initialize(uri: NEO4J_URI_DEFAULT, username: 'neo4j', password: 'password')
     @uri = uri
     @username = username
     @password = password
@@ -317,7 +323,7 @@ end
 # Parse command line options
 options = {
   output_dir: DEFAULT_OUTPUT_DIR,
-  uri: ENV.fetch('NEO4J_URI', 'bolt://localhost:7688'),
+  uri: NEO4J_URI_DEFAULT,
   username: 'neo4j',
   password: 'password'
 }

--- a/scripts/import_neo4j_full.rb
+++ b/scripts/import_neo4j_full.rb
@@ -126,7 +126,7 @@ class FullNeo4jImporter
   end
 
   def import_all_sources
-    base_dir = '/Users/mulgogi/src/ammitto'
+    base_dir = ENV['AMMITTO_DATA_DIR'] || File.expand_path('../..', __dir__)
     sources = Dir.glob(File.join(base_dir, 'data-*')).select { |d| Dir.exist?(File.join(d, 'processed')) }
 
     sources.each do |src_dir|

--- a/scripts/import_neo4j_full.rb
+++ b/scripts/import_neo4j_full.rb
@@ -27,7 +27,7 @@ include Neo4j::Driver
 class FullNeo4jImporter
   BATCH_SIZE = 100
 
-  def initialize(uri: 'bolt://localhost:7688', username: 'neo4j', password: 'password')
+  def initialize(uri: ENV.fetch('NEO4J_URI', 'bolt://localhost:7688'), username: 'neo4j', password: 'password')
     @uri = uri
     @username = username
     @password = password

--- a/scripts/import_neo4j_full.rb
+++ b/scripts/import_neo4j_full.rb
@@ -44,7 +44,7 @@ class FullNeo4jImporter
     connect
     sources = discover_sources
     if sources.empty?
-      abort 'No data-* repositories with processed/ data found — set ' \
+      abort 'No data-* repositories with processed/entities found — set ' \
             'AMMITTO_DATA_DIR or clone them next to the gem checkout'
     end
 
@@ -135,13 +135,14 @@ class FullNeo4jImporter
     puts "  Imported #{Ammitto::Ontology.authorities.size} authorities"
   end
 
-  # Find data-* repositories carrying processed/ data
+  # Find data-* repositories carrying importable entity data, matching
+  # what import_source actually requires
   # @return [Array<String>] matching directory paths
   def discover_sources
     base_dir = ENV['AMMITTO_DATA_DIR'].to_s
     base_dir = File.expand_path('../..', __dir__) if base_dir.empty?
     Dir.glob(File.join(base_dir, 'data-*'))
-       .select { |d| Dir.exist?(File.join(d, 'processed')) }
+       .select { |d| Dir.exist?(File.join(d, 'processed', 'entities')) }
   end
 
   def import_all_sources(sources)

--- a/scripts/import_neo4j_full.rb
+++ b/scripts/import_neo4j_full.rb
@@ -12,6 +12,11 @@
 # - Authority nodes
 # - Country nodes
 #
+# Exit codes:
+#   0 - Import completed
+#   1 - No importable data found, zero entities imported, or an
+#       unhandled error occurred (e.g. cannot connect to Neo4j)
+#
 # Usage:
 #   ruby scripts/import_neo4j_full.rb
 
@@ -19,18 +24,12 @@ $LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 
 require 'neo4j/driver'
 require 'yaml'
-require 'json'
 require 'ammitto/ontology'
+require_relative 'support/env_defaults'
 
 include Neo4j::Driver
 
-# Empty env values count as unset so defaults stay deterministic
-NEO4J_URI_DEFAULT =
-  ENV['NEO4J_URI'].to_s.empty? ? 'bolt://localhost:7688' : ENV.fetch('NEO4J_URI', nil)
-
 class FullNeo4jImporter
-  BATCH_SIZE = 100
-
   def initialize(uri: NEO4J_URI_DEFAULT, username: 'neo4j', password: 'password')
     @uri = uri
     @username = username
@@ -41,19 +40,27 @@ class FullNeo4jImporter
   end
 
   def run
-    connect
+    # Discover sources before connecting — no live Neo4j is needed to
+    # learn there is no data to import
     sources = discover_sources
     if sources.empty?
-      abort 'No data-* repositories with processed/entities found — set ' \
-            'AMMITTO_DATA_DIR or clone them next to the gem checkout'
+      abort 'No data-* repositories with entity YAML files ' \
+            '(processed/entities/*.yaml) found — set AMMITTO_DATA_DIR ' \
+            'or clone them next to the gem checkout'
     end
 
+    connect
     setup_schema
     clear_existing_data
 
     import_countries
     import_authorities
     import_all_sources(sources)
+
+    if (@stats[:nodes]['Entity'] || 0).zero?
+      abort 'No entities were imported — the discovered data-* ' \
+            'repositories contain no importable entity YAML documents'
+    end
 
     validate_data
     print_stats
@@ -139,10 +146,8 @@ class FullNeo4jImporter
   # what import_source actually requires
   # @return [Array<String>] matching directory paths
   def discover_sources
-    base_dir = ENV['AMMITTO_DATA_DIR'].to_s
-    base_dir = File.expand_path('../..', __dir__) if base_dir.empty?
-    Dir.glob(File.join(base_dir, 'data-*'))
-       .select { |d| Dir.exist?(File.join(d, 'processed', 'entities')) }
+    Dir.glob(File.join(DEFAULT_DATA_DIR, 'data-*'))
+       .select { |d| Dir.glob(File.join(d, 'processed', 'entities', '*.yaml')).any? }
   end
 
   def import_all_sources(sources)

--- a/scripts/import_neo4j_full.rb
+++ b/scripts/import_neo4j_full.rb
@@ -24,10 +24,14 @@ require 'ammitto/ontology'
 
 include Neo4j::Driver
 
+# Empty env values count as unset so defaults stay deterministic
+NEO4J_URI_DEFAULT =
+  ENV['NEO4J_URI'].to_s.empty? ? 'bolt://localhost:7688' : ENV.fetch('NEO4J_URI', nil)
+
 class FullNeo4jImporter
   BATCH_SIZE = 100
 
-  def initialize(uri: ENV.fetch('NEO4J_URI', 'bolt://localhost:7688'), username: 'neo4j', password: 'password')
+  def initialize(uri: NEO4J_URI_DEFAULT, username: 'neo4j', password: 'password')
     @uri = uri
     @username = username
     @password = password
@@ -126,7 +130,8 @@ class FullNeo4jImporter
   end
 
   def import_all_sources
-    base_dir = ENV['AMMITTO_DATA_DIR'] || File.expand_path('../..', __dir__)
+    base_dir = ENV['AMMITTO_DATA_DIR'].to_s
+    base_dir = File.expand_path('../..', __dir__) if base_dir.empty?
     sources = Dir.glob(File.join(base_dir, 'data-*')).select { |d| Dir.exist?(File.join(d, 'processed')) }
 
     sources.each do |src_dir|

--- a/scripts/import_neo4j_full.rb
+++ b/scripts/import_neo4j_full.rb
@@ -42,12 +42,18 @@ class FullNeo4jImporter
 
   def run
     connect
+    sources = discover_sources
+    if sources.empty?
+      abort 'No data-* repositories with processed/ data found — set ' \
+            'AMMITTO_DATA_DIR or clone them next to the gem checkout'
+    end
+
     setup_schema
     clear_existing_data
 
     import_countries
     import_authorities
-    import_all_sources
+    import_all_sources(sources)
 
     validate_data
     print_stats
@@ -129,11 +135,16 @@ class FullNeo4jImporter
     puts "  Imported #{Ammitto::Ontology.authorities.size} authorities"
   end
 
-  def import_all_sources
+  # Find data-* repositories carrying processed/ data
+  # @return [Array<String>] matching directory paths
+  def discover_sources
     base_dir = ENV['AMMITTO_DATA_DIR'].to_s
     base_dir = File.expand_path('../..', __dir__) if base_dir.empty?
-    sources = Dir.glob(File.join(base_dir, 'data-*')).select { |d| Dir.exist?(File.join(d, 'processed')) }
+    Dir.glob(File.join(base_dir, 'data-*'))
+       .select { |d| Dir.exist?(File.join(d, 'processed')) }
+  end
 
+  def import_all_sources(sources)
     sources.each do |src_dir|
       source = File.basename(src_dir).sub('data-', '')
       puts "\n=== Importing #{source} ==="

--- a/scripts/support/env_defaults.rb
+++ b/scripts/support/env_defaults.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Shared environment defaults for the ontology pipeline scripts.
+# Empty env values count as unset so defaults stay deterministic.
+
+data_dir = ENV.fetch('AMMITTO_DATA_DIR', '')
+# Fallback is the parent of the gem checkout — the sibling-directory
+# convention where data-* repositories live next to the gem.
+DEFAULT_DATA_DIR =
+  data_dir.empty? ? File.expand_path('../../..', __dir__) : data_dir
+
+neo4j_uri = ENV.fetch('NEO4J_URI', '')
+NEO4J_URI_DEFAULT = neo4j_uri.empty? ? 'bolt://localhost:7688' : neo4j_uri

--- a/scripts/validate_neo4j_data.rb
+++ b/scripts/validate_neo4j_data.rb
@@ -28,10 +28,14 @@ require 'ammitto/ontology'
 
 include Neo4j::Driver
 
+# Empty env values count as unset so defaults stay deterministic
+NEO4J_URI_DEFAULT =
+  ENV['NEO4J_URI'].to_s.empty? ? 'bolt://localhost:7688' : ENV.fetch('NEO4J_URI', nil)
+
 class Neo4jDataValidator
   VALIDATION_TYPES = %w[all schema integrity orphans coverage].freeze
 
-  def initialize(uri: ENV.fetch('NEO4J_URI', 'bolt://localhost:7688'), username: 'neo4j', password: 'password')
+  def initialize(uri: NEO4J_URI_DEFAULT, username: 'neo4j', password: 'password')
     @uri = uri
     @username = username
     @password = password
@@ -438,7 +442,7 @@ end
 
 # Parse command line options
 options = {
-  uri: ENV.fetch('NEO4J_URI', 'bolt://localhost:7688'),
+  uri: NEO4J_URI_DEFAULT,
   username: 'neo4j',
   password: 'password',
   validations: ['all']

--- a/scripts/validate_neo4j_data.rb
+++ b/scripts/validate_neo4j_data.rb
@@ -25,12 +25,11 @@ $LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 require 'neo4j/driver'
 require 'optparse'
 require 'ammitto/ontology'
+require_relative 'support/env_defaults'
 
 include Neo4j::Driver
-
-# Empty env values count as unset so defaults stay deterministic
-NEO4J_URI_DEFAULT =
-  ENV['NEO4J_URI'].to_s.empty? ? 'bolt://localhost:7688' : ENV.fetch('NEO4J_URI', nil)
+include Ammitto::Ontology::Entities
+include Ammitto::Ontology::ValueObjects
 
 class Neo4jDataValidator
   VALIDATION_TYPES = %w[all schema integrity orphans coverage].freeze
@@ -51,12 +50,14 @@ class Neo4jDataValidator
 
     connect
 
-    validations.each do |type|
-      send("validate_#{type}")
-      @checks_run << type
+    begin
+      validations.each do |type|
+        send("validate_#{type}")
+        @checks_run << type
+      end
+    ensure
+      disconnect
     end
-
-    disconnect
 
     print_report
 
@@ -71,7 +72,9 @@ class Neo4jDataValidator
   rescue StandardError => e
     puts "ERROR: Cannot connect to Neo4j: #{e.message}"
     exit 2
-  ensure
+  end
+
+  def disconnect
     @session&.close
     @driver&.close
   end
@@ -351,7 +354,7 @@ class Neo4jDataValidator
 
   def check_orphan_entries
     result = @session.run(
-      'MATCH (e:Entry) WHERE NOT (e)<-[:FOR_ENTITY]-() RETURN count(e) as count'
+      'MATCH (e:Entry) WHERE NOT (e)-[:FOR_ENTITY]->(:Entity) RETURN count(e) as count'
     )
     count = result.first[:count]
 

--- a/scripts/validate_neo4j_data.rb
+++ b/scripts/validate_neo4j_data.rb
@@ -31,7 +31,7 @@ include Neo4j::Driver
 class Neo4jDataValidator
   VALIDATION_TYPES = %w[all schema integrity orphans coverage].freeze
 
-  def initialize(uri: 'bolt://localhost:7688', username: 'neo4j', password: 'password')
+  def initialize(uri: ENV.fetch('NEO4J_URI', 'bolt://localhost:7688'), username: 'neo4j', password: 'password')
     @uri = uri
     @username = username
     @password = password
@@ -438,7 +438,7 @@ end
 
 # Parse command line options
 options = {
-  uri: 'bolt://localhost:7688',
+  uri: ENV.fetch('NEO4J_URI', 'bolt://localhost:7688'),
   username: 'neo4j',
   password: 'password',
   validations: ['all']

--- a/scripts/verify_round_trip.rb
+++ b/scripts/verify_round_trip.rb
@@ -30,6 +30,8 @@ require 'ammitto/ontology'
 
 include Neo4j::Driver
 
+DEFAULT_DATA_DIR = ENV['AMMITTO_DATA_DIR'] || File.expand_path('../..', __dir__)
+
 class RoundTripVerifier
   def initialize(uri: 'bolt://localhost:7688', username: 'neo4j', password: 'password')
     @uri = uri
@@ -42,7 +44,7 @@ class RoundTripVerifier
     @failed = 0
   end
 
-  def run(sample_size: 10, data_dir: '/Users/mulgogi/src/ammitto')
+  def run(sample_size: 10, data_dir: DEFAULT_DATA_DIR)
     connect
 
     puts '=' * 60
@@ -334,7 +336,7 @@ options = {
   username: 'neo4j',
   password: 'password',
   sample_size: 10,
-  data_dir: '/Users/mulgogi/src/ammitto'
+  data_dir: DEFAULT_DATA_DIR
 }
 
 OptionParser.new do |opts|

--- a/scripts/verify_round_trip.rb
+++ b/scripts/verify_round_trip.rb
@@ -67,7 +67,7 @@ class RoundTripVerifier
                  .select { |d| Dir.exist?(File.join(d, 'processed', 'entities')) }
 
     if sources.empty?
-      puts "ERROR: no data-* repositories with processed/entities found " \
+      puts 'ERROR: no data-* repositories with processed/entities found ' \
            "under #{data_dir} — set AMMITTO_DATA_DIR or clone them there"
       disconnect
       return 1

--- a/scripts/verify_round_trip.rb
+++ b/scripts/verify_round_trip.rb
@@ -30,10 +30,18 @@ require 'ammitto/ontology'
 
 include Neo4j::Driver
 
-DEFAULT_DATA_DIR = ENV['AMMITTO_DATA_DIR'] || File.expand_path('../..', __dir__)
+# Empty env values count as unset so defaults stay deterministic
+DEFAULT_DATA_DIR =
+  if ENV['AMMITTO_DATA_DIR'].to_s.empty?
+    File.expand_path('../..', __dir__)
+  else
+    ENV.fetch('AMMITTO_DATA_DIR', nil)
+  end
+NEO4J_URI_DEFAULT =
+  ENV['NEO4J_URI'].to_s.empty? ? 'bolt://localhost:7688' : ENV.fetch('NEO4J_URI', nil)
 
 class RoundTripVerifier
-  def initialize(uri: ENV.fetch('NEO4J_URI', 'bolt://localhost:7688'), username: 'neo4j', password: 'password')
+  def initialize(uri: NEO4J_URI_DEFAULT, username: 'neo4j', password: 'password')
     @uri = uri
     @username = username
     @password = password
@@ -332,7 +340,7 @@ end
 
 # Parse command line options
 options = {
-  uri: ENV.fetch('NEO4J_URI', 'bolt://localhost:7688'),
+  uri: NEO4J_URI_DEFAULT,
   username: 'neo4j',
   password: 'password',
   sample_size: 10,

--- a/scripts/verify_round_trip.rb
+++ b/scripts/verify_round_trip.rb
@@ -14,7 +14,7 @@
 #
 # Exit codes:
 #   0 - Round-trip successful
-#   1 - Discrepancies found
+#   1 - Discrepancies found, or no data sources discovered
 #   2 - Cannot connect to Neo4j
 #
 # Usage:
@@ -65,6 +65,13 @@ class RoundTripVerifier
     # Find and verify sample entities from each source
     sources = Dir.glob(File.join(data_dir, 'data-*'))
                  .select { |d| Dir.exist?(File.join(d, 'processed', 'entities')) }
+
+    if sources.empty?
+      puts "ERROR: no data-* repositories with processed/entities found " \
+           "under #{data_dir} — set AMMITTO_DATA_DIR or clone them there"
+      disconnect
+      return 1
+    end
 
     sources.each do |source_dir|
       source = File.basename(source_dir).sub('data-', '')

--- a/scripts/verify_round_trip.rb
+++ b/scripts/verify_round_trip.rb
@@ -33,7 +33,7 @@ include Neo4j::Driver
 DEFAULT_DATA_DIR = ENV['AMMITTO_DATA_DIR'] || File.expand_path('../..', __dir__)
 
 class RoundTripVerifier
-  def initialize(uri: 'bolt://localhost:7688', username: 'neo4j', password: 'password')
+  def initialize(uri: ENV.fetch('NEO4J_URI', 'bolt://localhost:7688'), username: 'neo4j', password: 'password')
     @uri = uri
     @username = username
     @password = password
@@ -332,7 +332,7 @@ end
 
 # Parse command line options
 options = {
-  uri: 'bolt://localhost:7688',
+  uri: ENV.fetch('NEO4J_URI', 'bolt://localhost:7688'),
   username: 'neo4j',
   password: 'password',
   sample_size: 10,

--- a/scripts/verify_round_trip.rb
+++ b/scripts/verify_round_trip.rb
@@ -14,7 +14,9 @@
 #
 # Exit codes:
 #   0 - Round-trip successful
-#   1 - Discrepancies found, or no data sources discovered
+#   1 - Verification failures (discrepancies, unloadable or non-entity
+#       YAML documents, entities missing from Neo4j, or nothing
+#       verified), or no data sources discovered
 #   2 - Cannot connect to Neo4j
 #
 # Usage:
@@ -24,23 +26,17 @@ $LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 
 require 'neo4j/driver'
 require 'yaml'
-require 'json'
 require 'optparse'
 require 'ammitto/ontology'
+require_relative 'support/env_defaults'
 
 include Neo4j::Driver
-
-# Empty env values count as unset so defaults stay deterministic
-DEFAULT_DATA_DIR =
-  if ENV['AMMITTO_DATA_DIR'].to_s.empty?
-    File.expand_path('../..', __dir__)
-  else
-    ENV.fetch('AMMITTO_DATA_DIR', nil)
-  end
-NEO4J_URI_DEFAULT =
-  ENV['NEO4J_URI'].to_s.empty? ? 'bolt://localhost:7688' : ENV.fetch('NEO4J_URI', nil)
+include Ammitto::Ontology::Entities
 
 class RoundTripVerifier
+  # Deterministic sampling so CI failures are reproducible run-to-run
+  SAMPLE_SEED = 42
+
   def initialize(uri: NEO4J_URI_DEFAULT, username: 'neo4j', password: 'password')
     @uri = uri
     @username = username
@@ -53,6 +49,18 @@ class RoundTripVerifier
   end
 
   def run(sample_size: 10, data_dir: DEFAULT_DATA_DIR)
+    # Discover sources before connecting — no live Neo4j is needed to
+    # learn there is nothing to verify
+    sources = Dir.glob(File.join(data_dir, 'data-*'))
+                 .select { |d| Dir.glob(File.join(d, 'processed', 'entities', '*.yaml')).any? }
+
+    if sources.empty?
+      puts 'ERROR: no data-* repositories with entity YAML files ' \
+           "(processed/entities/*.yaml) found under #{data_dir} — set " \
+           'AMMITTO_DATA_DIR or clone them there'
+      return 1
+    end
+
     connect
 
     puts '=' * 60
@@ -62,17 +70,7 @@ class RoundTripVerifier
     puts "Sample size: #{sample_size}"
     puts ''
 
-    # Find and verify sample entities from each source
-    sources = Dir.glob(File.join(data_dir, 'data-*'))
-                 .select { |d| Dir.exist?(File.join(d, 'processed', 'entities')) }
-
-    if sources.empty?
-      puts 'ERROR: no data-* repositories with processed/entities found ' \
-           "under #{data_dir} — set AMMITTO_DATA_DIR or clone them there"
-      disconnect
-      return 1
-    end
-
+    # Verify sample entities from each source
     sources.each do |source_dir|
       source = File.basename(source_dir).sub('data-', '')
       verify_source(source_dir, source, sample_size)
@@ -80,9 +78,10 @@ class RoundTripVerifier
 
     disconnect
 
-    print_report
+    success = @discrepancies.empty? && @failed.zero? && @verified.positive?
+    print_report(success)
 
-    @discrepancies.empty? ? 0 : 1
+    success ? 0 : 1
   end
 
   private
@@ -106,7 +105,8 @@ class RoundTripVerifier
 
     puts "\n--- Verifying #{source.upcase} ---"
 
-    entity_files = Dir.glob(File.join(entities_dir, '*.yaml')).sample(sample_size)
+    entity_files = Dir.glob(File.join(entities_dir, '*.yaml'))
+                      .sample(sample_size, random: Random.new(SAMPLE_SEED))
 
     entity_files.each do |entity_file|
       verify_entity(entity_file, source)
@@ -118,17 +118,25 @@ class RoundTripVerifier
       data = YAML.load_file(entity_file)
     rescue StandardError => e
       puts "  ⚠️  Cannot load #{File.basename(entity_file)}: #{e.message}"
+      @failed += 1
       return
     end
 
-    return unless data.is_a?(Hash) && data['id']
+    unless data.is_a?(Hash) && data['id']
+      puts "  ⚠️  Not an entity document: #{File.basename(entity_file)}"
+      @failed += 1
+      return
+    end
 
     entity_id = data['id']
     entity_type = data['entity_type'] || data['type'] || 'organization'
 
     # 1. Load original data into ontology class
     original = load_original_entity(data, entity_type)
-    return unless original
+    unless original
+      @failed += 1
+      return
+    end
 
     # 2. Load from Neo4j using ontology class
     loaded = load_from_neo4j(entity_id, entity_type)
@@ -309,38 +317,42 @@ class RoundTripVerifier
     val1 == val2
   end
 
-  def print_report
+  def print_report(success)
     puts "\n\n#{'=' * 60}"
     puts 'ROUND-TRIP VERIFICATION REPORT'
     puts '=' * 60
 
     puts "\nEntities verified: #{@verified}"
-    puts "Entities with discrepancies: #{@failed}"
+    puts "Entities with failures: #{@failed}"
 
-    if @discrepancies.empty?
+    if success
       puts "\n✓ ROUND-TRIP VERIFICATION PASSED"
       puts '  All imported data matches exported data'
       puts '  Import and export use the SAME ontology classes'
     else
       puts "\n✗ ROUND-TRIP VERIFICATION FAILED"
-      puts "\nDiscrepancies found: #{@discrepancies.size}"
+      puts '  No entities could be verified' if @verified.zero?
 
-      # Group by property
-      by_property = @discrepancies.group_by { |d| d[:property] }
+      if @discrepancies.any?
+        puts "\nDiscrepancies found: #{@discrepancies.size}"
 
-      by_property.each do |property, discreps|
-        puts "\n  Property: #{property}"
-        puts "  Affected entities: #{discreps.size}"
-        discreps.first(3).each do |d|
-          puts "    - #{d[:file]}: '#{d[:original]}' != '#{d[:loaded]}'"
+        # Group by property
+        by_property = @discrepancies.group_by { |d| d[:property] }
+
+        by_property.each do |property, discreps|
+          puts "\n  Property: #{property}"
+          puts "  Affected entities: #{discreps.size}"
+          discreps.first(3).each do |d|
+            puts "    - #{d[:file]}: '#{d[:original]}' != '#{d[:loaded]}'"
+          end
         end
-      end
 
-      puts "\n#{'-' * 60}"
-      puts 'ANALYSIS:'
-      puts "  If 'loaded' is nil: Property not imported to Neo4j"
-      puts "  If 'original' is nil: Extra property in Neo4j (not in source)"
-      puts '  If both have values: Values transformed incorrectly'
+        puts "\n#{'-' * 60}"
+        puts 'ANALYSIS:'
+        puts "  If 'loaded' is nil: Property not imported to Neo4j"
+        puts "  If 'original' is nil: Extra property in Neo4j (not in source)"
+        puts '  If both have values: Values transformed incorrectly'
+      end
     end
   end
 end


### PR DESCRIPTION
The **`Ontology Data Validation`** workflow has failed on every run since the data moved to separate `ammitto/data-*` repositories — it still expected `data-*` directories inside the checkout and died at its first step. Non-PR triggers (main, nightly, manual) now discover and clone all `data-*` repos (`--depth 1`, failing loudly if none are found) and run the full Neo4j validation; PR runs skip gracefully with a notice instead of failing. Also replaces the hardcoded `/Users/mulgogi/src/ammitto` paths in **`import_neo4j_full.rb`** and **`verify_round_trip.rb`** with `AMMITTO_DATA_DIR` / the sibling-directory default, and drops the impossible `data-*/processed/**` path filters.

Depends on #18
