### PR TITLE
Fix zero-entity harmonize caused by stale processed dirs

### DIFF
--- a/lib/ammitto/cli/harmonize_command.rb
+++ b/lib/ammitto/cli/harmonize_command.rb
@@ -200,32 +200,11 @@ module Ammitto
       def harmonize_source(source)
         puts "[#{source}] Harmonizing..." if options[:verbose]
 
-        input_dir = find_input_dir(source)
+        input_dir, yaml_files = find_input_dir(source)
         unless input_dir
           puts "[#{source}] No input directory found. Run 'ammitto fetch' first." if options[:verbose]
           return { code: source, status: :error, error: 'No input directory found' }
         end
-
-        # Load YAML files from multiple possible locations
-        yaml_files = []
-
-        # Check for entities subdirectory
-        yaml_files += Dir.glob(File.join(input_dir, 'entities', '*.yaml'))
-        yaml_files += Dir.glob(File.join(input_dir, 'entities', '*.yml'))
-
-        # Check for root directory
-        yaml_files += Dir.glob(File.join(input_dir, '*.yaml'))
-        yaml_files += Dir.glob(File.join(input_dir, '*.yml'))
-
-        # Check for nested subdirectories (data-cn format: sources/sanction-lists/*/)
-        yaml_files += Dir.glob(File.join(input_dir, '*', '*.yaml'))
-        yaml_files += Dir.glob(File.join(input_dir, '*', '*.yml'))
-
-        # Filter out metadata files (starting with _)
-        yaml_files = yaml_files.reject { |f| File.basename(f).start_with?('_') }
-
-        # Remove duplicates (in case same file exists in both locations)
-        yaml_files = yaml_files.uniq
 
         return { code: source, status: :error, error: 'No YAML files found' } if yaml_files.empty?
 
@@ -304,49 +283,205 @@ module Ammitto
         added
       end
 
-      # Find input directory for source
+      # Find input directory and its loadable YAML files for source
+      #
+      # Preference is eligibility-based, not existence-based: the first
+      # candidate holding at least one eligible YAML file wins, so a
+      # stale processed/ directory (empty or holding only _index.yaml)
+      # no longer shadows curated YAML under sources/sanction-lists/.
+      # When no candidate is eligible, the legacy existence-based chain
+      # decides and the legacy (non-recursive, unfiltered) file set is
+      # loaded, so failure and ingestion semantics for those
+      # directories stay unchanged. Selection and loading derive from
+      # one memoized resolution per directory (#resolve_yaml_files).
+      # @param source [Symbol] source code
+      # @return [Array(String, Array<String>), nil] directory and files
+      def find_input_dir(source)
+        explicit_input(source) || auto_input(source)
+      end
+
+      # Resolve the explicit --input-dir option, keeping the legacy
+      # precedence: the per-source subdirectory wins whenever it
+      # exists (a base holding per-source subdirectories must never be
+      # loaded as one source), then the base directory with its legacy
+      # file set. The subdirectory upgrades to the eligible set when
+      # one is found, so nested per-source layouts load; an explicit
+      # path that exists but holds nothing is still returned
+      # (surfacing "No YAML files found") rather than silently falling
+      # through to auto-detection, which would mask a mistyped path.
+      # @param source [Symbol] source code
+      # @return [Array(String, Array<String>), nil] directory and files
+      def explicit_input(source)
+        return nil unless options[:input_dir]
+
+        sub = File.join(options[:input_dir], source.to_s)
+        base = options[:input_dir]
+
+        if Dir.exist?(sub)
+          views = resolve_yaml_files(sub)
+          files = views[:eligible].any? ? views[:chosen] : views[:legacy]
+          return [sub, files]
+        end
+        return [base, resolve_yaml_files(base)[:legacy]] if Dir.exist?(base)
+
+        nil
+      end
+
+      # Auto-detection: the first candidate holding eligible YAML, or
+      # the legacy existence-based fallback. One memo per call keeps
+      # every directory resolved at most once, so the eligibility
+      # decision and the fallback's returned file list always come
+      # from the same resolution of that directory.
+      # @param source [Symbol] source code
+      # @return [Array(String, Array<String>), nil] directory and files
+      def auto_input(source)
+        views_by_dir = Hash.new do |memo, dir|
+          memo[dir] = resolve_yaml_files(dir)
+        end
+
+        candidate_input_dirs(source).each do |dir|
+          views = views_by_dir[dir]
+          return [dir, views[:chosen]] if views[:eligible].any?
+        end
+
+        dir = existing_input_dir(source)
+        dir ? [dir, views_by_dir[dir][:legacy]] : nil
+      end
+
+      # Auto-detection candidates in legacy order — processed/, then
+      # sources/sanction-lists/ (data-cn format), then raw/<latest
+      # date>, each for the underscore and hyphen repo namings, then
+      # the cache
+      # @param source [Symbol] source code
+      # @return [Array<String>] candidate directories
+      def candidate_input_dirs(source)
+        candidates = []
+
+        if options[:sources_dir]
+          %w[processed sources/sanction-lists].each do |subpath|
+            data_repo_names(source).each do |repo|
+              candidates << File.join(options[:sources_dir], repo, subpath)
+            end
+          end
+
+          data_repo_names(source).each do |repo|
+            raw_path = File.join(options[:sources_dir], repo, 'raw')
+            candidates << find_latest_subdir(raw_path)
+          end
+        end
+
+        candidates << find_latest_subdir(File.join(cache_dir, 'raw',
+                                                   source.to_s))
+        candidates.compact
+      end
+
+      # Underscore and hyphen data repository names for a source
+      # (eu_vessels -> data-eu_vessels, data-eu-vessels)
+      # @param source [Symbol] source code
+      # @return [Array<String>] unique data-* directory names
+      def data_repo_names(source)
+        ["data-#{source}", "data-#{source.to_s.gsub('_', '-')}"].uniq
+      end
+
+      # Legacy existence-based directory chain (including the
+      # historical early nil return for a raw/ directory without
+      # dated subdirectories)
       # @param source [Symbol] source code
       # @return [String, nil] input directory path
