### PR TITLE
Add Ammitto::Validation facade for unified file and object validation

### DIFF
--- a/lib/ammitto.rb
+++ b/lib/ammitto.rb
@@ -79,6 +79,9 @@ require_relative 'ammitto/ontology/json_ld_context'
 require_relative 'ammitto/schema/context'
 require_relative 'ammitto/schema/validator'
 
+# Validation facade
+require_relative 'ammitto/validation'
+
 # Transformers
 require_relative 'ammitto/transformers/registry'
 

--- a/lib/ammitto/authority.rb
+++ b/lib/ammitto/authority.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'lutaml/model'
+
 module Ammitto
   # Authority represents a sanctions-issuing authority
   #

--- a/lib/ammitto/config/env_provider.rb
+++ b/lib/ammitto/config/env_provider.rb
@@ -42,11 +42,16 @@ module Ammitto
       ENV_ALIASES = { sources_dir: 'DATA_DIR' }.freeze
 
       class << self
-        # Check if any Ammitto ENV variables are set
+        # Check if any Ammitto ENV variable carries a usable value
+        #
+        # Mirrors {configuration}: variables set to an empty string are
+        # ignored there, so they do not count as set here either.
+        #
         # @return [Boolean]
         def any_set?
-          (ENV_MAPPING.values + ENV_ALIASES.values)
-            .any? { |env_var| ENV.fetch("#{PREFIX}#{env_var}", nil) }
+          ENV_MAPPING.any? do |key, env_var|
+            !env_value(env_var, ENV_ALIASES[key]).nil?
+          end
         end
 
         # Get configuration from environment

--- a/lib/ammitto/config/env_provider.rb
+++ b/lib/ammitto/config/env_provider.rb
@@ -9,6 +9,9 @@ module Ammitto
     #
     # Supported environment variables:
     #   AMMITTO_CACHE_DIR - Directory for caching data
+    #   AMMITTO_SOURCES_DIR - Parent directory containing data-* repos
+    #     (AMMITTO_DATA_DIR is honored as an alias; the CI validation
+    #     scripts use that name for the same directory)
     #   AMMITTO_API_BASE_URL - Base URL for API
     #   AMMITTO_LOG_LEVEL - Log level (debug, info, warn, error)
     #   AMMITTO_SOURCES - Comma-separated list of sources
@@ -35,11 +38,15 @@ module Ammitto
         sources_dir: 'SOURCES_DIR'
       }.freeze
 
+      # Fallback ENV names consulted when the primary variable is unset
+      ENV_ALIASES = { sources_dir: 'DATA_DIR' }.freeze
+
       class << self
         # Check if any Ammitto ENV variables are set
         # @return [Boolean]
         def any_set?
-          ENV_MAPPING.keys.any? { |key| ENV.fetch("#{PREFIX}#{key.to_s.upcase}", nil) }
+          (ENV_MAPPING.values + ENV_ALIASES.values)
+            .any? { |env_var| ENV.fetch("#{PREFIX}#{env_var}", nil) }
         end
 
         # Get configuration from environment
@@ -48,8 +55,8 @@ module Ammitto
           config = {}
 
           ENV_MAPPING.each do |key, env_var|
-            value = ENV.fetch("#{PREFIX}#{env_var}", nil)
-            next if value.nil? || value.empty?
+            value = env_value(env_var, ENV_ALIASES[key])
+            next if value.nil?
 
             config[key] = parse_value(key, value)
           end
@@ -58,6 +65,18 @@ module Ammitto
         end
 
         private
+
+        # Read an ENV variable, falling back to its alias
+        # @param primary [String] primary variable name (without prefix)
+        # @param fallback [String, nil] alias name (without prefix)
+        # @return [String, nil] the value, or nil when unset/empty
+        def env_value(primary, fallback)
+          [primary, fallback].compact.each do |name|
+            value = ENV.fetch("#{PREFIX}#{name}", nil)
+            return value unless value.nil? || value.empty?
+          end
+          nil
+        end
 
         # Parse value based on option type
         # @param key [Symbol] option key

