### PR TITLE
Fix silent fetch failures and broken workflow invocation

### DIFF
--- a/.github/workflows/fetch-sources.yml
+++ b/.github/workflows/fetch-sources.yml
@@ -24,8 +24,32 @@ jobs:
         run: bundle install --jobs 4 --retry 3
 
       - name: Fetch latest data
+        # The input is comma-separated and defaults to "all"; the CLI takes
+        # space-separated codes and needs --all for the everything case.
+        # Passed through env so the untrusted input never reaches the shell
+        # as an expanded expression. CR/LF/tab all count as separators, so a
+        # pasted multi-line or CRLF value cannot lose codes or carry a stray
+        # \r into one; empty fields from "eu,,un" are dropped.
+        env:
+          SOURCES: ${{ github.event.inputs.sources }}
         run: |
-          bundle exec ammitto fetch ${{ github.event.inputs.sources != 'all' && github.event.inputs.sources || '' }} --verbose
+          normalized=$(printf '%s' "$SOURCES" | tr '\r\n\t' '   ')
+          if [ -z "$(printf '%s' "$normalized" | tr -d '[:space:]')" ] ||
+             [ "$(printf '%s' "$normalized" | tr '[:upper:]' '[:lower:]' \
+                  | tr -d '[:space:]')" = "all" ]; then
+            bundle exec ammitto fetch --all --verbose
+          else
+            IFS=', ' read -r -a raw <<< "$normalized"
+            codes=()
+            for code in "${raw[@]}"; do
+              if [ -n "$code" ]; then codes+=("$code"); fi
+            done
+            if [ ${#codes[@]} -eq 0 ]; then
+              echo "::error::sources input held separators but no source codes"
+              exit 1
+            fi
+            bundle exec ammitto fetch "${codes[@]}" --verbose
+          fi
 
       - name: Process data
         run: bundle exec ammitto process --verbose

--- a/.github/workflows/fetch-sources.yml
+++ b/.github/workflows/fetch-sources.yml
@@ -45,6 +45,9 @@ jobs:
             seen=' '
             for code in "${raw[@]}"; do
               [ -n "$code" ] || continue
+              # The CLI downcases codes, so fold here too: otherwise "EU,eu"
+              # survives as two entries that both resolve to :eu and refetch.
+              code=${code,,}
               # Quoted inside the pattern, so a code holding * or ? matches
               # literally instead of globbing away an unrelated entry.
               case "$seen" in *" $code "*) continue ;; esac

--- a/.github/workflows/fetch-sources.yml
+++ b/.github/workflows/fetch-sources.yml
@@ -29,7 +29,8 @@ jobs:
         # Passed through env so the untrusted input never reaches the shell
         # as an expanded expression. CR/LF/tab all count as separators, so a
         # pasted multi-line or CRLF value cannot lose codes or carry a stray
-        # \r into one; empty fields from "eu,,un" are dropped.
+        # \r into one; empty fields from "eu,,un" are dropped and repeats of
+        # one code are collapsed so the list cannot refetch a source.
         env:
           SOURCES: ${{ github.event.inputs.sources }}
         run: |
@@ -41,14 +42,23 @@ jobs:
           else
             IFS=', ' read -r -a raw <<< "$normalized"
             codes=()
+            seen=' '
             for code in "${raw[@]}"; do
-              if [ -n "$code" ]; then codes+=("$code"); fi
+              [ -n "$code" ] || continue
+              # Quoted inside the pattern, so a code holding * or ? matches
+              # literally instead of globbing away an unrelated entry.
+              case "$seen" in *" $code "*) continue ;; esac
+              seen="$seen$code "
+              codes+=("$code")
             done
             if [ ${#codes[@]} -eq 0 ]; then
               echo "::error::sources input held separators but no source codes"
               exit 1
             fi
-            bundle exec ammitto fetch "${codes[@]}" --verbose
+            # Options precede --, so an option-shaped input ("--all",
+            # "--output-dir /tmp") is parsed as a source code and rejected by
+            # the CLI instead of silently widening scope or moving the output.
+            bundle exec ammitto fetch --verbose -- "${codes[@]}"
           fi
 
       - name: Process data

--- a/.github/workflows/fetch-sources.yml
+++ b/.github/workflows/fetch-sources.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Fetch latest data
         run: |
           bundle exec ammitto fetch ${{ github.event.inputs.sources != 'all' && github.event.inputs.sources || '' }} --verbose
-        continue-on-error: true
 
       - name: Process data
         run: bundle exec ammitto process --verbose

--- a/README.adoc
+++ b/README.adoc
@@ -337,7 +337,7 @@ ammitto fetch uk --format yaml --output-dir ./processed --verbose
 # Fetch multiple sources
 ammitto fetch uk eu un --format yaml --output-dir ./processed
 
-# Fetch all sources
+# Fetch all automatable sources (skips cn, which is manually managed)
 ammitto fetch --all --format yaml --output-dir ./processed
 
 # Dry run (show what would be fetched)

--- a/ammitto.gemspec
+++ b/ammitto.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'csv'
   spec.add_dependency 'faraday', '~> 2.0'
   spec.add_dependency 'json-ld', '~> 3.3'
-  spec.add_dependency 'json-schema', '~> 4.0'
+  spec.add_dependency 'json-schema', '>= 4', '< 6'
   spec.add_dependency 'lutaml-model', '~> 0.8.17'
   spec.add_dependency 'mechanize', '~> 2.12'
   spec.add_dependency 'moxml', '~> 0.1', '>= 0.1.25'

--- a/docs/getting-started/quick-start.adoc
+++ b/docs/getting-started/quick-start.adoc
@@ -78,7 +78,7 @@ ammitto get un/KPi.066 --format json
 # Fetch from a specific source
 ammitto fetch eu --output-dir ./data
 
-# Fetch from all sources
+# Fetch from all automatable sources (skips manually managed cn)
 ammitto fetch --all
 ----
 

--- a/docs/interfaces/cli/index.adoc
+++ b/docs/interfaces/cli/index.adoc
@@ -102,7 +102,7 @@ ammitto fetch eu
 # Fetch multiple sources
 ammitto fetch eu un us
 
-# Fetch all sources
+# Fetch all automatable sources (skips manually managed cn)
 ammitto fetch --all
 
 # Dry run (show what would be fetched)
@@ -124,7 +124,7 @@ ammitto fetch eu --format yaml
 | Show what would be done without making changes
 
 | `--all`
-| Fetch all available sources
+| Fetch all automatable sources (skips manually managed cn)
 
 | `--format FORMAT`
 | Output format: yaml (default), jsonld

--- a/docs/sources/index.adoc
+++ b/docs/sources/index.adoc
@@ -247,11 +247,9 @@ ammitto fetch ch
 
 China publishes sanctions through official announcements and maintains lists of sanctioned entities.
 
-[source,bash]
-----
-# Fetch China data
-ammitto fetch cn
-----
+China data is manually managed in the `data-cn` repository as
+announcement-based reference documents; there is no automated fetch.
+`ammitto fetch cn` reports this and exits nonzero, and `--all` skips CN.
 
 === Russia (`ru`)
 

--- a/lib/ammitto/cli.rb
+++ b/lib/ammitto/cli.rb
@@ -132,16 +132,18 @@ module Ammitto
     long_desc <<~DESC
       Download raw sanction data from specified sources and save as YAML.
 
-      If no sources are specified with --all, fetches the specified sources only.
+      Pass source codes to fetch specific sources, or use --all to fetch
+      every automatable source (cn is skipped: it is manually managed).
 
       Examples:
         ammitto fetch uk --format yaml          # Fetch UK data as YAML
         ammitto fetch uk --output-dir ./data    # Save to specific directory
-        ammitto fetch --all                     # Fetch all sources
+        ammitto fetch --all                     # Fetch automatable sources
         ammitto fetch eu un --dry-run           # Show what would be fetched
     DESC
     option :dry_run, type: :boolean, default: false, desc: 'Show what would be done'
-    option :all, type: :boolean, default: false, desc: 'Fetch all available sources'
+    option :all, type: :boolean, default: false,
+                 desc: 'Fetch all automatable sources (skips cn)'
     option :format, type: :string, default: 'yaml', desc: 'Output format (yaml, jsonld)'
     option :output_dir, type: :string, desc: 'Output directory for YAML files'
     def fetch(*sources)

--- a/lib/ammitto/cli/fetch_command.rb
+++ b/lib/ammitto/cli/fetch_command.rb
@@ -12,7 +12,7 @@ module Ammitto
     # @example Fetch UK data as YAML
     #   ammitto fetch uk --format yaml --output-dir ./processed
     #
-    # @example Fetch all sources
+    # @example Fetch all automatable sources (skips manually managed cn)
     #   ammitto fetch --all
     #
     class FetchCommand
@@ -48,7 +48,7 @@ module Ammitto
       # @param sources [Array<String>]
       # @return [Array<Symbol>]
       def normalize_sources(sources)
-        return Config::Defaults::ALL_SOURCES if options[:all]
+        return Config::Defaults::FETCHABLE_SOURCES if options[:all]
 
         if sources.empty?
           raise Thor::Error,
@@ -80,7 +80,7 @@ module Ammitto
         end
       end
 
-      # Fetch all sources
+      # Fetch all requested sources
       # @return [void]
       def fetch_all
         results = @sources.map do |source|
@@ -88,6 +88,7 @@ module Ammitto
         end
 
         print_summary(results)
+        enforce_exit_status(results)
       end
 
       # Fetch a single source
@@ -406,6 +407,20 @@ module Ammitto
         results.select { |r| r[:status] == :error }.each do |r|
           puts "  #{r[:code]}: #{r[:error]}"
         end
+      end
+
+      # A run with any failed source must exit nonzero: otherwise cron/CI
+      # logs the per-source error and still concludes success, so a dead
+      # source keeps its published data silently stale behind green runs.
+      # @param results [Array<Hash>] fetch results
+      # @return [void]
+      # @raise [Thor::Error] when any requested source failed
+      def enforce_exit_status(results)
+        failed = results.select { |r| r[:status] == :error }
+        return if failed.empty?
+
+        raise Thor::Error,
+              "Fetch failed for: #{failed.map { |r| r[:code] }.join(', ')}"
       end
     end
   end

--- a/lib/ammitto/cli/harmonize_command.rb
+++ b/lib/ammitto/cli/harmonize_command.rb
@@ -505,46 +505,45 @@ module Ammitto
       # Find legal instruments directory
       # @return [String, nil] path to instruments directory
       def find_instruments_dir
-        # Check sources_dir first
-        sources_dir = options[:sources_dir]
-        if sources_dir
-          # Check for data-cn format: sources/legal-instruments/
-          instruments_path = File.join(sources_dir, 'data-cn', 'sources', 'legal-instruments')
-          return instruments_path if Dir.exist?(instruments_path)
-        end
-
-        # Check based on input_dir (sibling directory to legal-instruments)
-        input_dir = options[:input_dir]
-        if input_dir
-          # input_dir might be .../sources/sanction-lists
-          # so legal-instruments would be at .../sources/legal-instruments
-          parent_dir = File.dirname(input_dir)
-          instruments_path = File.join(parent_dir, 'legal-instruments')
-          return instruments_path if Dir.exist?(instruments_path)
-        end
-
-        nil
+        find_supplement_dir('legal-instruments')
       end
 
       # Find supporting data directory (document types, organizations)
       # @return [String, nil] path to supporting directory
       def find_supporting_dir
-        # Check sources_dir first
+        find_supplement_dir('supporting')
+      end
+
+      # Resolve a supplement subtree (legal-instruments/, supporting/) for
+      # the requested sources. Supplements live inside a source's own data
+      # repository (currently only data-cn ships them), so they are looked
+      # up per requested source — a run that does not include a source must
+      # not inject that source's supplement nodes into its output tree.
+      # Known limitation: first match wins in requested-source order, because
+      # the exporter accepts a single directory per supplement kind; if a
+      # second repository ever ships supplements, the exporter API must grow
+      # union loading.
+      # @param subdir [String] supplement directory name
+      # @return [String, nil] path to the supplement directory
+      def find_supplement_dir(subdir)
         sources_dir = options[:sources_dir]
         if sources_dir
-          # Check for data-cn format: sources/supporting/
-          supporting_path = File.join(sources_dir, 'data-cn', 'sources', 'supporting')
-          return supporting_path if Dir.exist?(supporting_path)
+          @sources.each do |source|
+            repo = Config::Defaults::DATA_REPO_TO_SOURCE.key(source)
+            next unless repo
+
+            path = File.join(sources_dir, repo, 'sources', subdir)
+            return path if Dir.exist?(path)
+          end
         end
 
-        # Check based on input_dir (sibling directory to supporting)
+        # input_dir is already scoped to the repository the caller pointed
+        # at; its supplements are sibling directories
+        # (.../sources/sanction-lists -> .../sources/<subdir>)
         input_dir = options[:input_dir]
         if input_dir
-          # input_dir might be .../sources/sanction-lists
-          # so supporting would be at .../sources/supporting
-          parent_dir = File.dirname(input_dir)
-          supporting_path = File.join(parent_dir, 'supporting')
-          return supporting_path if Dir.exist?(supporting_path)
+          path = File.join(File.dirname(input_dir), subdir)
+          return path if Dir.exist?(path)
         end
 
         nil

--- a/lib/ammitto/config/defaults.rb
+++ b/lib/ammitto/config/defaults.rb
@@ -34,6 +34,12 @@ module Ammitto
       # All available sources
       ALL_SOURCES = %i[eu un us wb uk au ca ch cn ru tr nz jp eu_vessels un_vessels].freeze
 
+      # Sources with an automated fetch path. CN is excluded: its YAML is
+      # manually managed in data-cn, so `fetch --all` must not fail on a
+      # source that cannot be fetched automatically (an explicit
+      # `fetch cn` still reports the manual-management error).
+      FETCHABLE_SOURCES = (ALL_SOURCES - %i[cn]).freeze
+
       # Default output format
       DEFAULT_OUTPUT_FORMAT = 'jsonld'
 

--- a/lib/ammitto/ontology/types.rb
+++ b/lib/ammitto/ontology/types.rb
@@ -106,18 +106,26 @@ module Ammitto
 
       # Name script/character set types (ISO 15924)
       # @return [Array<Symbol>]
+      # Latn: Latin, Cyrl: Cyrillic, Arab: Arabic, Hani: Han,
+      # Hebr: Hebrew, Beng: Bengali, Deva: Devanagari, Grek: Greek,
+      # Jpan: Japanese (Han + Kana), Kana: Katakana, Hang: Hangul,
+      # Kore: Korean (Hangul + Han), Thai: Thai. Comments must stay
+      # outside the %i[] literal: Ruby would keep each comment word as
+      # an enum member.
       NAME_SCRIPTS = %i[
-        Latn # Latin
-        Cyrl # Cyrillic
-        Arab # Arabic
-        Hani # Han (Chinese/Japanese/Korean)
-        Hebr # Hebrew
-        Beng # Bengali
-        Deva # Devanagari
-        Greek # Greek
-        Kana # Japanese Kana
-        Hang # Korean Hangul
-        Thai # Thai
+        Latn
+        Cyrl
+        Arab
+        Hani
+        Hebr
+        Beng
+        Deva
+        Grek
+        Jpan
+        Kana
+        Hang
+        Kore
+        Thai
         other
       ].freeze
 
@@ -235,7 +243,7 @@ module Ammitto
         return :Hani if text.match?(/\p{Han}/)
         return :Deva if text.match?(/\p{Devanagari}/)
         return :Beng if text.match?(/\p{Bengali}/)
-        return :Greek if text.match?(/\p{Greek}/)
+        return :Grek if text.match?(/\p{Greek}/)
         return :Kana if text.match?(/\p{Hiragana}|\p{Katakana}/)
         return :Hang if text.match?(/\p{Hangul}/)
         return :Thai if text.match?(/\p{Thai}/)

--- a/spec/ammitto/cli/fetch_command_spec.rb
+++ b/spec/ammitto/cli/fetch_command_spec.rb
@@ -17,4 +17,53 @@ RSpec.describe Ammitto::Cmd::FetchCommand do
     expect { described_class.new({}, []) }
       .to raise_error(Thor::Error, /No sources specified/)
   end
+
+  it 'excludes cn from --all so full runs can succeed' do
+    cmd = described_class.new({ all: true }, [])
+
+    expect(cmd.sources).not_to include(:cn)
+    expect(cmd.sources)
+      .to match_array(Ammitto::Config::Defaults::ALL_SOURCES - %i[cn])
+  end
+
+  describe 'exit honesty' do
+    it 'raises Thor::Error when a requested source fails' do
+      cmd = described_class.new({}, ['cn'])
+
+      expect { cmd.run }
+        .to raise_error(Thor::Error, /Fetch failed for: cn/)
+        .and output(/0 succeeded, 1 failed/).to_stdout
+    end
+
+    it 'fails the run when only some sources fail' do
+      cmd = described_class.new({}, %w[uk cn])
+      allow(cmd).to receive(:fetch_source).and_call_original
+      allow(cmd).to receive(:fetch_source)
+        .with(:uk).and_return({ code: :uk, status: :success, count: 3 })
+
+      expect { cmd.run }
+        .to raise_error(Thor::Error, /Fetch failed for: cn/)
+        .and output(/1 succeeded, 1 failed/).to_stdout
+    end
+
+    it 'names every failed source in the error' do
+      cmd = described_class.new({}, %w[uk eu])
+      allow(cmd).to receive(:fetch_source) do |source|
+        { code: source, status: :error, error: 'boom' }
+      end
+
+      expect { cmd.run }
+        .to raise_error(Thor::Error, /Fetch failed for: uk, eu/)
+        .and output(/0 succeeded, 2 failed/).to_stdout
+    end
+
+    it 'does not raise when all requested sources succeed' do
+      cmd = described_class.new({}, %w[uk])
+      allow(cmd).to receive(:fetch_source)
+        .with(:uk).and_return({ code: :uk, status: :success, count: 3 })
+
+      expect { cmd.run }
+        .to output(/1 succeeded, 0 failed/).to_stdout
+    end
+  end
 end

--- a/spec/ammitto/cli/harmonize_command_spec.rb
+++ b/spec/ammitto/cli/harmonize_command_spec.rb
@@ -367,6 +367,52 @@ RSpec.describe Ammitto::Cmd::HarmonizeCommand do
     end
   end
 
+  describe 'supplement directory resolution' do
+    it 'resolves cn supplements when cn is requested' do
+      instruments = make_dir('data-cn', 'sources', 'legal-instruments')
+      supporting = make_dir('data-cn', 'sources', 'supporting')
+      cn = described_class.new(options, ['cn'])
+
+      expect(cn.send(:find_instruments_dir)).to eq(instruments)
+      expect(cn.send(:find_supporting_dir)).to eq(supporting)
+    end
+
+    it 'does not leak cn supplements into other sources' do
+      make_dir('data-cn', 'sources', 'legal-instruments')
+      make_dir('data-cn', 'sources', 'supporting')
+
+      expect(command.send(:find_instruments_dir)).to be_nil
+      expect(command.send(:find_supporting_dir)).to be_nil
+    end
+
+    it 'resolves a requested source from its own data repository' do
+      instruments = make_dir('data-us', 'sources', 'legal-instruments')
+      make_dir('data-cn', 'sources', 'legal-instruments')
+
+      expect(command.send(:find_instruments_dir)).to eq(instruments)
+    end
+
+    it 'reaches cn supplements in a multi-source run without us ones' do
+      instruments = make_dir('data-cn', 'sources', 'legal-instruments')
+      multi = described_class.new(options, %w[us cn])
+
+      expect(multi.send(:find_instruments_dir)).to eq(instruments)
+    end
+
+    it 'falls back to siblings of an explicit input_dir' do
+      input_dir = make_dir('repo', 'sources', 'sanction-lists')
+      supporting = make_dir('repo', 'sources', 'supporting')
+      options[:input_dir] = input_dir
+
+      expect(command.send(:find_supporting_dir)).to eq(supporting)
+    end
+
+    it 'returns nil when no supplement directories exist' do
+      expect(command.send(:find_instruments_dir)).to be_nil
+      expect(command.send(:find_supporting_dir)).to be_nil
+    end
+  end
+
   describe '#harmonize_source' do
     it 'feeds deeply nested sanction-list files to transformation' do
       write_file('data-us', 'processed', '_index.yaml')

--- a/spec/ammitto/gemspec_spec.rb
+++ b/spec/ammitto/gemspec_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe 'ammitto.gemspec' do
+  subject(:gemspec) do
+    Gem::Specification.load(
+      File.expand_path('../../ammitto.gemspec', __dir__)
+    )
+  end
+
+  # data-ch and data-uk pin json-schema ~> 5.0; a gemspec pinned to ~> 4.0
+  # made `bundle lock` unresolvable there (exit 6), freezing both fetch
+  # pipelines. The constraint must admit both major versions 4 and 5.
+  it 'allows json-schema 4 and 5 but not 6' do
+    dep = gemspec.dependencies.find { |d| d.name == 'json-schema' }
+
+    expect(dep).not_to be_nil
+    expect(dep.requirement).to be_satisfied_by(Gem::Version.new('4.0.0'))
+    expect(dep.requirement).to be_satisfied_by(Gem::Version.new('5.2.0'))
+    expect(dep.requirement).not_to be_satisfied_by(Gem::Version.new('6.0.0'))
+  end
+end

--- a/spec/ammitto/ontology/types_spec.rb
+++ b/spec/ammitto/ontology/types_spec.rb
@@ -50,6 +50,48 @@ RSpec.describe Ammitto::Ontology::Types do
     it 'contains expected scripts' do
       expect(described_class::NAME_SCRIPTS).to include(:Latn, :Cyrl, :Arab, :Hani)
     end
+
+    it 'holds only ISO 15924 codes plus :other (no comment tokens)' do
+      described_class::NAME_SCRIPTS.each do |script|
+        expect(script.to_s).to match(/\A(?:[A-Z][a-z]{3}|other)\z/)
+      end
+    end
+
+    it 'uses the ISO 15924 code Grek, not the prose word Greek' do
+      expect(described_class::NAME_SCRIPTS).to include(:Grek)
+      expect(described_class::NAME_SCRIPTS).not_to include(:Greek)
+    end
+
+    it 'covers every script code the transformers and models emit' do
+      require 'ammitto/sources/au'
+
+      # Transformer literals plus the AU Script detector constants
+      transformer_literals = %i[Latn Cyrl Arab Hani Jpan]
+      script_module = Ammitto::Sources::Au::Script
+      emitted = script_module.constants
+                             .map { |c| script_module.const_get(c) }
+                             .grep(String)
+                             .map(&:to_sym) + transformer_literals
+
+      expect(described_class::NAME_SCRIPTS).to include(*emitted.uniq)
+    end
+  end
+
+  describe '.valid_script?' do
+    it 'rejects the comment token "#"' do
+      expect(described_class.valid_script?('#')).to be false
+    end
+
+    it 'rejects prose words from former inline comments' do
+      expect(described_class.valid_script?('Cyrillic')).to be false
+      expect(described_class.valid_script?('Greek')).to be false
+    end
+
+    it 'accepts Grek, Jpan, and Kore' do
+      expect(described_class.valid_script?('Grek')).to be true
+      expect(described_class.valid_script?(:Jpan)).to be true
+      expect(described_class.valid_script?('Kore')).to be true
+    end
   end
 
   describe '.valid_entity_type?' do
@@ -110,6 +152,13 @@ RSpec.describe Ammitto::Ontology::Types do
   describe '.detect_script' do
     it 'detects Cyrillic' do
       expect(described_class.detect_script('Иван Иванов')).to eq(:Cyrl)
+    end
+
+    it 'detects Greek as the ISO 15924 code Grek' do
+      script = described_class.detect_script('Αθήνα')
+
+      expect(script).to eq(:Grek)
+      expect(described_class.valid_script?(script)).to be true
     end
 
     it 'detects Arabic' do


### PR DESCRIPTION
`ammitto fetch` exited 0 while sources failed, so CI logged errors and reported success while the data repos went stale. Made **`FetchCommand`** raise **`Thor::Error`** naming every failed source, and removed `continue-on-error` from **`fetch-sources.yml`** — that flag was masking an invocation broken on every path, since the scheduled run passes no source (`No sources specified`, exit 1) and dispatch passes a comma list (`Invalid sources: eu,un`, exit 1). The step now reads its input from `env:`, normalizes separators and matches `all` case-insensitively, and `--all` resolves through a new **`FETCHABLE_SOURCES`** list since cn is manually managed. Also scoped harmonize's supplement lookup per requested source via **`DATA_REPO_TO_SOURCE`**, so cn document and organization nodes stop leaking into every source's tree, rewrote **`NAME_SCRIPTS`** where inline `%i[]` comments had left eleven `:"#"` members (Greek corrected to **`Grek`**, **`Jpan`** and **`Kore`** added), and relaxed **`json-schema`** to `>= 4, < 6` so data-ch and data-uk resolve again.

Verified by reproducing both broken invocations, `fetch cn` exiting 1, and the full suite under both json-schema majors plus RuboCop.