-      def find_input_dir(source)
-        # Check specified input_dir
-        if options[:input_dir]
-          return File.join(options[:input_dir], source.to_s) if Dir.exist?(File.join(options[:input_dir], source.to_s))
-          return options[:input_dir] if Dir.exist?(options[:input_dir])
-        end
-
-        # Check sources_dir - try both underscore and hyphen naming
+      def existing_input_dir(source)
         if options[:sources_dir]
-          # Try underscore version first (eu_vessels -> data-eu_vessels)
-          processed_path = File.join(options[:sources_dir], "data-#{source}", 'processed')
-          return processed_path if Dir.exist?(processed_path)
+          %w[processed sources/sanction-lists].each do |subpath|
+            data_repo_names(source).each do |repo|
+              path = File.join(options[:sources_dir], repo, subpath)
+              return path if Dir.exist?(path)
+            end
+          end
 
-          # Try hyphen version (eu_vessels -> data-eu-vessels)
-          hyphen_source = source.to_s.gsub('_', '-')
-          processed_path = File.join(options[:sources_dir], "data-#{hyphen_source}", 'processed')
-          return processed_path if Dir.exist?(processed_path)
-
-          # Check for sources/sanction-lists directory (data-cn format)
-          sources_lists_path = File.join(options[:sources_dir], "data-#{source}", 'sources', 'sanction-lists')
-          return sources_lists_path if Dir.exist?(sources_lists_path)
-
-          # Try hyphen version for sources
-          sources_lists_path = File.join(options[:sources_dir], "data-#{hyphen_source}", 'sources', 'sanction-lists')
-          return sources_lists_path if Dir.exist?(sources_lists_path)
-
-          # Then check for raw/{date} directory
-          source_path = File.join(options[:sources_dir], "data-#{source}", 'raw')
-          return find_latest_subdir(source_path) if Dir.exist?(source_path)
-
-          # Try hyphen version for raw
-          source_path = File.join(options[:sources_dir], "data-#{hyphen_source}", 'raw')
-          return find_latest_subdir(source_path) if Dir.exist?(source_path)
+          data_repo_names(source).each do |repo|
+            raw_path = File.join(options[:sources_dir], repo, 'raw')
+            return find_latest_subdir(raw_path) if Dir.exist?(raw_path)
+          end
         end
 