--- a/lib/ammitto/config/override_resolver.rb
+++ b/lib/ammitto/config/override_resolver.rb
@@ -51,6 +51,7 @@ module Ammitto
       def resolve_all
         {
           cache_dir: resolve(:cache_dir),
+          sources_dir: resolve(:sources_dir),
           api_base_url: resolve(:api_base_url),
           log_level: resolve(:log_level),
           sources: resolve(:sources),
@@ -75,6 +76,7 @@ module Ammitto
       def default_value(key)
         case key
         when :cache_dir then Defaults::CACHE_DIR
+        when :sources_dir then Defaults::SOURCES_DIR
         when :api_base_url then Defaults::API_BASE_URL
         when :log_level then Defaults::LOG_LEVEL
         when :sources then Defaults::DEFAULT_SOURCES

--- a/lib/ammitto/data/china/validator.rb
+++ b/lib/ammitto/data/china/validator.rb
@@ -1,21 +1,17 @@
 # frozen_string_literal: true
 
-require 'yaml'
-require 'json'
-begin
-  require 'json-schema'
-rescue LoadError
-  # json-schema not available - validation will be skipped
-end
+require_relative '../../validation'
 
 module Ammitto
   module Data
     module China
       # Validates China source YAML files against JSON schemas
       #
-      # Validator provides comprehensive validation of China sanctions data files
-      # against JSON schemas. It supports multiple schema types and provides
-      # detailed error reporting.
+      # Thin compatibility wrapper over
+      # Ammitto::Validation::FileSchemaValidator: the validation flow
+      # lives in the country-parameterized facade, while this class
+      # keeps the original return shapes (Boolean plus #errors for
+      # single files, report hashes for batches) for existing callers.
       #
       # @example Validate a single file
       #   validator = Validator.new
@@ -35,59 +31,32 @@ module Ammitto
         # Initialize the validator
         # @param schemas_dir [String, nil] Optional custom schemas directory
         def initialize(schemas_dir = nil)
-          @schemas_dir = schemas_dir || default_schemas_dir
+          @facade = Validation::FileSchemaValidator.new(country: :china)
+          @schemas_dir = schemas_dir || @facade.schemas_dir
           @errors = []
-          @schema_cache = {}
         end
 
         # Validate a single YAML file
         #
         # @param file_path [String] Path to YAML file
         # @return [Boolean] true if valid
+        # rubocop:disable Naming/PredicateMethod -- legacy public API name
         def validate(file_path)
-          @errors = []
-
-          unless File.exist?(file_path)
-            @errors << { path: file_path, message: 'File not found' }
-            return false
-          end
-
-          data = load_yaml(file_path)
-          return false if data.nil?
-
-          schema_type = SchemaResolver.resolve(file_path, data)
-          schema = load_schema(schema_type)
-          return false if schema.nil?
-
-          validate_against_schema(data, schema, file_path)
+          result = @facade.validate_file(file_path)
+          @errors = Validation::Result.deep_dup(result.errors)
+          result.valid?
         end
+        # rubocop:enable Naming/PredicateMethod
 
         # Validate multiple files
         #
         # @param file_paths [Array<String>] List of file paths to validate
-        # @return [Hash] Validation report with :valid, :total_files, :valid_files,
-        #   :invalid_files, :errors
+        # @return [Hash] Validation report with :valid, :total_files,
+        #   :valid_files, :invalid_files, :errors
         def validate_files(file_paths)
-          report = {
-            valid: true,
-            total_files: 0,
-            valid_files: 0,
-            invalid_files: 0,
-            errors: []
-          }
-
-          file_paths.each do |file|
-            report[:total_files] += 1
-            if validate(file)
-              report[:valid_files] += 1
-            else
-              report[:valid] = false
-              report[:invalid_files] += 1
-              report[:errors] << { file: file, errors: @errors.dup }
-            end
-          end
-
-          report
+          result = @facade.validate_files(file_paths)
+          @errors = last_file_errors(file_paths, result)
+          Validation::FileSchemaValidator.legacy_report(result)
         end
 
         # Validate all files in sources directory
@@ -96,19 +65,10 @@ module Ammitto
         # @return [Hash] Validation report
         def validate_all(sources_dir = nil)
           sources_dir ||= File.join(File.dirname(@schemas_dir), 'sources')
-
-          unless Dir.exist?(sources_dir)
-            return {
-              valid: false,
-              total_files: 0,
-              valid_files: 0,
-              invalid_files: 0,
-              errors: [{ message: "Sources directory not found: #{sources_dir}" }]
-            }
-          end
-
-          yaml_files = find_yaml_files(sources_dir)
-          validate_files(yaml_files)
+          files = @facade.find_yaml_files(sources_dir)
+          result = @facade.validate_directory(sources_dir)
+          @errors = last_file_errors(files, result)
+          Validation::FileSchemaValidator.legacy_report(result)
         end
 
         # Get list of YAML files in directory
@@ -116,68 +76,24 @@ module Ammitto
         # @param sources_dir [String] Path to sources directory
         # @return [Array<String>] List of YAML file paths
         def find_yaml_files(sources_dir)
-          Dir.glob(File.join(sources_dir, '**', '*.yml')) +
-            Dir.glob(File.join(sources_dir, '**', '*.yaml'))
+          @facade.find_yaml_files(sources_dir)
         end
 
         private
 
-        # Default schemas directory (ammitto/schemas/china)
-        def default_schemas_dir
-          File.expand_path('../../../../schemas/china', __dir__)
-        end
+        # Legacy #errors semantics: batch calls leave the last file's
+        # errors behind (empty when the last file was valid)
+        #
+        # @param file_paths [Array<String>] the validated files, in order
+        # @param result [Ammitto::Validation::Result] the batch result
+        # @return [Array<Hash>]
+        def last_file_errors(file_paths, result)
+          last = file_paths.last
+          return [] unless last
 
-        # Load a YAML file with error handling
-        # @param file_path [String] Path to YAML file
-        # @return [Hash, nil] Parsed content or nil on error
-        def load_yaml(file_path)
-          YAML.safe_load_file(file_path, permitted_classes: [Date, Time], aliases: true)
-        rescue Psych::SyntaxError => e
-          @errors << { path: file_path, message: "YAML syntax error: #{e.message}" }
-          nil
-        rescue StandardError => e
-          @errors << { path: file_path, message: "Failed to load file: #{e.message}" }
-          nil
-        end
-
-        # Load a schema by type
-        # @param schema_type [Symbol] The schema type
-        # @return [Hash, nil] The schema or nil if not found
-        def load_schema(schema_type)
-          @schema_cache[schema_type] ||= begin
-            SchemaLoader.load(schema_type)
-          rescue SchemaNotFoundError => e
-            @errors << { message: e.message }
-            nil
-          end
-        end
-
-        # Validate data against a JSON schema
-        # @param data [Hash] The data to validate
-        # @param schema [Hash] The JSON schema
-        # @param file_path [String] The file path for error reporting
-        # @return [Boolean] true if valid
-        def validate_against_schema(data, schema, file_path)
-          unless defined?(JSON::Validator)
-            @errors << { path: file_path, message: 'json-schema gem not available for validation' }
-            return false
-          end
-
-          begin
-            # Convert to JSON and back to ensure proper format for validator
-            json_content = JSON.parse(data.to_json)
-            JSON::Validator.validate!(schema, json_content, validate_schema: false)
-            true
-          rescue JSON::Schema::ValidationError => e
-            @errors << { path: file_path, message: e.message }
-            false
-          rescue JSON::Schema::SchemaError => e
-            @errors << { path: file_path, message: "Schema error: #{e.message}" }
-            false
-          rescue StandardError => e
-            @errors << { path: file_path, message: "Validation error: #{e.message}" }
-            false
-          end
+          group = result.details[:file_errors]
+                        &.find { |entry| entry[:file] == last }
+          group ? Validation::Result.deep_dup(group[:errors]) : []
         end
       end
     end

--- a/lib/ammitto/data/china/validator.rb
+++ b/lib/ammitto/data/china/validator.rb
@@ -65,9 +65,9 @@ module Ammitto
         # @return [Hash] Validation report
         def validate_all(sources_dir = nil)
           sources_dir ||= File.join(File.dirname(@schemas_dir), 'sources')
-          files = @facade.find_yaml_files(sources_dir)
           result = @facade.validate_directory(sources_dir)
-          @errors = last_file_errors(files, result)
+          @errors = last_file_errors(result.details.fetch(:files, []),
+                                     result)
           Validation::FileSchemaValidator.legacy_report(result)
         end
 

--- a/lib/ammitto/data/japan/validator.rb
+++ b/lib/ammitto/data/japan/validator.rb
@@ -1,24 +1,17 @@
 # frozen_string_literal: true
 
-require 'yaml'
-require 'json'
-begin
-  require 'json-schema'
-rescue LoadError
-  # json-schema not available - validation will be skipped
-end
-
-require_relative 'schema_loader'
-require_relative 'schema_resolver'
+require_relative '../../validation'
 
 module Ammitto
   module Data
     module Japan
       # Validates Japan source YAML files against JSON schemas
       #
-      # Validator provides comprehensive validation of Japan sanctions data files
-      # against JSON schemas. It supports multiple schema types and provides
-      # detailed error reporting.
+      # Thin compatibility wrapper over
+      # Ammitto::Validation::FileSchemaValidator: the validation flow
+      # lives in the country-parameterized facade, while this class
+      # keeps the original return shapes (Boolean plus #errors for
+      # single files, report hashes for batches) for existing callers.
       #
       # @example Validate a single file
       #   validator = Validator.new
@@ -38,59 +31,32 @@ module Ammitto
         # Initialize the validator
         # @param schemas_dir [String, nil] Optional custom schemas directory
         def initialize(schemas_dir = nil)
-          @schemas_dir = schemas_dir || default_schemas_dir
+          @facade = Validation::FileSchemaValidator.new(country: :japan)
+          @schemas_dir = schemas_dir || @facade.schemas_dir
           @errors = []
-          @schema_cache = {}
         end
 
         # Validate a single YAML file
         #
         # @param file_path [String] Path to YAML file
         # @return [Boolean] true if valid
+        # rubocop:disable Naming/PredicateMethod -- legacy public API name
         def validate(file_path)
-          @errors = []
-
-          unless File.exist?(file_path)
-            @errors << { path: file_path, message: 'File not found' }
-            return false
-          end
-
-          data = load_yaml(file_path)
-          return false if data.nil?
-
-          schema_type = SchemaResolver.resolve(file_path, data)
-          schema = load_schema(schema_type)
-          return false if schema.nil?
-
-          validate_against_schema(data, schema, file_path)
+          result = @facade.validate_file(file_path)
+          @errors = Validation::Result.deep_dup(result.errors)
+          result.valid?
         end
+        # rubocop:enable Naming/PredicateMethod
 
         # Validate multiple files
         #
         # @param file_paths [Array<String>] List of file paths to validate
-        # @return [Hash] Validation report with :valid, :total_files, :valid_files,
-        #   :invalid_files, :errors
+        # @return [Hash] Validation report with :valid, :total_files,
+        #   :valid_files, :invalid_files, :errors
         def validate_files(file_paths)
-          report = {
-            valid: true,
-            total_files: 0,
-            valid_files: 0,
-            invalid_files: 0,
-            errors: []
-          }
-
-          file_paths.each do |file|
-            report[:total_files] += 1
-            if validate(file)
-              report[:valid_files] += 1
-            else
-              report[:valid] = false
-              report[:invalid_files] += 1
-              report[:errors] << { file: file, errors: @errors.dup }
-            end
-          end
-
-          report
+          result = @facade.validate_files(file_paths)
+          @errors = last_file_errors(file_paths, result)
+          Validation::FileSchemaValidator.legacy_report(result)
         end
 
         # Validate all files in sources directory
@@ -99,19 +65,10 @@ module Ammitto
         # @return [Hash] Validation report
         def validate_all(sources_dir = nil)
           sources_dir ||= File.join(File.dirname(@schemas_dir), 'sources')
-
-          unless Dir.exist?(sources_dir)
-            return {
-              valid: false,
-              total_files: 0,
-              valid_files: 0,
-              invalid_files: 0,
-              errors: [{ message: "Sources directory not found: #{sources_dir}" }]
-            }
-          end
-
-          yaml_files = find_yaml_files(sources_dir)
-          validate_files(yaml_files)
+          files = @facade.find_yaml_files(sources_dir)
+          result = @facade.validate_directory(sources_dir)
+          @errors = last_file_errors(files, result)
+          Validation::FileSchemaValidator.legacy_report(result)
         end
 
         # Get list of YAML files in directory
@@ -119,68 +76,24 @@ module Ammitto
         # @param sources_dir [String] Path to sources directory
         # @return [Array<String>] List of YAML file paths
         def find_yaml_files(sources_dir)
-          Dir.glob(File.join(sources_dir, '**', '*.yml')) +
-            Dir.glob(File.join(sources_dir, '**', '*.yaml'))
+          @facade.find_yaml_files(sources_dir)
         end
 
         private
 
-        # Default schemas directory (ammitto/schemas/japan)
-        def default_schemas_dir
-          File.expand_path('../../../schemas/japan', __dir__)
-        end
+        # Legacy #errors semantics: batch calls leave the last file's
+        # errors behind (empty when the last file was valid)
+        #
+        # @param file_paths [Array<String>] the validated files, in order
+        # @param result [Ammitto::Validation::Result] the batch result
+        # @return [Array<Hash>]
+        def last_file_errors(file_paths, result)
+          last = file_paths.last
+          return [] unless last
 
-        # Load a YAML file with error handling
-        # @param file_path [String] Path to YAML file
-        # @return [Hash, nil] Parsed content or nil on error
-        def load_yaml(file_path)
-          YAML.safe_load_file(file_path, permitted_classes: [Date, Time], aliases: true)
-        rescue Psych::SyntaxError => e
-          @errors << { path: file_path, message: "YAML syntax error: #{e.message}" }
-          nil
-        rescue StandardError => e
-          @errors << { path: file_path, message: "Failed to load file: #{e.message}" }
-          nil
-        end
-
-        # Load a schema by type
-        # @param schema_type [Symbol] The schema type
-        # @return [Hash, nil] The schema or nil if not found
-        def load_schema(schema_type)
-          @schema_cache[schema_type] ||= begin
-            SchemaLoader.load(schema_type)
-          rescue SchemaNotFoundError => e
-            @errors << { message: e.message }
-            nil
-          end
-        end
-
-        # Validate data against a JSON schema
-        # @param data [Hash] The data to validate
-        # @param schema [Hash] The JSON schema
-        # @param file_path [String] The file path for error reporting
-        # @return [Boolean] true if valid
-        def validate_against_schema(data, schema, file_path)
-          unless defined?(JSON::Validator)
-            @errors << { path: file_path, message: 'json-schema gem not available for validation' }
-            return false
-          end
-
-          begin
-            # Convert to JSON and back to ensure proper format for validator
-            json_content = JSON.parse(data.to_json)
-            JSON::Validator.validate!(schema, json_content, validate_schema: false)
-            true
-          rescue JSON::Schema::ValidationError => e
-            @errors << { path: file_path, message: e.message }
-            false
-          rescue JSON::Schema::SchemaError => e
-            @errors << { path: file_path, message: "Schema error: #{e.message}" }
-            false
-          rescue StandardError => e
-            @errors << { path: file_path, message: "Validation error: #{e.message}" }
-            false
-          end
+          group = result.details[:file_errors]
+                        &.find { |entry| entry[:file] == last }
+          group ? Validation::Result.deep_dup(group[:errors]) : []
         end
       end
     end

--- a/lib/ammitto/data/japan/validator.rb
+++ b/lib/ammitto/data/japan/validator.rb
@@ -65,9 +65,9 @@ module Ammitto
         # @return [Hash] Validation report
         def validate_all(sources_dir = nil)
           sources_dir ||= File.join(File.dirname(@schemas_dir), 'sources')
-          files = @facade.find_yaml_files(sources_dir)
           result = @facade.validate_directory(sources_dir)
-          @errors = last_file_errors(files, result)
+          @errors = last_file_errors(result.details.fetch(:files, []),
+                                     result)
           Validation::FileSchemaValidator.legacy_report(result)
         end
 

--- a/lib/ammitto/schema/validator.rb
+++ b/lib/ammitto/schema/validator.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 
+require_relative '../authority'
 require_relative '../ontology/types'
 require_relative '../status_change'
 

--- a/lib/ammitto/schema/validator.rb
+++ b/lib/ammitto/schema/validator.rb
@@ -2,6 +2,9 @@
 
 require 'json'
 
+require_relative '../ontology/types'
+require_relative '../status_change'
+
 module Ammitto
   module Schema
     # Validator validates JSON-LD data against Ammitto schemas
@@ -17,10 +20,13 @@ module Ammitto
       # Required fields for Entity
       ENTITY_REQUIRED = %w[id entityType names].freeze
 
-      # Valid entity types
-      ENTITY_TYPES = %w[person organization vessel aircraft].freeze
+      # Valid entity types (single source of truth: Ontology::Types)
+      ENTITY_TYPES = Ontology::Types::ENTITY_TYPES.map(&:to_s).freeze
 
-      # Valid statuses
+      # Valid statuses. Deliberately the harmonized StatusChange set,
+      # not Ontology::Types::SANCTION_STATUSES: the two sets differ
+      # (resumed/terminated/deceased vs pending) and this validator
+      # checks harmonized JSON-LD payloads.
       STATUSES = StatusChange::STATUSES
 
       # Validate a sanction entry

--- a/lib/ammitto/status_change.rb
+++ b/lib/ammitto/status_change.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'lutaml/model'
+
 module Ammitto
   # NoticeReference represents a reference to an official notice
   #

--- a/lib/ammitto/validation.rb
+++ b/lib/ammitto/validation.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative 'validation/result'
+require_relative 'validation/file_schema_validator'
+require_relative 'validation/object_validator'
+
+module Ammitto
+  # Facade over the gem's validation machinery
+  #
+  # Entry point for the two in-process validation planes: YAML files
+  # against per-country JSON schemas ({FileSchemaValidator}) and
+  # in-memory hashes against harmonized-payload rules
+  # ({ObjectValidator}). Every call returns a {Result}. The persisted
+  # graph plane (scripts/validate_neo4j_data.rb and friends) is
+  # intentionally not wrapped here.
+  #
+  # @example Validate a source file or directory
+  #   Ammitto::Validation.file('sources/', country: :china).valid?
+  #
+  # @example Validate an in-memory entity hash
+  #   Ammitto::Validation.object(data, type: :entity).errors
+  #
+  module Validation
+    class << self
+      # Validate a YAML file or directory against country schemas
+      #
+      # @param path [String] a YAML file path or a directory to walk
+      # @param country [Symbol, String] a registered country key
+      #   (see FileSchemaValidator::COUNTRIES)
+      # @return [Result]
+      # @raise [UnknownCountryError] for unregistered countries
+      def file(path, country:)
+        validator = FileSchemaValidator.new(country: country)
+        if File.directory?(path)
+          validator.validate_directory(path)
+        else
+          validator.validate_file(path)
+        end
+      end
+
+      # Validate an in-memory hash as a harmonized payload type
+      #
+      # @param data [Hash] the data to validate
+      # @param type [Symbol, String] one of
+      #   ObjectValidator::TYPE_CHECKS keys
+      # @return [Result]
+      # @raise [ArgumentError] for unknown validation types
+      def object(data, type:)
+        ObjectValidator.new.validate(data, type: type)
+      end
+    end
+  end
+end

--- a/lib/ammitto/validation/file_schema_validator.rb
+++ b/lib/ammitto/validation/file_schema_validator.rb
@@ -98,7 +98,8 @@ module Ammitto
       #
       # @param file_paths [Array<String>] paths to validate
       # @return [Result] with :total_files, :valid_files, :invalid_files
-      #   counts and per-file :file_errors groups in {Result#details}
+      #   counts, per-file :file_errors groups, and the validated
+      #   :files list (in validation order) in {Result#details}
       def validate_files(file_paths)
         groups = file_paths.filter_map do |file|
           errors = file_errors(file)
@@ -111,7 +112,8 @@ module Ammitto
             total_files: file_paths.length,
             valid_files: file_paths.length - groups.length,
             invalid_files: groups.length,
-            file_errors: groups
+            file_errors: groups,
+            files: file_paths
           }
         )
       end
