### PR TITLE
Clamp oversized legal-instrument slugs to filename limit

### DIFF
--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require 'digest'
 require 'fileutils'
 require 'json'
 require 'time'
 require 'yaml'
+require_relative '../errors/base_error'
 require_relative 'json_ld_serializer'
 require_relative 'turtle_exporter'
 
@@ -28,6 +30,17 @@ module Ammitto
     class JsonLdGraphExporter
       # Base URI for all node IDs
       BASE_URI = 'https://www.ammitto.org'
+
+      # Longest instrument slug (IRI tail) whose exported filename
+      # "#{slug}.jsonld" still fits the 255-byte filesystem filename
+      # limit (255 minus the 7-byte '.jsonld' suffix)
+      MAX_SLUG_BYTES = 248
+
+      # Slug prefix bytes kept when clamping an oversized slug
+      CLAMP_PREFIX_BYTES = 100
+
+      # Hex digest chars appended when clamping an oversized slug
+      CLAMP_DIGEST_CHARS = 12
 
       # @return [String] output directory
       attr_reader :output_dir
@@ -86,6 +99,7 @@ module Ammitto
         @document_types = {}
         @organizations = {}
         @loaded_instruments = {}
+        @instrument_slugs = {}
 
         # Statistics tracking
         @stats = {
@@ -458,7 +472,8 @@ module Ammitto
 
             # Create a normalized identifier for the ID
             normalized_id = normalize_identifier(identifier)
-            instrument_id = "#{BASE_URI}/legal-instrument/#{source_code}/#{normalized_id}"
+            instrument_id = instrument_iri(source_code, normalized_id,
+                                           identifier)
 
             # Store full instrument if not already present
             @instruments[instrument_id] ||= {
@@ -498,7 +513,7 @@ module Ammitto
             local_id = match[2]
 
             # Create the canonical instrument ID (using /legal-instrument/)
-            instrument_id = "#{BASE_URI}/legal-instrument/#{instr_source}/#{local_id}"
+            instrument_id = instrument_iri(instr_source, local_id, local_id)
 
             # Look up loaded instrument metadata
             loaded_key = "#{instr_source}/#{local_id}"
@@ -562,6 +577,65 @@ module Ammitto
                   .gsub(/-+/, '-')
                   .gsub(/^-|-$/, '')
                   .downcase
+      end
+
+      # Build the canonical IRI for a legal-instrument node. The IRI tail
+      # doubles as the node filename (export_instrument_nodes derives the
+      # filename from the IRI), so oversized slugs are clamped here to
+      # keep every derived filename within filesystem limits, and a slug
+      # registry guards against two distinct slugs silently sharing one
+      # IRI.
+      # @param source_code [String] source segment of the IRI
+      # @param slug [String] normalized identifier (pre-clamp identity)
+      # @param original [String] identifier the slug was derived from
+      # @return [String] canonical instrument IRI
+      def instrument_iri(source_code, slug, original)
+        final_slug = clamp_slug(slug)
+        iri = "#{BASE_URI}/legal-instrument/#{source_code}/#{final_slug}"
+        register_instrument_slug(iri, slug, original)
+        iri
+      end
+
+      # Clamp an oversized slug so its "#{slug}.jsonld" filename fits the
+      # 255-byte filesystem filename limit. Slugs within budget pass
+      # through untouched, so existing short IRIs never change. Oversized
+      # slugs become their first CLAMP_PREFIX_BYTES bytes (trimmed back
+      # to a character boundary, never splitting a multibyte character)
+      # plus '-' and the first CLAMP_DIGEST_CHARS hex chars of the
+      # SHA-256 of the full pre-truncation slug, which keeps slugs that
+      # share a prefix but differ later distinct.
+      # @param slug [String] normalized identifier
+      # @return [String] slug safe to use as IRI tail and filename
+      def clamp_slug(slug)
+        return slug if slug.bytesize <= MAX_SLUG_BYTES
+
+        prefix = slug.byteslice(0, CLAMP_PREFIX_BYTES)
+        # byteslice can cut through a multibyte character; drop trailing
+        # bytes until the prefix is valid again
+        prefix = prefix.byteslice(0, prefix.bytesize - 1) until prefix.valid_encoding?
+        "#{prefix}-#{Digest::SHA256.hexdigest(slug)[0, CLAMP_DIGEST_CHARS]}"
+      end
+
+      # Record which pre-clamp slug produced an instrument IRI, raising
+      # when a different slug maps to the same IRI: @instruments dedupes
+      # by IRI, and a digest-truncation collision must fail loudly
+      # instead of silently merging two distinct instruments. Identical
+      # slugs (including distinct originals normalizing to one slug) stay
+      # merged — that is the exporter's existing dedup semantics.
+      # @param iri [String] final instrument IRI
+      # @param slug [String] pre-clamp slug (the instrument identity)
+      # @param original [String] identifier the slug was derived from
+      # @return [void]
+      def register_instrument_slug(iri, slug, original)
+        existing = @instrument_slugs[iri]
+        if existing && existing[:slug] != slug
+          raise Ammitto::Error,
+                "Instrument slug collision on #{iri}: " \
+                "#{existing[:original].inspect} and #{original.inspect} " \
+                'clamp to the same slug'
+        end
+
+        @instrument_slugs[iri] ||= { slug: slug, original: original }
       end
 
       # Export entity node files

--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -590,10 +590,35 @@ module Ammitto
       # @param original [String] identifier the slug was derived from
       # @return [String] canonical instrument IRI
       def instrument_iri(source_code, slug, original)
+        # The legalCitations path derives BOTH the source and the slug
+        # from IRI text, and each becomes a path component under
+        # node/legal-instrument/ — so either spanning components (or
+        # being '.'/'..') means a malformed instrument IRI that would
+        # write outside the node layout. Fail loudly; multibyte slugs
+        # pass through untouched (normalizing here would collapse
+        # non-Latin identifiers to nothing).
+        [source_code.to_s, slug].each do |component|
+          next unless unusable_path_component?(component)
+
+          raise Ammitto::Error,
+                "Instrument identifier #{original.inspect} yields " \
+                "unusable path component #{component.inspect}"
+        end
+
         final_slug = clamp_slug(slug)
         iri = "#{BASE_URI}/legal-instrument/#{source_code}/#{final_slug}"
         register_instrument_slug(iri, slug, original)
         iri
+      end
+
+      # A path component is unusable when empty, containing separators
+      # or NUL, or a filesystem navigation name
+      # @param component [String] candidate path component
+      # @return [Boolean]
+      def unusable_path_component?(component)
+        component.empty? ||
+          component.match?(%r{[/\\\x00]}) ||
+          ['.', '..'].include?(component)
       end
 
       # Clamp an oversized slug so its "#{slug}.jsonld" filename fits the

--- a/spec/ammitto/serialization/json_ld_graph_exporter_filename_clamp_spec.rb
+++ b/spec/ammitto/serialization/json_ld_graph_exporter_filename_clamp_spec.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'digest'
+require 'fileutils'
+require 'json'
+require 'tmpdir'
+require 'ammitto/serialization/json_ld_graph_exporter'
+
+RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
+  let(:output_dir) { Dir.mktmpdir('ammitto_clamp_test') }
+  let(:context_url) { 'https://www.ammitto.org/ontology/context.jsonld' }
+  let(:exporter) do
+    described_class.new(output_dir: output_dir, context_url: context_url)
+  end
+
+  after do
+    FileUtils.rm_rf(output_dir)
+  end
+
+  def add_entry(exp, ref, identifiers)
+    entity = {
+      '@id' => "https://www.ammitto.org/entity/au/#{ref}",
+      '@type' => 'PersonEntity'
+    }
+    entry = {
+      '@id' => "https://www.ammitto.org/entry/au/consolidated/#{ref}",
+      '@type' => 'SanctionEntry',
+      'legalBases' => identifiers.map { |id| { 'identifier' => id } }
+    }
+    exp.add_node(entity: entity, entry: entry, source: :au)
+  end
+
+  def instrument_tails(exp)
+    exp.instruments.keys.map { |id| id.split('/').last }
+  end
+
+  describe 'instrument slug clamping' do
+    it 'clamps an oversized identifier to a 113-byte slug' do
+      identifier = 'a' * 300
+      add_entry(exporter, 'e1', [identifier])
+
+      tail = instrument_tails(exporter).first
+      digest = Digest::SHA256.hexdigest('a' * 300)[0, 12]
+      expect(tail).to eq("#{'a' * 100}-#{digest}")
+      expect(tail.bytesize).to eq(113)
+    end
+
+    it 'produces the same clamped IRI across independent runs' do
+      identifier = "Long citation #{'x' * 400} end"
+
+      first = described_class.new(output_dir: output_dir,
+                                  context_url: context_url)
+      second = described_class.new(output_dir: output_dir,
+                                   context_url: context_url)
+      add_entry(first, 'e1', [identifier])
+      add_entry(second, 'e1', [identifier])
+
+      expect(first.instruments.keys).to eq(second.instruments.keys)
+    end
+
+    it 'trims to a character boundary without splitting multibyte' do
+      # legalCitations local_ids bypass normalize_identifier, so a
+      # multibyte slug can reach the clamp. 100 three-byte chars =
+      # 300 bytes; the 100-byte prefix cut lands mid-character and must
+      # back up to 99 bytes (33 whole characters).
+      local_id = '日' * 100
+      entity = {
+        '@id' => 'https://www.ammitto.org/entity/xx/m1',
+        '@type' => 'PersonEntity'
+      }
+      entry = {
+        '@id' => 'https://www.ammitto.org/entry/xx/list/m1',
+        '@type' => 'SanctionEntry',
+        'legalCitations' => [
+          {
+            'legalInstrumentId' =>
+              "https://www.ammitto.org/legal_instrument/xx/#{local_id}"
+          }
+        ]
+      }
+      exporter.add_node(entity: entity, entry: entry, source: :xx)
+
+      tail = instrument_tails(exporter).first
+      digest = Digest::SHA256.hexdigest(local_id)[0, 12]
+      expect(tail).to eq("#{'日' * 33}-#{digest}")
+      expect(tail).to be_valid_encoding
+      expect(tail.bytesize).to eq(112)
+    end
+
+    it 'keeps identifiers sharing a 100-byte prefix distinct' do
+      shared = 'p' * 260
+      add_entry(exporter, 'e1', ["#{shared}alpha"])
+      add_entry(exporter, 'e2', ["#{shared}omega"])
+
+      tails = instrument_tails(exporter)
+      expect(tails.length).to eq(2)
+      expect(tails.uniq.length).to eq(2)
+      expect(tails).to all(start_with("#{'p' * 100}-"))
+    end
+
+    it 'passes a short identifier through byte-identical' do
+      add_entry(exporter, 'e1', ['unscr-1718'])
+
+      expect(exporter.instruments.keys).to eq(
+        ['https://www.ammitto.org/legal-instrument/au/unscr-1718']
+      )
+    end
+
+    it 'leaves a slug exactly at the byte budget untouched' do
+      at_budget = 'b' * 248
+      add_entry(exporter, 'e1', [at_budget])
+
+      expect(instrument_tails(exporter)).to eq([at_budget])
+    end
+
+    it 'merges distinct originals that normalize to one slug' do
+      # Existing dedup semantics: whitespace/punctuation variants of the
+      # same citation collapse to one instrument, clamped or not.
+      add_entry(exporter, 'e1', ['UNSCR 1718', 'unscr--1718'])
+      add_entry(exporter, 'e2', ["Act #{'z' * 300}", "act  #{'z' * 300}"])
+
+      expect(exporter.instruments.length).to eq(2)
+    end
+
+    it 'raises loudly on a true clamped-slug collision' do
+      allow(Digest::SHA256).to receive(:hexdigest).and_return('0' * 64)
+
+      first = 'c' * 300
+      second = 'c' * 301
+      add_entry(exporter, 'e1', [first])
+
+      expect { add_entry(exporter, 'e2', [second]) }
+        .to raise_error(Ammitto::Error) { |error|
+          expect(error.message).to include(first.inspect)
+          expect(error.message).to include(second.inspect)
+        }
+    end
+
+    it 'does not raise when the same identifier repeats' do
+      identifier = 'd' * 300
+      add_entry(exporter, 'e1', [identifier])
+
+      expect { add_entry(exporter, 'e2', [identifier]) }.not_to raise_error
+      expect(exporter.instruments.length).to eq(1)
+    end
+
+    it 'writes filenames equal to IRI tails for clamped and unclamped' do
+      add_entry(exporter, 'e1', ['unscr-1718', 'a' * 300])
+      exporter.export
+
+      files = Dir.glob(
+        File.join(output_dir, 'node', 'legal-instrument', 'au', '*.jsonld')
+      )
+      expect(files.length).to eq(2)
+
+      files.each do |file|
+        basename = File.basename(file, '.jsonld')
+        expect(File.basename(file).bytesize).to be <= 255
+        data = JSON.parse(File.read(file))
+        expect(data['@id'].split('/').last).to eq(basename)
+      end
+    end
+  end
+end

--- a/spec/ammitto/serialization/json_ld_graph_exporter_filename_clamp_spec.rb
+++ b/spec/ammitto/serialization/json_ld_graph_exporter_filename_clamp_spec.rb
@@ -145,6 +145,47 @@ RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
       expect(exporter.instruments.length).to eq(1)
     end
 
+    it 'raises on citation-derived slugs spanning path components' do
+      entity = {
+        '@id' => 'https://www.ammitto.org/entity/au/e9',
+        '@type' => 'PersonEntity'
+      }
+      entry = {
+        '@id' => 'https://www.ammitto.org/entry/au/consolidated/e9',
+        '@type' => 'SanctionEntry',
+        'legalCitations' => [{
+          'legalInstrumentId' =>
+            'https://www.ammitto.org/legal_instrument/au/../../escape/act-1'
+        }]
+      }
+
+      expect { exporter.add_node(entity: entity, entry: entry, source: :au) }
+        .to raise_error(Ammitto::Error, /unusable path component/)
+    end
+
+    it 'raises loudly when an identifier normalizes to an empty slug' do
+      expect { add_entry(exporter, 'e8', ['///']) }
+        .to raise_error(Ammitto::Error, /unusable path component/)
+    end
+
+    it 'raises on citation-derived sources escaping the node layout' do
+      entity = {
+        '@id' => 'https://www.ammitto.org/entity/au/e10',
+        '@type' => 'PersonEntity'
+      }
+      entry = {
+        '@id' => 'https://www.ammitto.org/entry/au/consolidated/e10',
+        '@type' => 'SanctionEntry',
+        'legalCitations' => [{
+          'legalInstrumentId' =>
+            'https://www.ammitto.org/legal_instrument/../act-1'
+        }]
+      }
+
+      expect { exporter.add_node(entity: entity, entry: entry, source: :au) }
+        .to raise_error(Ammitto::Error, /unusable path component/)
+    end
+
     it 'writes filenames equal to IRI tails for clamped and unclamped' do
       add_entry(exporter, 'e1', ['unscr-1718', 'a' * 300])
       exporter.export


### PR DESCRIPTION
Harmonize crashed with **`Errno::ENAMETOOLONG`** on AU because free-text legal citations become instrument node filenames, and 105 of them exceed the 255-byte limit. Added a single mint point for instrument IRIs that clamps oversized slugs (100 bytes + 12-hex hash) and keeps filename == IRI tail, leaving short slugs byte-identical. Added a collision guard that raises when two distinct slugs would map to one IRI, and preserved the existing citation-variant merging.

Verified: full suite green, end-to-end AU harmonize completes with all 341 instrument nodes and zero over-limit filenames.