-        # Check default cache location
         cache_raw = File.join(cache_dir, 'raw', source.to_s)
         return find_latest_subdir(cache_raw) if Dir.exist?(cache_raw)
 
         nil
+      end
+
+      # Resolve a directory's YAML tiers once and derive the three
+      # views discovery uses, so the eligibility decision and the
+      # returned load list always come from the same resolution:
+      # - :eligible — the selection predicate: regular files from the
+      #   legacy tiers (entities/ subdirectory, flat files, one-level
+      #   list directories — data-cn format), plus a recursive tier
+      #   when those hold no regular direct YAML, reaching lists
+      #   nested more than one level deep (data-jp). Only regular
+      #   files count (a directory named like a YAML file must not
+      #   make a candidate eligible), but eligibility is otherwise by
+      #   name: malformed YAML stays eligible so source corruption
+      #   surfaces through load errors and the health gates instead of
+      #   silently falling through to another directory.
+      # - :chosen — the load list for an eligibility winner: the
+      #   unfiltered legacy set (layout anomalies like a directory
+      #   named entity.yaml still surface as load errors exactly as
+      #   before) plus the recursive regular files.
+      # - :legacy — the loader's historical set (direct plus
+      #   one-level tiers, unfiltered, never recursive) for existence
+      #   fallbacks, keeping their semantics byte-identical.
+      # @param dir [String, nil] directory to inspect
+      # @return [Hash{Symbol=>Array<String>}] tier views
+      def resolve_yaml_files(dir)
+        empty = { eligible: [], chosen: [], legacy: [] }
+        return empty if dir.nil? || !Dir.exist?(dir)
+
+        direct = yaml_files_in(dir, 'entities') + yaml_files_in(dir)
+        one_level = yaml_files_in(dir, '*')
+        direct_regular = regular_files(direct)
+        recursive = if direct_regular.empty?
+                      regular_files(yaml_files_in(dir, '**'))
+                    else
+                      []
+                    end
+        legacy = (direct + one_level).uniq
+
+        {
+          eligible: (direct_regular + regular_files(one_level) +
+                     recursive).uniq,
+          chosen: (legacy + recursive).uniq,
+          legacy: legacy
+        }
+      end
+
+      # Eligible YAML files within a directory (see #resolve_yaml_files)
+      # @param dir [String, nil] directory to inspect
+      # @return [Array<String>] eligible YAML file paths
+      def eligible_yaml_files(dir)
+        resolve_yaml_files(dir)[:eligible]
+      end
+
+      # One glob tier of YAML entries, excluding metadata files
+      # (basename starting with "_"). Patterns are globbed relative to
+      # the directory (base:) so glob metacharacters in configured
+      # paths are treated literally.
+      # @param dir [String] directory to glob under
+      # @param segments [Array<String>] intermediate path segments
+      # @return [Array<String>] YAML entry paths
+      def yaml_files_in(dir, *segments)
+        patterns = %w[yaml yml].map do |ext|
+          File.join(*segments, "*.#{ext}")
+        end
+
+        patterns.flat_map { |pattern| Dir.glob(pattern, base: dir) }
+                .map { |relative| File.join(dir, relative) }
+                .reject { |f| File.basename(f).start_with?('_') }
+      end
+
+      # Restrict paths to regular files (following symlinks)
+      # @param paths [Array<String>] candidate paths
+      # @return [Array<String>] regular file paths
+      def regular_files(paths)
+        paths.select { |f| File.file?(f) }
       end
 
       # Find latest subdirectory (by date)