@@ -125,7 +127,7 @@ module Ammitto
           return Result.failure(
             { message: "Sources directory not found: #{sources_dir}" },
             details: { total_files: 0, valid_files: 0, invalid_files: 0,
-                       file_errors: [] }
+                       file_errors: [], files: [] }
           )
         end
 

--- a/lib/ammitto/validation/file_schema_validator.rb
+++ b/lib/ammitto/validation/file_schema_validator.rb
@@ -60,6 +60,10 @@ module Ammitto
         Data::Japan::SchemaNotFoundError
       ].freeze
 
+      # Sentinel caching a schema type whose file is missing, so repeated
+      # lookups don't re-raise for every validated file
+      MissingSchema = Struct.new(:message)
+
       # @return [Symbol] registered country key (:china, :japan)
       attr_reader :country
 
@@ -218,13 +222,26 @@ module Ammitto
 
       # Load and cache a schema by type, recording load failures
       #
+      # Negative lookups are memoized too: the miss is cached as a
+      # {MissingSchema} and re-reported per file without reloading.
+      #
       # @param schema_type [Symbol] resolver-provided schema type
       # @param errors [Array<Hash>] error sink
       # @return [Hash, nil] the schema, or nil when unavailable
       def load_schema(schema_type, errors)
-        @schema_cache[schema_type] ||= @loader.load(schema_type)
-      rescue *MISSING_SCHEMA_ERRORS => e
-        errors << { message: e.message }
+        unless @schema_cache.key?(schema_type)
+          @schema_cache[schema_type] =
+            begin
+              @loader.load(schema_type)
+            rescue *MISSING_SCHEMA_ERRORS => e
+              MissingSchema.new(e.message)
+            end
+        end
+
+        cached = @schema_cache[schema_type]
+        return cached unless cached.is_a?(MissingSchema)
+
+        errors << { message: cached.message }
         nil
       end
 

--- a/lib/ammitto/validation/file_schema_validator.rb
+++ b/lib/ammitto/validation/file_schema_validator.rb
@@ -1,0 +1,257 @@
+# frozen_string_literal: true
+
+require 'yaml'
+require 'json'
+begin
+  require 'json-schema'
+rescue LoadError
+  # json-schema not available - validation will be skipped
+end
+
+require_relative 'result'
+require_relative '../data/china/schema_loader'
+require_relative '../data/china/schema_resolver'
+require_relative '../data/japan/schema_loader'
+require_relative '../data/japan/schema_resolver'
+
+module Ammitto
+  module Validation
+    # Raised when asked to validate files for an unregistered country
+    class UnknownCountryError < ArgumentError; end
+
+    # Country-parameterized YAML-file-vs-JSON-Schema validator
+    #
+    # Single implementation behind the per-country file validators
+    # (Data::China::Validator, Data::Japan::Validator): each country
+    # contributes its schema machinery via {COUNTRIES}, and the
+    # validation flow (YAML load, schema resolution, JSON-Schema run) is
+    # shared. All public methods return {Result} objects.
+    #
+    # @example Validate a single file
+    #   validator = FileSchemaValidator.new(country: :china)
+    #   result = validator.validate_file('sources/announcement.yml')
+    #   result.valid? # => true
+    #
+    # @example Validate a directory tree
+    #   result = validator.validate_directory('sources/')
+    #   result.details[:invalid_files] # => 0
+    #
+    class FileSchemaValidator
+      # Registered per-country schema machinery: the resolver picks a
+      # schema type for a file, the loader loads that schema, and
+      # schemas_dir is where the country's schema files live.
+      COUNTRIES = {
+        china: {
+          resolver: Data::China::SchemaResolver,
+          loader: Data::China::SchemaLoader,
+          schemas_dir: Data::China::SchemaLoader::SCHEMAS_DIR
+        }.freeze,
+        japan: {
+          resolver: Data::Japan::SchemaResolver,
+          loader: Data::Japan::SchemaLoader,
+          schemas_dir: Data::Japan::SchemaLoader::SCHEMAS_DIR
+        }.freeze
+      }.freeze
+
+      # Errors the country schema loaders raise for unknown or missing
+      # schema files
+      MISSING_SCHEMA_ERRORS = [
+        Data::China::SchemaNotFoundError,
+        Data::Japan::SchemaNotFoundError
+      ].freeze
+
+      # @return [Symbol] registered country key (:china, :japan)
+      attr_reader :country
+
+      # @return [String] directory holding the country's schema files
+      attr_reader :schemas_dir
+
+      # Initialize a validator for one country
+      #
+      # @param country [Symbol, String] a {COUNTRIES} key
+      # @raise [UnknownCountryError] for unregistered countries
+      def initialize(country:)
+        entry = COUNTRIES[country&.to_sym]
+        unless entry
+          raise UnknownCountryError,
+                "Unknown country: #{country.inspect} " \
+                "(supported: #{COUNTRIES.keys.join(', ')})"
+        end
+
+        @country = country.to_sym
+        @resolver = entry[:resolver]
+        @loader = entry[:loader]
+        @schemas_dir = entry[:schemas_dir]
+        @schema_cache = {}
+      end
+
+      # Validate a single YAML file against its resolved schema
+      #
+      # @param file_path [String] path to the YAML file
+      # @return [Result]
+      def validate_file(file_path)
+        Result.new(errors: file_errors(file_path),
+                   details: { file: file_path })
+      end
+
+      # Validate multiple YAML files
+      #
+      # @param file_paths [Array<String>] paths to validate
+      # @return [Result] with :total_files, :valid_files, :invalid_files
+      #   counts and per-file :file_errors groups in {Result#details}
+      def validate_files(file_paths)
+        groups = file_paths.filter_map do |file|
+          errors = file_errors(file)
+          { file: file, errors: errors } if errors.any?
+        end
+
+        Result.new(
+          errors: groups.flat_map { |group| group[:errors] },
+          details: {
+            total_files: file_paths.length,
+            valid_files: file_paths.length - groups.length,
+            invalid_files: groups.length,
+            file_errors: groups
+          }
+        )
+      end
+
+      # Validate every YAML file under a directory
+      #
+      # @param sources_dir [String] directory to walk
+      # @return [Result]
+      def validate_directory(sources_dir)
+        unless Dir.exist?(sources_dir)
+          return Result.failure(
+            { message: "Sources directory not found: #{sources_dir}" },
+            details: { total_files: 0, valid_files: 0, invalid_files: 0,
+                       file_errors: [] }
+          )
+        end
+
+        validate_files(find_yaml_files(sources_dir))
+      end
+
+      # List YAML files under a directory
+      #
+      # @param sources_dir [String] directory to walk
+      # @return [Array<String>] .yml and .yaml file paths
+      def find_yaml_files(sources_dir)
+        Dir.glob(File.join(sources_dir, '**', '*.yml')) +
+          Dir.glob(File.join(sources_dir, '**', '*.yaml'))
+      end
+
+      # Render a multi-file {Result} in the legacy report shape returned
+      # by the per-country validators
+      #
+      # @param result [Result] produced by {#validate_files} or
+      #   {#validate_directory}
+      # @return [Hash] with :valid, :total_files, :valid_files,
+      #   :invalid_files and :errors keys
+      def self.legacy_report(result)
+        details = result.details
+        errors = details.fetch(:file_errors, [])
+        errors = result.errors if errors.empty? && !result.valid?
+
+        {
+          valid: result.valid?,
+          total_files: details.fetch(:total_files, 0),
+          valid_files: details.fetch(:valid_files, 0),
+          invalid_files: details.fetch(:invalid_files, 0),
+          errors: Result.deep_dup(errors)
+        }
+      end
+
+      private
+
+      # Collect all errors for one file
+      #
+      # @param file_path [String] path to the YAML file
+      # @return [Array<Hash>] empty when the file is valid
+      def file_errors(file_path)
+        return not_found(file_path) unless File.exist?(file_path)
+
+        errors = []
+        data = load_yaml(file_path, errors)
+        return errors if data.nil?
+
+        schema = load_schema(@resolver.resolve(file_path, data), errors)
+        return errors if schema.nil?
+
+        schema_errors(data, schema, file_path)
+      end
+
+      # Parse a YAML file, recording any failure
+      #
+      # @param file_path [String] path to the YAML file
+      # @param errors [Array<Hash>] error sink
+      # @return [Object, nil] parsed content, or nil when unusable
+      def load_yaml(file_path, errors)
+        data = YAML.safe_load_file(file_path,
+                                   permitted_classes: [Date, Time],
+                                   aliases: true)
+        if data.nil?
+          errors << { path: file_path, message: 'YAML file is empty' }
+          return nil
+        end
+
+        data
+      rescue Psych::SyntaxError => e
+        errors << { path: file_path,
+                    message: "YAML syntax error: #{e.message}" }
+        nil
+      rescue StandardError => e
+        errors << { path: file_path,
+                    message: "Failed to load file: #{e.message}" }
+        nil
+      end
+
+      # Error list for a nonexistent file
+      #
+      # @param file_path [String] the missing path
+      # @return [Array<Hash>]
+      def not_found(file_path)
+        [{ path: file_path, message: 'File not found' }]
+      end
+
+      # Load and cache a schema by type, recording load failures
+      #
+      # @param schema_type [Symbol] resolver-provided schema type
+      # @param errors [Array<Hash>] error sink
+      # @return [Hash, nil] the schema, or nil when unavailable
+      def load_schema(schema_type, errors)
+        @schema_cache[schema_type] ||= @loader.load(schema_type)
+      rescue *MISSING_SCHEMA_ERRORS => e
+        errors << { message: e.message }
+        nil
+      end
+
+      # Run the JSON-Schema engine against parsed data
+      #
+      # Mirrors the soft dependency on the json-schema gem: its absence
+      # is reported as a validation error rather than a crash.
+      #
+      # @param data [Object] parsed YAML content
+      # @param schema [Hash] the JSON schema
+      # @param file_path [String] file path for error reporting
+      # @return [Array<Hash>] empty when the data is valid
+      def schema_errors(data, schema, file_path)
+        unless defined?(JSON::Validator)
+          return [{ path: file_path,
+                    message: 'json-schema gem not available for validation' }]
+        end
+
+        # Convert to JSON and back to ensure proper format for validator
+        json_content = JSON.parse(data.to_json)
+        JSON::Validator.validate!(schema, json_content, validate_schema: false)
+        []
+      rescue JSON::Schema::ValidationError => e
+        [{ path: file_path, message: e.message }]
+      rescue JSON::Schema::SchemaError => e
+        [{ path: file_path, message: "Schema error: #{e.message}" }]
+      rescue StandardError => e
+        [{ path: file_path, message: "Validation error: #{e.message}" }]
+      end
+    end
+  end
+end

--- a/lib/ammitto/validation/object_validator.rb
+++ b/lib/ammitto/validation/object_validator.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require_relative 'result'
+require_relative '../schema/validator'
+
+module Ammitto
+  module Validation
+    # In-memory object validator returning unified {Result} objects
+    #
+    # Wraps Schema::Validator, mapping each of its check methods to a
+    # validation type so callers use one entry point for every
+    # harmonized-payload shape.
+    #
+    # @example Validating an entity hash
+    #   result = ObjectValidator.new.validate(data, type: :entity)
+    #   result.valid? # => true
+    #
+    class ObjectValidator
+      # Validation type to Schema::Validator check method mapping
+      TYPE_CHECKS = {
+        entity: :validate_entity,
+        sanction_entry: :validate_sanction_entry,
+        name_variant: :validate_name_variant,
+        json_ld: :validate_json_ld
+      }.freeze
+
+      # Initialize the validator
+      #
+      # @param schema_validator [Schema::Validator, nil] override for
+      #   testing; defaults to a fresh Schema::Validator
+      def initialize(schema_validator: nil)
+        @schema_validator = schema_validator || Schema::Validator.new
+      end
+
+      # Validate a data hash as the given type
+      #
+      # @param data [Hash] the data to validate
+      # @param type [Symbol, String] one of {TYPE_CHECKS} keys
+      # @return [Result]
+      # @raise [ArgumentError] for unknown validation types
+      def validate(data, type:)
+        check = TYPE_CHECKS[type.to_sym] if type.respond_to?(:to_sym)
+        unless check
+          raise ArgumentError,
+                "Unknown validation type: #{type.inspect} " \
+                "(supported: #{TYPE_CHECKS.keys.join(', ')})"
+        end
+
+        errors = @schema_validator.public_send(check, data)
+        Result.new(errors: errors, details: { type: type.to_sym })
+      end
+    end
+  end
+end