--- a/lib/ammitto/cli/harmonize_command.rb
+++ b/lib/ammitto/cli/harmonize_command.rb
@@ -415,8 +415,10 @@ module Ammitto
       # - :eligible — the selection predicate: regular files from the
       #   legacy tiers (entities/ subdirectory, flat files, one-level
       #   list directories — data-cn format), plus a recursive tier
-      #   when those hold no regular direct YAML, reaching lists
-      #   nested more than one level deep (data-jp). Only regular
+      #   when the direct tiers (entities/ and flat files) hold no
+      #   regular YAML — one-level list files do not suppress it —
+      #   reaching lists nested more than one level deep (data-jp).
+      #   Only regular
       #   files count (a directory named like a YAML file must not
       #   make a candidate eligible), but eligibility is otherwise by
       #   name: malformed YAML stays eligible so source corruption

--- a/spec/ammitto/cli/harmonize_command_spec.rb
+++ b/spec/ammitto/cli/harmonize_command_spec.rb
@@ -1,0 +1,388 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+require 'fileutils'
+require 'ammitto'
+require 'ammitto/cli'
+require 'ammitto/cli/harmonize_command'
+
+RSpec.describe Ammitto::Cmd::HarmonizeCommand do
+  let(:sources_dir) { Dir.mktmpdir('ammitto_harmonize_test') }
+  let(:options) { { sources_dir: sources_dir } }
+  let(:command) { described_class.new(options, ['us']) }
+
+  after do
+    FileUtils.rm_rf(sources_dir)
+  end
+
+  # Create a file (plus its parent directories) under sources_dir
+  def write_file(*segments)
+    path = File.join(sources_dir, *segments)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, "---\nid: test\n")
+    path
+  end
+
+  # Create a directory under sources_dir
+  def make_dir(*segments)
+    path = File.join(sources_dir, *segments)
+    FileUtils.mkdir_p(path)
+    path
+  end
+
+  describe '#find_input_dir' do
+    def find_input(source = :us)
+      command.send(:find_input_dir, source)
+    end
+
+    def find_input_dir(source = :us)
+      find_input(source)&.first
+    end
+
+    it 'prefers a populated processed/ directory' do
+      write_file('data-us', 'processed', 'entities', 'entity.yaml')
+      make_dir('data-us', 'sources', 'sanction-lists', 'sdn-list')
+
+      expect(find_input_dir)
+        .to eq(File.join(sources_dir, 'data-us', 'processed'))
+    end
+
+    it 'falls through an empty processed/ to sources/sanction-lists' do
+      make_dir('data-us', 'processed')
+      entity = write_file('data-us', 'sources', 'sanction-lists',
+                          'sdn-list', 'entity.yml')
+
+      dir, files = find_input
+
+      expect(dir).to eq(File.join(sources_dir, 'data-us', 'sources',
+                                  'sanction-lists'))
+      expect(files).to eq([entity])
+    end
+
+    it 'loads one-level and deeper files together when direct is empty' do
+      make_dir('data-jp', 'processed')
+      one = write_file('data-jp', 'sources', 'sanction-lists',
+                       'fefta-list', 'entity.yml')
+      deep = write_file('data-jp', 'sources', 'sanction-lists',
+                        'mof-asset-freeze', '01-milosevic', '20260306.yml')
+
+      _dir, files = find_input(:jp)
+
+      expect(files).to contain_exactly(one, deep)
+    end
+
+    it 'falls through a processed/ holding only _index.yaml' do
+      write_file('data-us', 'processed', '_index.yaml')
+      write_file('data-us', 'sources', 'sanction-lists', 'sdn-list',
+                 'entity.yml')
+
+      expect(find_input_dir)
+        .to eq(File.join(sources_dir, 'data-us', 'sources',
+                         'sanction-lists'))
+    end
+
+    it 'falls through unusable processed/ and sanction-lists to raw' do
+      write_file('data-us', 'processed', '_index.yaml')
+      make_dir('data-us', 'sources', 'sanction-lists')
+      write_file('data-us', 'raw', '2026-01-02', 'entity.yaml')
+
+      expect(find_input_dir)
+        .to eq(File.join(sources_dir, 'data-us', 'raw', '2026-01-02'))
+    end
+
+    it 'resolves hyphen-named repositories by eligibility' do
+      make_dir('data-eu-vessels', 'processed')
+      write_file('data-eu-vessels', 'sources', 'sanction-lists', 'list',
+                 'vessel.yml')
+
+      expect(find_input_dir(:eu_vessels))
+        .to eq(File.join(sources_dir, 'data-eu-vessels', 'sources',
+                         'sanction-lists'))
+    end
+
+    it 'prefers the underscore repository when both are eligible' do
+      write_file('data-eu_vessels', 'processed', 'entity.yaml')
+      write_file('data-eu-vessels', 'processed', 'entity.yaml')
+
+      expect(find_input_dir(:eu_vessels))
+        .to eq(File.join(sources_dir, 'data-eu_vessels', 'processed'))
+    end
+
+    it 'falls through to a usable cache when repo dirs are unusable' do
+      make_dir('data-us', 'processed')
+      cache_dir = make_dir('cache')
+      options[:cache_dir] = cache_dir
+      File.write(File.join(make_dir('cache', 'raw', 'us', '2026-01-01'),
+                           'entity.yaml'), "---\nid: test\n")
+
+      expect(find_input_dir)
+        .to eq(File.join(cache_dir, 'raw', 'us', '2026-01-01'))
+    end
+
+    it 'reaches a usable cache past a raw/ dir without dated subdirs' do
+      make_dir('data-us', 'raw')
+      cache_dir = make_dir('cache')
+      options[:cache_dir] = cache_dir
+      File.write(File.join(make_dir('cache', 'raw', 'us', '2026-01-01'),
+                           'entity.yaml'), "---\nid: test\n")
+
+      expect(find_input_dir)
+        .to eq(File.join(cache_dir, 'raw', 'us', '2026-01-01'))
+    end
+
+    it 'treats glob metacharacters in configured paths literally' do
+      weird = File.join(sources_dir, 'we[i]rd')
+      entity = File.join(weird, 'data-us', 'processed', 'entity.yaml')
+      FileUtils.mkdir_p(File.dirname(entity))
+      File.write(entity, "---\nid: test\n")
+      options[:sources_dir] = weird
+
+      dir, files = find_input
+
+      expect(dir).to eq(File.join(weird, 'data-us', 'processed'))
+      expect(files).to eq([entity])
+    end
+
+    it 'resolves each directory at most once per discovery call' do
+      write_file('data-us', 'processed', '_index.yaml')
+
+      resolved = []
+      allow(command).to receive(:resolve_yaml_files)
+        .and_wrap_original do |original, dir|
+          resolved << dir
+          original.call(dir)
+        end
+
+      find_input
+
+      expect(resolved).to eq(resolved.uniq)
+    end
+
+    context 'when no candidate holds eligible YAML' do
+      it 'returns the existing processed/ directory as before' do
+        write_file('data-us', 'processed', '_index.yaml')
+
+        expect(find_input_dir)
+          .to eq(File.join(sources_dir, 'data-us', 'processed'))
+      end
+
+      it 'reports "No YAML files found" for that directory' do
+        write_file('data-us', 'processed', '_index.yaml')
+
+        result = command.send(:harmonize_source, :us)
+
+        expect(result[:status]).to eq(:error)
+        expect(result[:error]).to eq('No YAML files found')
+      end
+
+      it 'returns nil when nothing exists for the source' do
+        options[:cache_dir] = make_dir('cache')
+
+        expect(command.send(:find_input_dir, :us)).to be_nil
+      end
+
+      it 'keeps the legacy nil for a raw/ dir without dated subdirs' do
+        make_dir('data-us', 'raw')
+        options[:cache_dir] = make_dir('cache')
+
+        expect(command.send(:find_input_dir, :us)).to be_nil
+      end
+    end
+
+    context 'with an explicit input_dir option' do
+      it 'prefers the per-source subdirectory and its eligible files' do
+        input_dir = make_dir('input')
+        entity = write_file('input', 'us', 'list', 'deep', 'entity.yml')
+        options[:input_dir] = input_dir
+
+        dir, files = find_input
+
+        expect(dir).to eq(File.join(input_dir, 'us'))
+        expect(files).to eq([entity])
+      end
+
+      it 'keeps subdirectory precedence even when it is empty' do
+        input_dir = make_dir('input')
+        make_dir('input', 'us')
+        write_file('input', 'entity.yaml')
+        write_file('input', 'uk', 'entity.yml')
+        options[:input_dir] = input_dir
+
+        dir, files = find_input
+
+        expect(dir).to eq(File.join(input_dir, 'us'))
+        expect(files).to eq([])
+      end
+
+      it 'does not fall through past an existing but empty path' do
+        options[:input_dir] = make_dir('input')
+        write_file('data-us', 'processed', 'entity.yaml')
+
+        expect(find_input_dir).to eq(File.join(sources_dir, 'input'))
+      end
+
+      it 'never loads deeply nested sibling files from the base dir' do
+        input_dir = make_dir('input')
+        write_file('input', 'uk', 'deep', 'entity.yml')
+        options[:input_dir] = input_dir
+
+        dir, files = find_input
+
+        expect(dir).to eq(input_dir)
+        expect(files).to eq([])
+      end
+
+      it 'keeps the legacy one-level ingestion for the base fallback' do
+        input_dir = make_dir('input')
+        sibling = write_file('input', 'uk', 'entity.yml')
+        options[:input_dir] = input_dir
+
+        dir, files = find_input
+
+        expect(dir).to eq(input_dir)
+        expect(files).to eq([sibling])
+      end
+
+      it 'falls through to auto-detection when the path does not exist' do
+        options[:input_dir] = File.join(sources_dir, 'missing')
+        write_file('data-us', 'processed', 'entity.yaml')
+
+        expect(find_input_dir)
+          .to eq(File.join(sources_dir, 'data-us', 'processed'))
+      end
+    end
+
+    context 'with non-regular YAML entries' do
+      it 'keeps the legacy load-error path for the fallback dir' do
+        junk = make_dir('data-us', 'processed', 'not-a-file.yaml')
+
+        dir, files = command.send(:find_input_dir, :us)
+
+        expect(dir).to eq(File.join(sources_dir, 'data-us', 'processed'))
+        expect(files).to eq([junk])
+      end
+
+      it 'keeps them in the load list of a chosen directory' do
+        entity = write_file('data-us', 'processed', 'entity.yaml')
+        junk = make_dir('data-us', 'processed', 'broken.yaml')
+
+        dir, files = command.send(:find_input_dir, :us)
+
+        expect(dir).to eq(File.join(sources_dir, 'data-us', 'processed'))
+        expect(files).to contain_exactly(entity, junk)
+      end
+
+      it 'surfaces the load error for a mixed chosen directory' do
+        write_file('data-us', 'processed', 'entity.yaml')
+        make_dir('data-us', 'processed', 'broken.yaml')
+
+        result = command.send(:harmonize_source, :us)
+
+        expect(result[:status]).to eq(:error)
+        expect(result[:error]).to match(/directory/i)
+      end
+    end
+  end
+
+  describe '#eligible_yaml_files' do
+    def eligible_yaml_files(dir)
+      command.send(:eligible_yaml_files, dir)
+    end
+
+    it 'collects entities/, flat, and one-level-nested YAML files' do
+      dir = make_dir('data-us', 'processed')
+      a = write_file('data-us', 'processed', 'entities', 'a.yaml')
+      b = write_file('data-us', 'processed', 'b.yml')
+      c = write_file('data-us', 'processed', 'list', 'c.yaml')
+
+      expect(eligible_yaml_files(dir)).to eq([a, b, c])
+    end
+
+    it 'scans recursively when the direct tiers are empty' do
+      dir = make_dir('data-jp', 'sources', 'sanction-lists')
+      one = write_file('data-jp', 'sources', 'sanction-lists',
+                       'fefta-list', 'entity.yml')
+      two = write_file('data-jp', 'sources', 'sanction-lists',
+                       'mof-asset-freeze', '01-milosevic', '20260306.yml')
+
+      expect(eligible_yaml_files(dir)).to contain_exactly(one, two)
+    end
+
+    it 'excludes deep non-regular entries from the recursive tier' do
+      dir = make_dir('data-jp', 'sources', 'sanction-lists')
+      deep = write_file('data-jp', 'sources', 'sanction-lists',
+                        'list', 'sub', 'entity.yml')
+      make_dir('data-jp', 'sources', 'sanction-lists', 'list', 'sub',
+               'junk.yaml')
+
+      expect(eligible_yaml_files(dir)).to eq([deep])
+    end
+
+    it 'does not scan deeper than one level when direct files exist' do
+      dir = make_dir('data-us', 'processed')
+      flat = write_file('data-us', 'processed', 'entity.yaml')
+      write_file('data-us', 'processed', 'list', 'deep', 'entity.yml')
+
+      expect(eligible_yaml_files(dir)).to eq([flat])
+    end
+
+    it 'keeps files reached through a symlinked list directory' do
+      dir = make_dir('data-us', 'sources', 'sanction-lists')
+      target = write_file('elsewhere', 'entity.yml')
+      File.symlink(File.dirname(target), File.join(dir, 'linked'))
+
+      expect(eligible_yaml_files(dir))
+        .to eq([File.join(dir, 'linked', 'entity.yml')])
+    end
+
+    it 'excludes metadata files at every level' do
+      dir = make_dir('data-us', 'sources', 'sanction-lists')
+      write_file('data-us', 'sources', 'sanction-lists', '_index.yaml')
+      write_file('data-us', 'sources', 'sanction-lists', 'list',
+                 '_index.yml')
+      eligible = write_file('data-us', 'sources', 'sanction-lists',
+                            'list', 'entity.yml')
+
+      expect(eligible_yaml_files(dir)).to contain_exactly(eligible)
+    end
+
+    it 'ignores directories named like YAML files' do
+      dir = make_dir('data-us', 'processed')
+      make_dir('data-us', 'processed', 'not-a-file.yaml')
+
+      expect(eligible_yaml_files(dir)).to eq([])
+    end
+
+    it 'returns each file once despite overlapping patterns' do
+      dir = make_dir('data-us', 'processed')
+      nested = write_file('data-us', 'processed', 'entities', 'a.yaml')
+
+      expect(eligible_yaml_files(dir)).to eq([nested])
+    end
+
+    it 'returns an empty array for nil or missing directories' do
+      expect(eligible_yaml_files(nil)).to eq([])
+      expect(eligible_yaml_files(File.join(sources_dir, 'missing')))
+        .to eq([])
+    end
+  end
+
+  describe '#harmonize_source' do
+    it 'feeds deeply nested sanction-list files to transformation' do
+      write_file('data-us', 'processed', '_index.yaml')
+      write_file('data-us', 'sources', 'sanction-lists', 'sdn-list',
+                 '2026', 'entity.yml')
+
+      seen = []
+      allow(command).to receive(:transform_data) do |src, _data|
+        seen << src
+        { entity: nil, entry: nil }
+      end
+
+      result = command.send(:harmonize_source, :us)
+
+      expect(result[:status]).to eq(:success)
+      expect(seen).to eq([:us])
+    end
+  end
+end


### PR DESCRIPTION
Harmonize picked input directories by existence, so stale **`processed/`** dirs holding only `_index.yaml` shadowed curated YAML and data-us, data-ch and data-jp harvested zero entities. Flipped **`find_input_dir`** to eligibility-based preference: the first candidate holding loadable YAML wins, with candidate order unchanged. Added recursive scanning for lists nested below one level (data-jp) and made directory choice and file loading come from one scan so they can never disagree. Kept explicit **`--input-dir`** precedence and no-data failure semantics byte-identical, so sources without usable candidates fail exactly as before.

Verified against fresh data-us, data-ch and data-jp clones plus the full suite and RuboCop.