--- a/lib/ammitto/validation/result.rb
+++ b/lib/ammitto/validation/result.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+module Ammitto
+  module Validation
+    # Unified result value object for all validation planes
+    #
+    # Wraps the outcome of a validation run in a single shape regardless
+    # of which validator produced it. Errors may be plain strings (as
+    # emitted by Schema::Validator) or hashes such as
+    # <tt>{ path:, message: }</tt> (as emitted by the file schema
+    # validators). Validator-specific extras such as file counts live in
+    # {#details}.
+    #
+    # @example Checking a result
+    #   result = Ammitto::Validation.object(data, type: :entity)
+    #   result.valid?         # => false
+    #   result.error_messages # => ["Missing required field: names"]
+    #
+    class Result
+      # @return [Array<String, Hash>] validation errors
+      attr_reader :errors
+
+      # @return [Array<String, Hash>] non-fatal findings
+      attr_reader :warnings
+
+      # @return [Hash] validator-specific extras (e.g. file counts)
+      attr_reader :details
+
+      # Initialize a result
+      #
+      # Accepted structures are deep-copied and frozen so a Result
+      # cannot be mutated afterwards, through nested error hashes or
+      # details arrays included.
+      #
+      # @param errors [Array<String, Hash>] validation errors
+      # @param warnings [Array<String, Hash>] non-fatal findings
+      # @param details [Hash] validator-specific extras
+      def initialize(errors: [], warnings: [], details: {})
+        @errors = deep_freeze(errors)
+        @warnings = deep_freeze(warnings)
+        @details = deep_freeze(details)
+      end
+
+      # Build a passing result
+      #
+      # @param warnings [Array<String, Hash>] non-fatal findings
+      # @param details [Hash] validator-specific extras
+      # @return [Result]
+      def self.success(warnings: [], details: {})
+        new(warnings: warnings, details: details)
+      end
+
+      # Build a failing result
+      #
+      # @param errors [Array<String, Hash>, String, Hash] one error or a
+      #   list of errors
+      # @param warnings [Array<String, Hash>] non-fatal findings
+      # @param details [Hash] validator-specific extras
+      # @return [Result]
+      def self.failure(errors, warnings: [], details: {})
+        errors = [errors] unless errors.is_a?(Array)
+        new(errors: errors, warnings: warnings, details: details)
+      end
+
+      # Combine many results into one
+      #
+      # @param results [Array<Result>] results to combine
+      # @return [Result] the folded result (valid when empty)
+      def self.combine(results)
+        results.reduce(new) { |combined, result| combined.merge(result) }
+      end
+
+      # Recursively copy a frozen Result structure back into plain
+      # mutable objects, for legacy interfaces that predate the frozen
+      # contract
+      #
+      # @param value [Object] structure to copy
+      # @return [Object] an independent mutable copy
+      def self.deep_dup(value)
+        case value
+        when Hash
+          value.to_h { |key, item| [key, deep_dup(item)] }
+        when Array
+          value.map { |item| deep_dup(item) }
+        when String
+          value.dup
+        else
+          value
+        end
+      end
+
+      # @return [Boolean] true when no errors were recorded
+      def valid?
+        errors.empty?
+      end
+
+      # Merge with another result
+      #
+      # Errors and warnings are concatenated; details are shallow-merged
+      # with +other+ winning on key conflicts.
+      #
+      # @param other [Result] result to merge in
+      # @return [Result] a new combined result
+      def merge(other)
+        self.class.new(
+          errors: errors + other.errors,
+          warnings: warnings + other.warnings,
+          details: details.merge(other.details)
+        )
+      end
+
+      # Human-readable messages for all errors
+      #
+      # @return [Array<String>] the message of each error, whether the
+      #   error is a plain string or a hash with a :message key
+      def error_messages
+        errors.map { |error| error.is_a?(Hash) ? error[:message] : error.to_s }
+      end
+
+      private
+
+      # Recursively copy-and-freeze plain collections and strings;
+      # other values pass through untouched
+      #
+      # @param value [Object] structure to copy
+      # @return [Object] an independent frozen copy
+      def deep_freeze(value)
+        case value
+        when Hash
+          value.to_h { |key, item| [key, deep_freeze(item)] }.freeze
+        when Array
+          value.map { |item| deep_freeze(item) }.freeze
+        when String
+          value.dup.freeze
+        else
+          value
+        end
+      end
+    end
+  end
+end

--- a/spec/ammitto/config/override_resolver_spec.rb
+++ b/spec/ammitto/config/override_resolver_spec.rb
@@ -29,6 +29,13 @@ RSpec.describe Ammitto::Config::OverrideResolver do
     end
   end
 
+  # Run a block with every named ENV variable removed
+  def with_env_cleared(names, &block)
+    return yield if names.empty?
+
+    with_env(names.first, nil) { with_env_cleared(names[1..], &block) }
+  end
+
   describe ':sources_dir resolution' do
     it 'falls back to Defaults::SOURCES_DIR' do
       with_sources_env(nil, nil) do
@@ -120,6 +127,17 @@ RSpec.describe Ammitto::Config::OverrideResolver do
     it 'counts the alias in any_set?' do
       with_sources_env(nil, '/from-alias') do
         expect(Ammitto::Config::EnvProvider.any_set?).to be(true)
+      end
+    end
+
+    it 'does not count empty variables in any_set?' do
+      provider = Ammitto::Config::EnvProvider
+      names = (provider::ENV_MAPPING.values + provider::ENV_ALIASES.values)
+              .map { |var| "#{provider::PREFIX}#{var}" }
+      with_env_cleared(names) do
+        with_sources_env('', '') do
+          expect(provider.any_set?).to be(false)
+        end
       end
     end
   end

--- a/spec/ammitto/config/override_resolver_spec.rb
+++ b/spec/ammitto/config/override_resolver_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ammitto/config/override_resolver'
+
+RSpec.describe Ammitto::Config::OverrideResolver do
+  # Run a block with an ENV variable set (or removed when value is
+  # nil), restoring the original value afterwards.
+  def with_env(key, value)
+    original = ENV.fetch(key, nil)
+    if value.nil?
+      ENV.delete(key)
+    else
+      ENV[key] = value
+    end
+    yield
+  ensure
+    if original.nil?
+      ENV.delete(key)
+    else
+      ENV[key] = original
+    end
+  end
+
+  # Pin both the primary variable and its alias for a block
+  def with_sources_env(primary, alias_value, &block)
+    with_env('AMMITTO_SOURCES_DIR', primary) do
+      with_env('AMMITTO_DATA_DIR', alias_value, &block)
+    end
+  end
+
+  describe ':sources_dir resolution' do
+    it 'falls back to Defaults::SOURCES_DIR' do
+      with_sources_env(nil, nil) do
+        expect(described_class.new.resolve(:sources_dir))
+          .to eq(Ammitto::Config::Defaults::SOURCES_DIR)
+      end
+    end
+
+    it 'uses programmatic config over the default' do
+      with_sources_env(nil, nil) do
+        resolver = described_class.new(sources_dir: '/programmatic')
+        expect(resolver.resolve(:sources_dir)).to eq('/programmatic')
+      end
+    end
+
+    it 'prefers AMMITTO_SOURCES_DIR over programmatic config' do
+      with_sources_env('/from-env', nil) do
+        resolver = described_class.new(sources_dir: '/programmatic')
+        expect(resolver.resolve(:sources_dir)).to eq('/from-env')
+      end
+    end
+
+    it 'honors AMMITTO_DATA_DIR as an alias when the primary is unset' do
+      with_sources_env(nil, '/from-alias') do
+        expect(described_class.new.resolve(:sources_dir))
+          .to eq('/from-alias')
+      end
+    end
+
+    it 'prefers the primary variable over the alias' do
+      with_sources_env('/primary', '/from-alias') do
+        expect(described_class.new.resolve(:sources_dir)).to eq('/primary')
+      end
+    end
+
+    it 'prefers a directly provided value over ENV' do
+      with_sources_env('/from-env', nil) do
+        expect(described_class.new.resolve(:sources_dir, provided: '/given'))
+          .to eq('/given')
+      end
+    end
+
+    it 'is included in resolve_all' do
+      with_sources_env('/from-env', nil) do
+        expect(described_class.new.resolve_all[:sources_dir])
+          .to eq('/from-env')
+      end
+    end
+  end
+
+  describe ':cache_dir resolution (existing pattern)' do
+    it 'falls back to Defaults::CACHE_DIR' do
+      with_env('AMMITTO_CACHE_DIR', nil) do
+        expect(described_class.new.resolve(:cache_dir))
+          .to eq(Ammitto::Config::Defaults::CACHE_DIR)
+      end
+    end
+
+    it 'prefers AMMITTO_CACHE_DIR over programmatic config' do
+      with_env('AMMITTO_CACHE_DIR', '/env-cache') do
+        resolver = described_class.new(cache_dir: '/programmatic')
+        expect(resolver.resolve(:cache_dir)).to eq('/env-cache')
+      end
+    end
+  end
+
+  describe 'EnvProvider mapping' do
+    it 'maps AMMITTO_SOURCES_DIR to :sources_dir' do
+      with_sources_env('/from-env', nil) do
+        config = Ammitto::Config::EnvProvider.configuration
+        expect(config[:sources_dir]).to eq('/from-env')
+      end
+    end
+
+    it 'maps the AMMITTO_DATA_DIR alias to :sources_dir' do
+      with_sources_env(nil, '/from-alias') do
+        config = Ammitto::Config::EnvProvider.configuration
+        expect(config[:sources_dir]).to eq('/from-alias')
+      end
+    end
+
+    it 'ignores empty values for both variable names' do
+      with_sources_env('', '') do
+        config = Ammitto::Config::EnvProvider.configuration
+        expect(config).not_to have_key(:sources_dir)
+      end
+    end
+
+    it 'counts the alias in any_set?' do
+      with_sources_env(nil, '/from-alias') do
+        expect(Ammitto::Config::EnvProvider.any_set?).to be(true)
+      end
+    end
+  end
+end

--- a/spec/ammitto/data/legacy_validator_shims_spec.rb
+++ b/spec/ammitto/data/legacy_validator_shims_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+
+# Legacy #errors semantics of the country validator shims: batch calls
+# leave the LAST file's errors behind (empty when that file was valid),
+# matching the original implementations that iterated via #validate.
+RSpec.describe 'legacy validator shim #errors compatibility' do
+  let(:validator) { Ammitto::Data::China::Validator.new }
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @good = File.join(dir, 'good-announcement.yml')
+      File.write(@good, <<~YAML)
+        announcement:
+          title: "关于对有关实体实施制裁的公告"
+          url: "https://www.mfa.gov.cn/announcement/1"
+          publish_date: "2025-01-15"
+          authority: "外交部"
+          type: "制裁公告"
+          document_id: "第4号"
+          signatory: "外交部"
+          content: "公告内容"
+        sanction_details:
+          instruments:
+            - law: "反外国制裁法"
+          entities:
+            - name:
+                zh-Hans: "测试实体"
+                en: "Test Entity"
+              type: organization
+              effective_date: "2025-01-15"
+              sanction_list: "反制裁清单"
+              reason:
+                - zh-Hans: "原因"
+              measures:
+                - type:
+                    - asset_freeze
+                  zh-Hans: "冻结资产"
+      YAML
+      @bad = File.join(dir, 'bad-announcement.yml')
+      File.write(@bad, { 'announcement' => { 'title' => 'incomplete' } }.to_yaml)
+      example.run
+    end
+  end
+
+  it 'leaves the last file errors after validate_files' do
+    validator.validate_files([@good, @bad])
+    expect(validator.errors).not_to be_empty
+  end
+
+  it 'leaves empty errors when the last file is valid' do
+    report = validator.validate_files([@bad, @good])
+    expect(report[:invalid_files]).to eq(1)
+    expect(validator.errors).to be_empty
+  end
+
+  it 'resets errors between batch calls' do
+    validator.validate_files([@bad])
+    validator.validate_files([@good])
+    expect(validator.errors).to be_empty
+  end
+
+  it 'returns mutable structures through the legacy surfaces' do
+    report = validator.validate_files([@good, @bad])
+    expect { report[:errors].first[:errors].first[:message] = 'edited' }
+      .not_to raise_error
+    validator.validate(@bad)
+    expect { validator.errors.first[:message] = 'edited' }
+      .not_to raise_error
+  end
+end

--- a/spec/ammitto/data/legacy_validator_shims_spec.rb
+++ b/spec/ammitto/data/legacy_validator_shims_spec.rb
@@ -62,6 +62,14 @@ RSpec.describe 'legacy validator shim #errors compatibility' do
     expect(validator.errors).to be_empty
   end
 
+  it 'keeps last-file semantics through validate_all' do
+    # Sorted glob order: bad-announcement.yml then good-announcement.yml,
+    # so the last validated file is the valid one.
+    report = validator.validate_all(File.dirname(@good))
+    expect(report[:invalid_files]).to eq(1)
+    expect(validator.errors).to be_empty
+  end
+
   it 'returns mutable structures through the legacy surfaces' do
     report = validator.validate_files([@good, @bad])
     expect { report[:errors].first[:errors].first[:message] = 'edited' }

--- a/spec/ammitto/validation/file_schema_validator_spec.rb
+++ b/spec/ammitto/validation/file_schema_validator_spec.rb
@@ -180,6 +180,21 @@ RSpec.describe Ammitto::Validation::FileSchemaValidator do
         .to match(/Schema not found: .*jp-legal-instrument\.yml/)
     end
 
+    it 'memoizes missing schemas while still reporting them per file' do
+      loader = Ammitto::Data::Japan::SchemaLoader
+      allow(loader).to receive(:load).and_call_original
+
+      paths = %w[a b].map do |name|
+        write_file("legal-instruments/#{name}.yml",
+                   "title: FEFTA\ncontent: text\n")
+      end
+      result = validator.validate_files(paths)
+
+      expect(loader).to have_received(:load).once
+      expect(result.details[:invalid_files]).to eq(2)
+      expect(result.errors.length).to eq(2)
+    end
+
     it 'reports the announcement schema draft as a schema error' do
       # jp-announcement.yml declares JSON Schema draft 2020-12, which
       # the json-schema gem cannot process; this must surface as a

--- a/spec/ammitto/validation/file_schema_validator_spec.rb
+++ b/spec/ammitto/validation/file_schema_validator_spec.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+require 'ammitto/data/japan/validator'
+
+RSpec.describe Ammitto::Validation::FileSchemaValidator do
+  let(:tmpdir) { Dir.mktmpdir('ammitto_validation_test') }
+
+  let(:valid_china_yaml) do
+    <<~YAML
+      announcement:
+        title: "关于对有关实体实施制裁的公告"
+        url: "https://www.mfa.gov.cn/announcement/1"
+        publish_date: "2025-01-15"
+        authority: "外交部"
+        type: "制裁公告"
+        document_id: "第4号"
+        signatory: "外交部"
+        content: "公告内容"
+      sanction_details:
+        instruments:
+          - law: "反外国制裁法"
+        entities:
+          - name:
+              zh-Hans: "测试实体"
+              en: "Test Entity"
+            type: organization
+            effective_date: "2025-01-15"
+            sanction_list: "反制裁清单"
+            reason:
+              - zh-Hans: "原因"
+            measures:
+              - type:
+                  - asset_freeze
+                zh-Hans: "冻结资产"
+    YAML
+  end
+
+  let(:invalid_china_yaml) do
+    <<~YAML
+      announcement:
+        title: "缺少制裁详情"
+    YAML
+  end
+
+  after { FileUtils.rm_rf(tmpdir) }
+
+  def write_file(name, content)
+    path = File.join(tmpdir, name)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+    path
+  end
+
+  describe '#initialize' do
+    it 'raises UnknownCountryError for an unregistered country' do
+      expect { described_class.new(country: :atlantis) }
+        .to raise_error(Ammitto::Validation::UnknownCountryError,
+                        /Unknown country: :atlantis/)
+    end
+
+    it 'accepts a string country key' do
+      validator = described_class.new(country: 'china')
+      expect(validator.country).to eq(:china)
+    end
+
+    it 'exposes the country schemas directory' do
+      validator = described_class.new(country: :china)
+      expect(validator.schemas_dir)
+        .to eq(Ammitto::Data::China::SchemaLoader::SCHEMAS_DIR)
+    end
+  end
+
+  describe '#validate_file (china)' do
+    subject(:validator) { described_class.new(country: :china) }
+
+    it 'returns a valid result for a schema-conforming file' do
+      path = write_file('announcement.yml', valid_china_yaml)
+      result = validator.validate_file(path)
+
+      expect(result).to be_a(Ammitto::Validation::Result)
+      expect(result.valid?).to be true
+      expect(result.errors).to be_empty
+      expect(result.details[:file]).to eq(path)
+    end
+
+    it 'returns schema errors for a non-conforming file' do
+      path = write_file('announcement.yml', invalid_china_yaml)
+      result = validator.validate_file(path)
+
+      expect(result.valid?).to be false
+      expect(result.errors.first[:path]).to eq(path)
+      expect(result.errors.first[:message]).to match(/sanction_details/)
+    end
+
+    it 'reports a missing file' do
+      result = validator.validate_file(File.join(tmpdir, 'nope.yml'))
+
+      expect(result.valid?).to be false
+      expect(result.error_messages).to eq(['File not found'])
+    end
+
+    it 'reports a YAML syntax error' do
+      path = write_file('broken.yml', "announcement: [unclosed\n  nope")
+      result = validator.validate_file(path)
+
+      expect(result.valid?).to be false
+      expect(result.error_messages.first).to match(/YAML syntax error/)
+    end
+
+    it 'reports an empty YAML file as invalid' do
+      path = write_file('empty.yml', '')
+      result = validator.validate_file(path)
+
+      expect(result.valid?).to be false
+      expect(result.error_messages).to eq(['YAML file is empty'])
+    end
+  end
+
+  describe '#validate_files / #validate_directory (china)' do
+    subject(:validator) { described_class.new(country: :china) }
+
+    it 'walks a directory and reports per-file counts' do
+      write_file('good.yml', valid_china_yaml)
+      bad = write_file('bad.yml', invalid_china_yaml)
+
+      result = validator.validate_directory(tmpdir)
+
+      expect(result.valid?).to be false
+      expect(result.details[:total_files]).to eq(2)
+      expect(result.details[:valid_files]).to eq(1)
+      expect(result.details[:invalid_files]).to eq(1)
+
+      group = result.details[:file_errors].first
+      expect(group[:file]).to eq(bad)
+      expect(group[:errors].first[:message]).to match(/sanction_details/)
+    end
+
+    it 'flattens all file errors into Result#errors' do
+      write_file('bad.yml', invalid_china_yaml)
+      result = validator.validate_directory(tmpdir)
+
+      expect(result.errors.length).to eq(1)
+      expect(result.error_messages.first).to match(/sanction_details/)
+    end
+
+    it 'returns a valid result for a directory of valid files' do
+      write_file('good.yml', valid_china_yaml)
+      result = validator.validate_directory(tmpdir)
+
+      expect(result.valid?).to be true
+      expect(result.details[:invalid_files]).to eq(0)
+    end
+
+    it 'reports a missing sources directory' do
+      result = validator.validate_directory(File.join(tmpdir, 'absent'))
+
+      expect(result.valid?).to be false
+      expect(result.error_messages.first)
+        .to match(/Sources directory not found/)
+      expect(result.details[:total_files]).to eq(0)
+    end
+  end
+
+  describe 'japan' do
+    subject(:validator) { described_class.new(country: :japan) }
+
+    it 'reports a graceful error when the schema file is missing' do
+      # 4 of Japan's 5 mapped schema files do not exist; the loader
+      # raises SchemaNotFoundError, which must surface as an error, not
+      # an exception.
+      path = write_file('legal-instruments/fefta.yml',
+                        "title: FEFTA\ncontent: text\n")
+      result = validator.validate_file(path)
+
+      expect(result.valid?).to be false
+      expect(result.error_messages.first)
+        .to match(/Schema not found: .*jp-legal-instrument\.yml/)
+    end
+
+    it 'reports the announcement schema draft as a schema error' do
+      # jp-announcement.yml declares JSON Schema draft 2020-12, which
+      # the json-schema gem cannot process; this must surface as a
+      # graceful schema error.
+      path = write_file('sanction-lists/entry.yml',
+                        "announcement:\n  title: x\nsanction_details: {}\n")
+      result = validator.validate_file(path)
+
+      expect(result.valid?).to be false
+      expect(result.error_messages.first).to match(/Schema error/)
+    end
+  end
+
+  describe 'legacy country validator compatibility' do
+    it 'Data::China::Validator#validate keeps its Boolean + #errors API' do
+      good = write_file('good.yml', valid_china_yaml)
+      bad = write_file('bad.yml', invalid_china_yaml)
+      legacy = Ammitto::Data::China::Validator.new
+
+      expect(legacy.validate(good)).to be true
+      expect(legacy.errors).to be_empty
+      expect(legacy.validate(bad)).to be false
+      expect(legacy.errors.first).to include(:path, :message)
+    end
+
+    it 'Data::China::Validator#validate_files keeps the report shape' do
+      good = write_file('good.yml', valid_china_yaml)
+      bad = write_file('bad.yml', invalid_china_yaml)
+
+      report = Ammitto::Data::China::Validator.new.validate_files([good, bad])
+
+      expect(report).to include(valid: false, total_files: 2,
+                                valid_files: 1, invalid_files: 1)
+      expect(report[:errors].first[:file]).to eq(bad)
+      expect(report[:errors].first[:errors].first[:message])
+        .to match(/sanction_details/)
+    end
+
+    it 'Data::Japan::Validator#validate_all reports a missing directory' do
+      report = Ammitto::Data::Japan::Validator.new
+                                              .validate_all('/no/such/dir')
+
+      expect(report).to include(valid: false, total_files: 0,
+                                valid_files: 0, invalid_files: 0)
+      expect(report[:errors].first[:message])
+        .to match(/Sources directory not found/)
+    end
+  end
+
+  describe 'Ammitto::Validation.file' do
+    it 'validates a single file' do
+      path = write_file('announcement.yml', valid_china_yaml)
+      result = Ammitto::Validation.file(path, country: :china)
+
+      expect(result.valid?).to be true
+    end
+
+    it 'validates a directory' do
+      write_file('bad.yml', invalid_china_yaml)
+      result = Ammitto::Validation.file(tmpdir, country: :china)
+
+      expect(result.valid?).to be false
+      expect(result.details[:total_files]).to eq(1)
+    end
+
+    it 'raises UnknownCountryError for an unregistered country' do
+      expect { Ammitto::Validation.file(tmpdir, country: :mars) }
+        .to raise_error(Ammitto::Validation::UnknownCountryError)
+    end
+  end
+end

--- a/spec/ammitto/validation/object_validator_spec.rb
+++ b/spec/ammitto/validation/object_validator_spec.rb
@@ -167,5 +167,16 @@ RSpec.describe Ammitto::Validation::ObjectValidator do
       expect(system(RbConfig.ruby, '-I', lib, '-e', script))
         .to be(true), 'ammitto/validation must load without full ammitto'
     end
+
+    it 'resolves Authority from a standalone require' do
+      lib = File.expand_path('../../../lib', __dir__)
+      script = 'require "ammitto/validation"; ' \
+               'r = Ammitto::Validation.object(' \
+               '{ "authority" => { "id" => "zz" } }, ' \
+               'type: :sanction_entry); ' \
+               'exit(r.errors.include?("Unknown authority: zz"))'
+      expect(system(RbConfig.ruby, '-I', lib, '-e', script))
+        .to be(true), 'Schema::Validator must load Authority itself'
+    end
   end
 end

--- a/spec/ammitto/validation/object_validator_spec.rb
+++ b/spec/ammitto/validation/object_validator_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Ammitto::Validation::ObjectValidator do
+  subject(:validator) { described_class.new }
+
+  describe '#validate with type: :entity' do
+    let(:valid_entity) do
+      {
+        'id' => 'entity-1',
+        'entityType' => 'person',
+        'names' => [{ 'fullName' => 'Jane Doe' }]
+      }
+    end
+
+    it 'returns a valid result for a well-formed entity' do
+      result = validator.validate(valid_entity, type: :entity)
+
+      expect(result).to be_a(Ammitto::Validation::Result)
+      expect(result.valid?).to be true
+      expect(result.details[:type]).to eq(:entity)
+    end
+
+    it 'rejects an unknown entity type' do
+      entity = valid_entity.merge('entityType' => 'robot')
+      result = validator.validate(entity, type: :entity)
+
+      expect(result.valid?).to be false
+      expect(result.errors).to include('Invalid entity type: robot')
+    end
+
+    it 'accepts every Ontology::Types entity type' do
+      Ammitto::Ontology::Types::ENTITY_TYPES.each do |type|
+        entity = valid_entity.merge('entityType' => type.to_s)
+        expect(validator.validate(entity, type: :entity).valid?).to be true
+      end
+    end
+
+    it 'rejects an entity without names' do
+      result = validator.validate({ 'id' => 'x', 'entityType' => 'person' },
+                                  type: :entity)
+
+      expect(result.valid?).to be false
+      expect(result.errors).to include('Missing required field: names')
+    end
+
+    it 'rejects a name variant without any name component' do
+      entity = valid_entity.merge('names' => [{ 'title' => 'Dr.' }])
+      result = validator.validate(entity, type: :entity)
+
+      expect(result.valid?).to be false
+      expect(result.errors)
+        .to include('names[0]: Must have fullName, firstName, or lastName')
+    end
+  end
+
+  describe '#validate with type: :sanction_entry' do
+    let(:valid_entry) do
+      {
+        'id' => 'entry-1',
+        'entityId' => 'entity-1',
+        'authority' => { 'id' => 'eu' },
+        'status' => 'active'
+      }
+    end
+
+    it 'returns a valid result for a well-formed entry' do
+      result = validator.validate(valid_entry, type: :sanction_entry)
+      expect(result.valid?).to be true
+    end
+
+    it 'accepts the harmonized StatusChange statuses' do
+      Ammitto::StatusChange::STATUSES.each do |status|
+        entry = valid_entry.merge('status' => status)
+        expect(validator.validate(entry, type: :sanction_entry).valid?)
+          .to be(true), "expected status #{status} to be valid"
+      end
+    end
+
+    it 'rejects an unknown status' do
+      entry = valid_entry.merge('status' => 'bogus')
+      result = validator.validate(entry, type: :sanction_entry)
+
+      expect(result.valid?).to be false
+      expect(result.errors).to include('Invalid status: bogus')
+    end
+
+    it 'rejects an unknown authority' do
+      entry = valid_entry.merge('authority' => { 'id' => 'zz' })
+      result = validator.validate(entry, type: :sanction_entry)
+
+      expect(result.valid?).to be false
+      expect(result.errors).to include('Unknown authority: zz')
+    end
+
+    it 'reports missing required fields' do
+      result = validator.validate({}, type: :sanction_entry)
+
+      expect(result.valid?).to be false
+      expect(result.errors).to include('Missing required field: id',
+                                       'Missing required field: entityId')
+    end
+  end
+
+  describe '#validate with type: :name_variant' do
+    it 'accepts a variant with a name component' do
+      result = validator.validate({ 'firstName' => 'Jane' },
+                                  type: :name_variant)
+      expect(result.valid?).to be true
+    end
+
+    it 'rejects a variant without any name component' do
+      result = validator.validate({}, type: :name_variant)
+      expect(result.valid?).to be false
+    end
+  end
+
+  describe '#validate with type: :json_ld' do
+    it 'accepts a document with @context and @graph' do
+      result = validator.validate({ '@context' => {}, '@graph' => [] },
+                                  type: :json_ld)
+      expect(result.valid?).to be true
+    end
+
+    it 'rejects a document without JSON-LD keywords' do
+      result = validator.validate({}, type: :json_ld)
+
+      expect(result.valid?).to be false
+      expect(result.errors).to include('Missing @context in JSON-LD')
+    end
+  end
+
+  describe '#validate with an unknown type' do
+    it 'raises ArgumentError' do
+      expect { validator.validate({}, type: :galaxy) }
+        .to raise_error(ArgumentError, /Unknown validation type: :galaxy/)
+    end
+  end
+
+  describe 'enum routing through Ontology::Types' do
+    it 'keeps Schema::Validator::ENTITY_TYPES aligned with the ontology' do
+      expect(Ammitto::Schema::Validator::ENTITY_TYPES)
+        .to eq(Ammitto::Ontology::Types::ENTITY_TYPES.map(&:to_s))
+    end
+
+    it 'keeps the legacy string values for API compatibility' do
+      expect(Ammitto::Schema::Validator::ENTITY_TYPES)
+        .to eq(%w[person organization vessel aircraft])
+    end
+  end
+
+  describe 'Ammitto::Validation.object' do
+    it 'validates through the facade entry point' do
+      result = Ammitto::Validation.object(
+        { 'id' => 'x', 'entityType' => 'vessel',
+          'names' => [{ 'fullName' => 'MV Example' }] },
+        type: :entity
+      )
+      expect(result.valid?).to be true
+    end
+
+    it 'works from a standalone require of ammitto/validation' do
+      lib = File.expand_path('../../../lib', __dir__)
+      script = 'require "ammitto/validation"; ' \
+               'Ammitto::Validation.object({}, type: :entity)'
+      expect(system(RbConfig.ruby, '-I', lib, '-e', script))
+        .to be(true), 'ammitto/validation must load without full ammitto'
+    end
+  end
+end

--- a/spec/ammitto/validation/result_spec.rb
+++ b/spec/ammitto/validation/result_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Ammitto::Validation::Result do
+  describe '#valid?' do
+    it 'is true when there are no errors' do
+      expect(described_class.new.valid?).to be true
+    end
+
+    it 'is false when errors are present' do
+      result = described_class.new(errors: ['broken'])
+      expect(result.valid?).to be false
+    end
+
+    it 'is not affected by warnings' do
+      result = described_class.new(warnings: ['minor issue'])
+      expect(result.valid?).to be true
+    end
+  end
+
+  describe '#errors' do
+    it 'represents plain string errors' do
+      result = described_class.new(errors: ['Missing required field: id'])
+      expect(result.errors).to eq(['Missing required field: id'])
+    end
+
+    it 'represents { path:, message: } hash errors' do
+      error = { path: 'a.yml', message: 'File not found' }
+      result = described_class.new(errors: [error])
+      expect(result.errors).to eq([error])
+    end
+  end
+
+  describe '#details' do
+    it 'defaults to an empty hash' do
+      expect(described_class.new.details).to eq({})
+    end
+
+    it 'carries validator-specific extras such as file counts' do
+      result = described_class.new(
+        details: { total_files: 3, valid_files: 2, invalid_files: 1 }
+      )
+      expect(result.details[:total_files]).to eq(3)
+      expect(result.details[:invalid_files]).to eq(1)
+    end
+  end
+
+  describe '#error_messages' do
+    it 'extracts messages from string and hash errors alike' do
+      result = described_class.new(
+        errors: ['plain error', { path: 'a.yml', message: 'hash error' }]
+      )
+      expect(result.error_messages).to eq(['plain error', 'hash error'])
+    end
+  end
+
+  describe '.success' do
+    it 'builds a passing result' do
+      result = described_class.success(details: { source: :test })
+      expect(result.valid?).to be true
+      expect(result.details).to eq(source: :test)
+    end
+  end
+
+  describe '.failure' do
+    it 'builds a failing result from a list of errors' do
+      result = described_class.failure(%w[one two])
+      expect(result.valid?).to be false
+      expect(result.errors).to eq(%w[one two])
+    end
+
+    it 'wraps a single error into an array' do
+      result = described_class.failure({ message: 'boom' })
+      expect(result.errors).to eq([{ message: 'boom' }])
+    end
+  end
+
+  describe '#merge' do
+    it 'concatenates errors and warnings' do
+      merged = described_class.new(errors: ['a'], warnings: ['w1'])
+                              .merge(described_class.new(errors: ['b'],
+                                                         warnings: ['w2']))
+      expect(merged.errors).to eq(%w[a b])
+      expect(merged.warnings).to eq(%w[w1 w2])
+    end
+
+    it 'shallow-merges details with the other result winning' do
+      merged = described_class.new(details: { a: 1, b: 1 })
+                              .merge(described_class.new(details: { b: 2 }))
+      expect(merged.details).to eq(a: 1, b: 2)
+    end
+
+    it 'returns a new result without mutating the originals' do
+      original = described_class.new(errors: ['a'])
+      merged = original.merge(described_class.new(errors: ['b']))
+      expect(original.errors).to eq(['a'])
+      expect(merged).not_to be(original)
+    end
+  end
+
+  describe 'deep immutability' do
+    it 'is not affected by later mutation of the input structures' do
+      error = { path: 'a.yml', message: 'original' }
+      details = { file_errors: [{ file: 'a.yml', errors: [error] }] }
+      result = described_class.new(errors: [error], details: details)
+
+      error[:message] = 'mutated'
+      details[:file_errors] << { file: 'b.yml', errors: [] }
+
+      expect(result.errors.first[:message]).to eq('original')
+      expect(result.details[:file_errors].length).to eq(1)
+    end
+
+    it 'freezes nested structures against mutation through readers' do
+      result = described_class.new(
+        errors: [{ path: 'a.yml', message: 'boom' }],
+        details: { file_errors: [] }
+      )
+
+      expect { result.errors.first[:message] = 'changed' }
+        .to raise_error(FrozenError)
+      expect { result.details[:file_errors] << :extra }
+        .to raise_error(FrozenError)
+    end
+  end
+
+  describe '.combine' do
+    it 'folds many results into one' do
+      combined = described_class.combine(
+        [
+          described_class.new(errors: ['a'], details: { total: 1 }),
+          described_class.new(warnings: ['w']),
+          described_class.new(errors: ['b'])
+        ]
+      )
+      expect(combined.valid?).to be false
+      expect(combined.errors).to eq(%w[a b])
+      expect(combined.warnings).to eq(['w'])
+      expect(combined.details).to eq(total: 1)
+    end
+
+    it 'returns a valid result for an empty list' do
+      expect(described_class.combine([]).valid?).to be true
+    end
+  end
+end


### PR DESCRIPTION
Added **`Ammitto::Validation`** — a single entry point (`Validation.file`, `Validation.object`, unified immutable **`Result`**) over the previously disconnected validation planes: the byte-for-byte China/Japan file validators are now one country-parameterized **`FileSchemaValidator`** (the originals remain as compatibility shims with their exact legacy APIs, `#errors` semantics included), and the previously unreachable **`Schema::Validator`** is wired up behind `Validation.object` with its entity enum sourced from **`Ontology::Types`**. Also unifies the data-directory knob (`AMMITTO_SOURCES_DIR`, with `AMMITTO_DATA_DIR` honored as the alias the CI validation scripts use) and fixes latent load-order bugs so `require "ammitto/validation"` works standalone. Known pre-existing gap left as-is: the Japan announcement schema declares JSON Schema draft 2020-12, which the `json-schema` gem cannot process (`json_schemer` would - possible follow-up).

Depends on #21
