### PR TITLE
Fix wrong list identity and gates passing garbage

### DIFF
--- a/lib/ammitto/cli.rb
+++ b/lib/ammitto/cli.rb
@@ -172,8 +172,8 @@ module Ammitto
     option :combine, type: :boolean, default: false, desc: 'Create combined all.jsonld'
     option :allow_empty, type: :string,
                          desc: 'Sources exempt from the health gates: zero entities, source errors, ' \
-                               'and missing aggregates will not fail the run (comma-separated). ' \
-                               'Per-file transform errors always fail.'
+                               'missing aggregates, and the quality floors will not fail the run ' \
+                               '(comma-separated). Per-file transform errors always fail.'
     def harmonize(*sources)
       require_relative 'cli/harmonize_command'
       Cmd::HarmonizeCommand.new(options, sources).run

--- a/lib/ammitto/cli/harmonize_command.rb
+++ b/lib/ammitto/cli/harmonize_command.rb
@@ -334,9 +334,9 @@ module Ammitto
           "#{result.dig(:quality, :entity_nodes)} served entities)"
       end
 
-      # Sources the caller exempts from the source-error, zero-entity, and
-      # missing-aggregate gates (--allow-empty). Per-file transform errors
-      # are never exempt.
+      # Sources the caller exempts from the source-error, zero-entity,
+      # missing-aggregate, and quality-floor gates (--allow-empty).
+      # Per-file transform errors are never exempt.
       # @return [Array<Symbol>] validated source codes
       def allowed_empty_sources
         @allowed_empty_sources ||= begin

--- a/lib/ammitto/cli/harmonize_command.rb
+++ b/lib/ammitto/cli/harmonize_command.rb
@@ -171,23 +171,32 @@ module Ammitto
 
         results.each do |r|
           attach_quality_metrics(r, output_dir) if r[:status] == :success
-          r[:gate_failures] = source_gate_failures(r, output_dir)
+          hard = unconditional_gate_failures(r)
+          soft = hard.empty? ? exemptable_gate_failures(r, output_dir) : []
+          exempt = allowed_empty_sources.include?(r[:code])
+
+          r[:gate_failures] = hard + (exempt ? [] : soft)
+          r[:exempted_failures] = exempt ? soft : []
         end
       end
 
-      # Gate failures for one per-source result
+      # Failures no exemption can clear: a file that exists but fails to
+      # parse or transform is a data defect regardless of --allow-empty
+      # @param result [Hash] per-source result
+      # @return [Array<String>] failure messages
+      def unconditional_gate_failures(result)
+        return [] unless result[:errors]&.any?
+
+        ["#{result[:code]}: #{result[:errors].length} file(s) failed to transform " \
+         "(first: #{result[:errors].first})"]
+      end
+
+      # Failures --allow-empty clears for the sources it names
       # @param result [Hash] per-source result
       # @param output_dir [String] output directory
       # @return [Array<String>] failure messages
-      def source_gate_failures(result, output_dir)
+      def exemptable_gate_failures(result, output_dir)
         code = result[:code]
-
-        # Per-file errors are checked first and are never exempt
-        if result[:errors]&.any?
-          return ["#{code}: #{result[:errors].length} file(s) failed to transform " \
-                  "(first: #{result[:errors].first})"]
-        end
-        return [] if allowed_empty_sources.include?(code)
 
         if result[:status] == :error
           ["#{code}: #{result[:error]}"]
@@ -1135,40 +1144,42 @@ module Ammitto
       end
 
       # Print summary of results using the gate classification, so the
-      # summary can never print "succeeded" for a source the health gates
-      # are about to fail (error, per-file failures, or quality floors).
-      # Entity/entry totals come from the exporter's deduplicated stats so
-      # the log agrees with the published stats.json numbers.
+      # counts and the exit code always agree: "failed" counts exactly the
+      # sources that make #enforce_health_gates raise, and a source whose
+      # only failures were cleared by --allow-empty is reported as
+      # exempted rather than as either a success or a failure (printing
+      # "failed" for a source on a run that exits 0 is the same dishonesty
+      # the gates exist to remove). Entity/entry totals come from the
+      # exporter's deduplicated stats so the log agrees with stats.json.
       # @param results [Array<Hash>] harmonize results
       # @return [void]
       def print_summary(results)
         evaluate_gates(results)
-        clean, troubled = results.partition do |r|
-          r[:status] == :success && (r[:gate_failures] || []).empty?
+        failed, rest = results.partition { |r| (r[:gate_failures] || []).any? }
+        exempted, clean = rest.partition do |r|
+          (r[:exempted_failures] || []).any?
         end
 
         puts
-        puts "Harmonize complete: #{clean.length} succeeded, #{troubled.length} failed"
+        puts "Harmonize complete: #{clean.length} succeeded, " \
+             "#{failed.length} failed, #{exempted.length} exempted"
         print_graph_totals
 
-        return if troubled.empty?
-
-        puts 'Failed sources:'
-        troubled.each do |r|
-          failure_lines(r).each { |line| puts "  #{line}" }
-        end
+        print_source_problems('Failed sources:', failed, :gate_failures)
+        print_source_problems('Exempted sources (--allow-empty):', exempted,
+                              :exempted_failures)
       end
 
-      # Failure lines for a troubled per-source result. Gate failures
-      # already carry the source code; an exempted (--allow-empty) errored
-      # source has none, so its error is reported directly.
-      # @param result [Hash] harmonize result
-      # @return [Array<String>]
-      def failure_lines(result)
-        failures = result[:gate_failures] || []
-        return failures if failures.any?
+      # Print one labelled block of per-source problem lines
+      # @param heading [String] block heading
+      # @param results [Array<Hash>] results to report
+      # @param key [Symbol] result key holding the lines
+      # @return [void]
+      def print_source_problems(heading, results, key)
+        return if results.empty?
 
-        ["#{result[:code]}: #{result[:error] || 'failed'}"]
+        puts heading
+        results.each { |r| r[key].each { |line| puts "  #{line}" } }
       end
 
       # Deduplicated entity/entry totals as exported (stats.json numbers)

--- a/lib/ammitto/cli/harmonize_command.rb
+++ b/lib/ammitto/cli/harmonize_command.rb
@@ -27,6 +27,16 @@ module Ammitto
       # @return [JsonLdGraphExporter] the graph exporter
       attr_reader :exporter
 
+      # Quality floors: emptiness gates alone let one garbage entity pass
+      # (the us incident: a single nameless entity, exit 0, served as the
+      # entire dataset). Two per-source floors close that hole. Thresholds
+      # are operator policy: the unique-id floor catches catastrophic id
+      # collapse (jp: 86 files, 1 id) while tolerating moderate duplicate
+      # pairs that dedup handles; the named floor requires the served
+      # entities to be overwhelmingly identifiable.
+      MIN_UNIQUE_ID_RATIO = 0.5
+      MIN_NAMED_ENTITY_RATIO = 0.9
+
       # Initialize with options and sources
       # @param options [Hash] command options
       # @param sources [Array<String>] source codes
@@ -121,39 +131,207 @@ module Ammitto
       # Health gates: a run that produced no data or swallowed errors must
       # exit nonzero so cron/CI cannot publish empty artifacts as success.
       # Strict by default; the caller opts individual sources out of the
-      # source-error, zero-entity, and missing-aggregate checks with
-      # --allow-empty (the raise-or-silence policy belongs to the invoking
-      # workflow, not to a hardcoded list). Per-file transform errors are
-      # never exempt: a file that exists but fails to transform is a data
-      # defect regardless of the source's status.
+      # source-error, zero-entity, missing-aggregate, and quality-floor
+      # checks with --allow-empty (the raise-or-silence policy belongs to
+      # the invoking workflow, not to a hardcoded list). Per-file transform
+      # errors are never exempt: a file that exists but fails to transform
+      # is a data defect regardless of the source's status.
+      #
+      # Quality floors (per source, computed after the emptiness gates,
+      # attached to the per-source result as result[:quality]):
+      # - unique_id_ratio: deduplicated entity count (the stats.json
+      #   number) over ingested entity count; denominator is the count of
+      #   entity/entry pairs the source's files produced (multi-entity
+      #   files contribute one per pair). Floor: MIN_UNIQUE_ID_RATIO.
+      # - named_entity_ratio: entity nodes in the served per-source
+      #   aggregate carrying at least one non-empty name over all its
+      #   entity nodes. Floor: MIN_NAMED_ENTITY_RATIO.
       # @param results [Array<Hash>] per-source results
       # @return [void]
       def enforce_health_gates(results)
-        allowed_empty = allowed_empty_sources
-        failures = []
-
-        output_dir = options[:output_dir] || './api/v1'
-
-        results.each do |r|
-          code = r[:code]
-          # Per-file errors are checked first and are never exempt
-          if r[:errors]&.any?
-            failures << "#{code}: #{r[:errors].length} file(s) failed to transform " \
-                        "(first: #{r[:errors].first})"
-          elsif r[:status] == :error
-            failures << "#{code}: #{r[:error]}" unless allowed_empty.include?(code)
-          elsif r[:entities].to_i.zero? && !allowed_empty.include?(code)
-            failures << "#{code}: produced 0 entities"
-          elsif !allowed_empty.include?(code) &&
-                !File.exist?(File.join(output_dir, 'sources', "#{code}.jsonld"))
-            failures << "#{code}: per-source aggregate sources/#{code}.jsonld was not written"
-          end
-        end
-
+        evaluate_gates(results)
+        failures = results.flat_map { |r| r[:gate_failures] || [] }
         return if failures.empty?
 
         raise Thor::Error,
               "Harmonize health gate failed:\n  #{failures.join("\n  ")}"
+      end
+
+      # Evaluate the gates once per results set: attach quality metrics
+      # and per-source gate failures to each result, so the printed
+      # summary and the gate raise report the same classification (the
+      # summary and the gates receive the same results array in a run)
+      # @param results [Array<Hash>] per-source results (mutated)
+      # @return [void]
+      def evaluate_gates(results)
+        return if @gates_evaluated_results.equal?(results)
+
+        @gates_evaluated_results = results
+        output_dir = options[:output_dir] || './api/v1'
+
+        results.each do |r|
+          attach_quality_metrics(r, output_dir) if r[:status] == :success
+          r[:gate_failures] = source_gate_failures(r, output_dir)
+        end
+      end
+
+      # Gate failures for one per-source result
+      # @param result [Hash] per-source result
+      # @param output_dir [String] output directory
+      # @return [Array<String>] failure messages
+      def source_gate_failures(result, output_dir)
+        code = result[:code]
+
+        # Per-file errors are checked first and are never exempt
+        if result[:errors]&.any?
+          return ["#{code}: #{result[:errors].length} file(s) failed to transform " \
+                  "(first: #{result[:errors].first})"]
+        end
+        return [] if allowed_empty_sources.include?(code)
+
+        if result[:status] == :error
+          ["#{code}: #{result[:error]}"]
+        elsif result[:entities].to_i.zero?
+          ["#{code}: produced 0 entities"]
+        elsif !File.exist?(File.join(output_dir, 'sources', "#{code}.jsonld"))
+          ["#{code}: per-source aggregate sources/#{code}.jsonld was not written"]
+        else
+          quality_floor_failures(result)
+        end
+      end
+
+      # Compute quality metrics for a successful per-source result and
+      # attach them to the result hash (part of the per-source result
+      # contract; see #enforce_health_gates for definitions)
+      # @param result [Hash] per-source result (mutated)
+      # @param output_dir [String] output directory
+      # @return [void]
+      def attach_quality_metrics(result, output_dir)
+        metrics = {}
+        ingested = result[:entities].to_i
+        unique = @exporter&.stats&.dig(:sources, result[:code].to_s, :entities)
+
+        if unique && ingested.positive?
+          metrics[:unique_entities] = unique
+          metrics[:unique_id_ratio] = unique.to_f / ingested
+        end
+
+        metrics.merge!(aggregate_name_metrics(result[:code], output_dir))
+        result[:quality] = metrics
+      end
+
+      # Name metrics read from the served per-source aggregate. Every
+      # unusable document shape — unparseable JSON, a non-object root, a
+      # non-array @graph, or a graph without a single entity node — is
+      # reported as invalid so the gate fails closed instead of skipping
+      # the floors.
+      # @param code [Symbol] source code
+      # @param output_dir [String] output directory
+      # @return [Hash] name metrics (empty when the file is absent)
+      def aggregate_name_metrics(code, output_dir)
+        path = File.join(output_dir, 'sources', "#{code}.jsonld")
+        return {} unless File.exist?(path)
+
+        nodes = parse_aggregate_graph(path)
+        entity_nodes = nodes&.select do |n|
+          n.is_a?(Hash) && n['@id'].to_s.include?('/entity/')
+        end
+        return { aggregate_invalid: true } if entity_nodes.nil? ||
+                                              entity_nodes.empty?
+
+        named = entity_nodes.count { |n| named_entity_node?(n) }
+        {
+          entity_nodes: entity_nodes.length,
+          named_entities: named,
+          named_entity_ratio: named.to_f / entity_nodes.length
+        }
+      end
+
+      # @param path [String] aggregate file path
+      # @return [Array, nil] graph nodes, or nil for an unusable document
+      def parse_aggregate_graph(path)
+        document = JSON.parse(File.read(path))
+        return nil unless document.is_a?(Hash)
+
+        nodes = document['@graph']
+        nodes.is_a?(Array) ? nodes : nil
+      rescue JSON::ParserError
+        nil
+      end
+
+      # Whether an entity node carries at least one usable name string
+      # @param node [Hash] entity node from the aggregate
+      # @return [Boolean]
+      def named_entity_node?(node)
+        names = node['names']
+        named = names.is_a?(Array) &&
+                names.any? { |n| name_variant_present?(n) }
+
+        named || usable_name_string?(node['name'])
+      end
+
+      # Whether one name variant holds a usable name string
+      # @param variant [Hash, String, Object] name variant
+      # @return [Boolean]
+      def name_variant_present?(variant)
+        return usable_name_string?(variant) if variant.is_a?(String)
+        return false unless variant.is_a?(Hash)
+
+        %w[fullName firstName middleName lastName
+           full_name first_name middle_name last_name].any? do |key|
+          usable_name_string?(variant[key])
+        end
+      end
+
+      # Only non-blank Strings count as names — 0, {}, or [] in a name
+      # field must not make a malformed aggregate look fully named
+      # @param value [Object] candidate name value
+      # @return [Boolean]
+      def usable_name_string?(value)
+        value.is_a?(String) && !value.match?(/\A[[:space:]]*\z/)
+      end
+
+      # Quality-floor gate failures for one per-source result
+      # @param result [Hash] per-source result carrying :quality metrics
+      # @return [Array<String>] failure messages
+      def quality_floor_failures(result)
+        [invalid_aggregate_failure(result),
+         unique_id_floor_failure(result),
+         named_floor_failure(result)].compact
+      end
+
+      # @param result [Hash] per-source result
+      # @return [String, nil] failure message
+      def invalid_aggregate_failure(result)
+        return nil unless result.dig(:quality, :aggregate_invalid)
+
+        code = result[:code]
+        "#{code}: per-source aggregate sources/#{code}.jsonld " \
+          'is not a usable JSON-LD aggregate'
+      end
+
+      # @param result [Hash] per-source result
+      # @return [String, nil] failure message
+      def unique_id_floor_failure(result)
+        ratio = result.dig(:quality, :unique_id_ratio)
+        return nil unless ratio && ratio < MIN_UNIQUE_ID_RATIO
+
+        "#{result[:code]}: unique-id ratio #{format('%.2f', ratio)} " \
+          "below floor #{format('%.2f', MIN_UNIQUE_ID_RATIO)} " \
+          "(#{result.dig(:quality, :unique_entities)} unique of " \
+          "#{result[:entities].to_i} ingested entities)"
+      end
+
+      # @param result [Hash] per-source result
+      # @return [String, nil] failure message
+      def named_floor_failure(result)
+        ratio = result.dig(:quality, :named_entity_ratio)
+        return nil unless ratio && ratio < MIN_NAMED_ENTITY_RATIO
+
+        "#{result[:code]}: named-entity ratio #{format('%.2f', ratio)} " \
+          "below floor #{format('%.2f', MIN_NAMED_ENTITY_RATIO)} " \
+          "(#{result.dig(:quality, :named_entities)} named of " \
+          "#{result.dig(:quality, :entity_nodes)} served entities)"
       end
 
       # Sources the caller exempts from the source-error, zero-entity, and
@@ -956,22 +1134,51 @@ module Ammitto
         options[:cache_dir] || File.expand_path('~/.ammitto')
       end
 
-      # Print summary of results
+      # Print summary of results using the gate classification, so the
+      # summary can never print "succeeded" for a source the health gates
+      # are about to fail (error, per-file failures, or quality floors).
+      # Entity/entry totals come from the exporter's deduplicated stats so
+      # the log agrees with the published stats.json numbers.
       # @param results [Array<Hash>] harmonize results
       # @return [void]
       def print_summary(results)
-        success = results.count { |r| r[:status] == :success }
-        failed = results.count { |r| r[:status] == :error }
+        evaluate_gates(results)
+        clean, troubled = results.partition do |r|
+          r[:status] == :success && (r[:gate_failures] || []).empty?
+        end
 
         puts
-        puts "Harmonize complete: #{success} succeeded, #{failed} failed"
+        puts "Harmonize complete: #{clean.length} succeeded, #{troubled.length} failed"
+        print_graph_totals
 
-        return unless failed.positive?
+        return if troubled.empty?
 
         puts 'Failed sources:'
-        results.select { |r| r[:status] == :error }.each do |r|
-          puts "  #{r[:code]}: #{r[:error]}"
+        troubled.each do |r|
+          failure_lines(r).each { |line| puts "  #{line}" }
         end
+      end
+
+      # Failure lines for a troubled per-source result. Gate failures
+      # already carry the source code; an exempted (--allow-empty) errored
+      # source has none, so its error is reported directly.
+      # @param result [Hash] harmonize result
+      # @return [Array<String>]
+      def failure_lines(result)
+        failures = result[:gate_failures] || []
+        return failures if failures.any?
+
+        ["#{result[:code]}: #{result[:error] || 'failed'}"]
+      end
+
+      # Deduplicated entity/entry totals as exported (stats.json numbers)
+      # @return [void]
+      def print_graph_totals
+        stats = @exporter&.stats
+        return unless stats
+
+        puts "Graph totals: #{stats[:total_entities]} entities, " \
+             "#{stats[:total_entries]} entries (deduplicated)"
       end
     end
   end

--- a/lib/ammitto/cli/harmonize_command.rb
+++ b/lib/ammitto/cli/harmonize_command.rb
@@ -401,20 +401,22 @@ module Ammitto
         errors = []
         source_graph = []
 
+        # The YAML parse belongs inside the per-file rescue: a file that
+        # exists but will not parse is a per-file data defect (never
+        # exempt), not a source-level error --allow-empty can clear, and
+        # one unparseable file must not discard the other files' entities
         yaml_files.each do |file|
           data = YAML.safe_load_file(file, permitted_classes: [Date, Time], aliases: true)
           next unless data
 
-          begin
-            result = transform_data(source, data)
-            added = ingest_results(result, source, source_graph, errors, File.basename(file))
-            entities_count += added
-            entries_count += added
-          rescue StandardError => e
-            error_msg = "#{File.basename(file)}: #{e.message}"
-            puts "[#{source}] Error processing #{error_msg}" if options[:verbose]
-            errors << error_msg
-          end
+          result = transform_data(source, data)
+          added = ingest_results(result, source, source_graph, errors, File.basename(file))
+          entities_count += added
+          entries_count += added
+        rescue StandardError => e
+          error_msg = "#{File.basename(file)}: #{e.message}"
+          puts "[#{source}] Error processing #{error_msg}" if options[:verbose]
+          errors << error_msg
         end
 
         # Per-source aggregate: required by BaseSource downloads and

--- a/lib/ammitto/serialization/search_index_exporter.rb
+++ b/lib/ammitto/serialization/search_index_exporter.rb
@@ -3,6 +3,7 @@
 require 'fileutils'
 require 'json'
 require 'time'
+require_relative '../utils/presence'
 
 module Ammitto
   module Serialization
@@ -11,6 +12,16 @@ module Ammitto
     # The website currently loads 69MB of JSON-LD data. This exporter creates
     # a lightweight (~5-10MB) search-index.json with only essential fields,
     # allowing full entity data to be loaded on-demand from node files.
+    #
+    # Rows are deduplicated by entity @id: one search row per entity,
+    # however many entity/entry pairs the input carries. Repeated ids
+    # aggregate into the existing row — names are unioned, missing or
+    # blank fields are filled, and present scalar fields keep their
+    # first-seen value. The type/status defaults (person/active) apply
+    # after aggregation, so a later pair carrying the real value can
+    # still fill it. Facets are recomputed from the deduplicated rows,
+    # so facet counts, search rows, and the deduplicated stats.json
+    # numbers agree.
     #
     # @example Using the search index exporter
     #   exporter = SearchIndexExporter.new
@@ -22,12 +33,6 @@ module Ammitto
     #   exporter.export('./api/v1')
     #
     class SearchIndexExporter
-      # @return [Array<Hash>] entities for search index
-      attr_reader :entities
-
-      # @return [Hash] facet counts
-      attr_reader :facets
-
       # Authority names for facet display
       AUTHORITY_NAMES = {
         'un' => 'United Nations',
@@ -57,18 +62,24 @@ module Ammitto
 
       # Initialize the search index exporter
       def initialize
-        @entities = []
-        @facets = {
-          authorities: Hash.new(0),
-          list_types: Hash.new(0),
-          regimes: {},
-          types: Hash.new(0),
-          countries: Hash.new(0),
-          statuses: Hash.new(0)
-        }
+        @rows_by_id = {}
+        @regime_names = {}
       end
 
-      # Add entity to search index
+      # Deduplicated search rows (one per entity @id), with post-merge
+      # defaults applied
+      # @return [Array<Hash>] entities for search index
+      def entities
+        @rows_by_id.values.map { |row| finalize_row(row) }
+      end
+
+      # Facet counts recomputed from the deduplicated rows
+      # @return [Hash] facet counts
+      def facets
+        build_facets
+      end
+
+      # Add entity to search index, aggregating repeated entity ids
       # @param entity [Hash] full entity data
       # @param entry [Hash] sanction entry data
       # @return [void]
@@ -77,36 +88,17 @@ module Ammitto
         entity_id = entity['@id'] || entity['id']
         return unless entity_id
 
-        # Extract authority code from entry
-        authority_code = extract_authority_code(entry)
-        regime_code = extract_regime_code(entry)
-        list_type = extract_list_type(entry)
+        regime_code = string_presence(extract_regime_code(entry))
+        remember_regime_name(regime_code, entry)
 
-        # Extract names
-        names = extract_names(entity)
-        primary_name = extract_primary_name(entity)
+        search_entity = build_row(entity_id, entity, entry, regime_code)
 
-        # Support both camelCase and snake_case entity type
-        entity_type = entity['entityType'] || entity['entity_type'] || 'person'
-
-        # Create search entity (lightweight)
-        search_entity = {
-          id: entity_id,
-          ref: extract_ref(entity_id),
-          type: entity_type,
-          names: names,
-          primaryName: primary_name,
-          country: extract_country(entity),
-          regime: regime_code,
-          authority: authority_code,
-          listType: list_type,
-          status: entry['status'] || 'active',
-          birthYear: extract_birth_year(entity),
-          imo: extract_imo(entity)
-        }.compact
-
-        @entities << search_entity
-        update_facets(search_entity, regime_code, entry)
+        existing = @rows_by_id[entity_id]
+        if existing
+          merge_row(existing, search_entity)
+        else
+          @rows_by_id[entity_id] = search_entity
+        end
       end
 
       # Export search index and facets to output directory
@@ -118,6 +110,130 @@ module Ammitto
       end
 
       private
+
+      # Build one lightweight search row
+      # @param entity_id [String] entity id
+      # @param entity [Hash] full entity data
+      # @param entry [Hash] sanction entry data
+      # @param regime_code [String, nil] regime code
+      # @return [Hash] search row
+      def build_row(entity_id, entity, entry, regime_code)
+        {
+          id: entity_id,
+          ref: extract_ref(entity_id),
+          # Support both camelCase and snake_case entity type; defaults
+          # apply post-merge (#finalize_row), not here, so a later
+          # duplicate pair carrying the real value can still fill it
+          type: string_presence(entity['entityType'] || entity['entity_type']),
+          names: extract_names(entity),
+          primaryName: string_presence(extract_primary_name(entity)),
+          country: string_presence(extract_country(entity)),
+          regime: regime_code,
+          authority: string_presence(extract_authority_code(entry)),
+          listType: string_presence(extract_list_type(entry)),
+          status: string_presence(entry['status']),
+          birthYear: string_presence(extract_birth_year(entity)),
+          imo: scalar_presence(extract_imo(entity))
+        }.compact
+      end
+
+      # Only non-blank Strings become row scalars: blanks must not block
+      # a later real value, and wrong-typed source values (numbers,
+      # hashes) must never reach the facet builders' String calls
+      # @param value [Object] candidate value
+      # @return [String, nil]
+      def string_presence(value)
+        return nil unless value.is_a?(String)
+
+        Utils::Presence.present?(value) ? value : nil
+      end
+
+      # IMO numbers legitimately arrive numeric in some sources; coerce
+      # Numerics, otherwise apply the String rule
+      # @param value [Object] candidate value
+      # @return [String, nil]
+      def scalar_presence(value)
+        return value.to_s if value.is_a?(Numeric)
+
+        string_presence(value)
+      end
+
+      # Post-aggregation defaults for the exported row shape
+      # @param row [Hash] stored search row
+      # @return [Hash] finalized copy
+      def finalize_row(row)
+        finalized = row.dup
+        finalized[:type] ||= 'person'
+        finalized[:status] ||= 'active'
+        finalized
+      end
+
+      # Aggregate a repeated entity id into its existing row: union the
+      # names, fill fields the row lacks, keep first-seen values otherwise
+      # @param existing [Hash] stored search row
+      # @param incoming [Hash] newly built row for the same entity id
+      # @return [void]
+      def merge_row(existing, incoming)
+        merged_names = (existing[:names] || []) | (incoming[:names] || [])
+        existing[:names] = merged_names unless merged_names.empty?
+
+        incoming.each do |key, value|
+          existing[key] = value unless existing.key?(key)
+        end
+      end
+
+      # Record a regime display name for facet output (String-typed, so
+      # a wrong-typed source name can never leak into facets)
+      # @param regime_code [String, nil] regime code
+      # @param entry [Hash] entry data
+      # @return [void]
+      def remember_regime_name(regime_code, entry)
+        return unless regime_code
+
+        name = entry['regime']['name'] if entry['regime'].is_a?(Hash)
+        @regime_names[regime_code] ||= string_presence(name)
+      end
+
+      # Recompute facet counts from the deduplicated, finalized rows
+      # @return [Hash] facet counts
+      def build_facets
+        facets = empty_facets
+
+        entities.each do |row|
+          facets[:authorities][row[:authority]] += 1 if row[:authority]
+          facets[:list_types][row[:listType]] += 1 if row[:listType]
+          count_regime_facet(facets, row[:regime])
+          facets[:types][row[:type]] += 1 if row[:type]
+          facets[:countries][row[:country].upcase] += 1 if row[:country]
+          facets[:statuses][row[:status]] += 1 if row[:status]
+        end
+
+        facets
+      end
+
+      # @return [Hash] empty facet structure
+      def empty_facets
+        {
+          authorities: Hash.new(0),
+          list_types: Hash.new(0),
+          regimes: {},
+          types: Hash.new(0),
+          countries: Hash.new(0),
+          statuses: Hash.new(0)
+        }
+      end
+
+      # Count one row's regime into the facets
+      # @param facets [Hash] facet accumulator
+      # @param regime_code [String, nil] regime code
+      # @return [void]
+      def count_regime_facet(facets, regime_code)
+        return unless regime_code
+
+        regime = facets[:regimes][regime_code] ||=
+          { count: 0, name: @regime_names[regime_code] }
+        regime[:count] += 1
+      end
 
       # Extract reference path from entity ID
       # @param entity_id [String] full entity ID or simple ID
@@ -386,61 +502,24 @@ module Ammitto
         entity['imo'] || entity['imoNumber'] || entity['imo_number']
       end
 
-      # Update facet counts
-      # @param search_entity [Hash] search entity data
-      # @param regime_code [String, nil] regime code
-      # @param entry [Hash] entry data
-      def update_facets(search_entity, regime_code, entry)
-        # Authority
-        @facets[:authorities][search_entity[:authority]] += 1 if search_entity[:authority]
-
-        # List type
-        @facets[:list_types][search_entity[:listType]] += 1 if search_entity[:listType]
-
-        # Regime
-        if regime_code
-          @facets[:regimes][regime_code] ||= { count: 0, name: extract_regime_name(entry) }
-          @facets[:regimes][regime_code][:count] += 1
-        end
-
-        # Type
-        @facets[:types][search_entity[:type]] += 1 if search_entity[:type]
-
-        # Country
-        @facets[:countries][search_entity[:country].upcase] += 1 if search_entity[:country]
-
-        # Status
-        return unless search_entity[:status]
-
-        @facets[:statuses][search_entity[:status]] += 1
-      end
-
-      # Extract regime name from entry
-      # @param entry [Hash] entry data
-      # @return [String, nil] regime name
-      def extract_regime_name(entry)
-        return nil unless entry && entry['regime'].is_a?(Hash)
-
-        entry['regime']['name']
-      end
-
       # Export search index to file
       # @param output_dir [String] output directory
       def export_search_index(output_dir)
+        rows = entities
         data = {
           metadata: {
             generated: Time.now.utc.iso8601,
-            totalEntities: @entities.length,
-            sources: @facets[:authorities].keys.length
+            totalEntities: rows.length,
+            sources: rows.map { |r| r[:authority] }.compact.uniq.length
           },
-          entities: @entities
+          entities: rows
         }
 
         output_path = File.join(output_dir, 'search-index.json')
         FileUtils.mkdir_p(File.dirname(output_path))
         File.write(output_path, JSON.generate(data))
 
-        puts "Exported search index: #{@entities.length} entities to #{output_path}"
+        puts "Exported search index: #{rows.length} entities to #{output_path}"
       end
 
       # Export facet files
@@ -449,29 +528,21 @@ module Ammitto
         facets_dir = File.join(output_dir, 'facets')
         FileUtils.mkdir_p(facets_dir)
 
-        # Authorities
-        export_authority_facets(facets_dir)
+        counts = build_facets
 
-        # List types
-        export_list_type_facets(facets_dir)
-
-        # Regimes
-        export_regime_facets(facets_dir)
-
-        # Types
-        export_type_facets(facets_dir)
-
-        # Countries
-        export_country_facets(facets_dir)
-
-        # Statuses
-        export_status_facets(facets_dir)
+        export_authority_facets(facets_dir, counts)
+        export_list_type_facets(facets_dir, counts)
+        export_regime_facets(facets_dir, counts)
+        export_type_facets(facets_dir, counts)
+        export_country_facets(facets_dir, counts)
+        export_status_facets(facets_dir, counts)
       end
 
       # Export authority facets
       # @param dir [String] facets directory
-      def export_authority_facets(dir)
-        facets_data = @facets[:authorities].map do |code, count|
+      # @param counts [Hash] facet counts
+      def export_authority_facets(dir, counts)
+        facets_data = counts[:authorities].map do |code, count|
           {
             code: code,
             name: AUTHORITY_NAMES[code] || code.upcase,
@@ -484,8 +555,9 @@ module Ammitto
 
       # Export list type facets
       # @param dir [String] facets directory
-      def export_list_type_facets(dir)
-        facets_data = @facets[:list_types].map do |code, count|
+      # @param counts [Hash] facet counts
+      def export_list_type_facets(dir, counts)
+        facets_data = counts[:list_types].map do |code, count|
           {
             code: code,
             name: format_list_type_name(code),
@@ -509,8 +581,9 @@ module Ammitto
 
       # Export regime facets
       # @param dir [String] facets directory
-      def export_regime_facets(dir)
-        facets_data = @facets[:regimes].map do |code, data|
+      # @param counts [Hash] facet counts
+      def export_regime_facets(dir, counts)
+        facets_data = counts[:regimes].map do |code, data|
           {
             code: code,
             name: data[:name] || code.upcase,
@@ -523,8 +596,9 @@ module Ammitto
 
       # Export type facets
       # @param dir [String] facets directory
-      def export_type_facets(dir)
-        facets_data = @facets[:types].map do |code, count|
+      # @param counts [Hash] facet counts
+      def export_type_facets(dir, counts)
+        facets_data = counts[:types].map do |code, count|
           type_info = ENTITY_TYPES[code] || { name: code.capitalize, icon: 'circle' }
           {
             code: code,
@@ -539,8 +613,9 @@ module Ammitto
 
       # Export country facets
       # @param dir [String] facets directory
-      def export_country_facets(dir)
-        facets_data = @facets[:countries].map do |code, count|
+      # @param counts [Hash] facet counts
+      def export_country_facets(dir, counts)
+        facets_data = counts[:countries].map do |code, count|
           {
             code: code,
             count: count
@@ -552,8 +627,9 @@ module Ammitto
 
       # Export status facets
       # @param dir [String] facets directory
-      def export_status_facets(dir)
-        facets_data = @facets[:statuses].map do |code, count|
+      # @param counts [Hash] facet counts
+      def export_status_facets(dir, counts)
+        facets_data = counts[:statuses].map do |code, count|
           {
             code: code,
             name: code.capitalize,

--- a/lib/ammitto/serialization/search_index_exporter.rb
+++ b/lib/ammitto/serialization/search_index_exporter.rb
@@ -84,8 +84,13 @@ module Ammitto
       # @param entry [Hash] sanction entry data
       # @return [void]
       def add(entity, entry)
-        # Support both '@id' (JSON-LD) and 'id' (model hash) formats
-        entity_id = entity['@id'] || entity['id']
+        # Support both '@id' (JSON-LD) and 'id' (model hash) formats.
+        # The id is the dedup key, so it takes the same String rule as
+        # the row scalars: a blank '@id' is truthy in Ruby, and would
+        # both mask a usable 'id' and collapse every blank-id entity
+        # into one shared row
+        entity_id = string_presence(entity['@id']) ||
+                    string_presence(entity['id'])
         return unless entity_id
 
         regime_code = string_presence(extract_regime_code(entry))
@@ -125,7 +130,7 @@ module Ammitto
           # apply post-merge (#finalize_row), not here, so a later
           # duplicate pair carrying the real value can still fill it
           type: string_presence(entity['entityType'] || entity['entity_type']),
-          names: extract_names(entity),
+          names: string_list(extract_names(entity)),
           primaryName: string_presence(extract_primary_name(entity)),
           country: string_presence(extract_country(entity)),
           regime: regime_code,
@@ -146,6 +151,15 @@ module Ammitto
         return nil unless value.is_a?(String)
 
         Utils::Presence.present?(value) ? value : nil
+      end
+
+      # Names obey the same String rule as the row scalars: the
+      # extractors guard on truthiness, so blanks and wrong-typed source
+      # values (numbers, hashes) would otherwise reach search-index.json
+      # @param values [Array<Object>] candidate names
+      # @return [Array<String>] non-blank String names
+      def string_list(values)
+        Array(values).filter_map { |value| string_presence(value) }
       end
 
       # IMO numbers legitimately arrive numeric in some sources; coerce
@@ -261,14 +275,18 @@ module Ammitto
         # Direct string value
         return authority.downcase if authority.is_a?(String)
 
-        # Check for @id reference
+        # Check for @id reference. Both lookups take the String rule:
+        # the extractor calls #match/#downcase, so a wrong-typed source
+        # value would raise NoMethodError mid-harmonize instead of
+        # dropping out of the row
         if authority.is_a?(Hash)
-          if authority['@id']
+          id = string_presence(authority['@id'])
+          if id
             # Extract from "https://www.ammitto.org/authority/un"
-            match = authority['@id'].match(%r{/authority/([^/]+)$})
+            match = id.match(%r{/authority/([^/]+)$})
             return match[1] if match
           end
-          return authority['countryCode']&.downcase
+          return string_presence(authority['countryCode'])&.downcase
         end
 
         nil
@@ -280,14 +298,16 @@ module Ammitto
       def extract_regime_code(entry)
         return nil unless entry
 
-        # Check for @id reference
+        # Check for @id reference (same String rule as the authority
+        # extractor: #match and #downcase must never see a non-String)
         if entry['regime'].is_a?(Hash)
-          if entry['regime']['@id']
+          id = string_presence(entry['regime']['@id'])
+          if id
             # Extract from "https://www.ammitto.org/regime/dprk"
-            match = entry['regime']['@id'].match(%r{/regime/([^/]+)$})
+            match = id.match(%r{/regime/([^/]+)$})
             return match[1] if match
           end
-          return entry['regime']['code']&.downcase
+          return string_presence(entry['regime']['code'])&.downcase
         end
 
         nil
@@ -299,12 +319,16 @@ module Ammitto
       def extract_list_type(entry)
         return nil unless entry
 
-        # Check for list_type field (normalized structure)
-        return entry['list_type'] if entry['list_type']
-        return entry['listType'] if entry['listType']
+        # Check for list_type field (normalized structure). A blank or
+        # wrong-typed field must not mask the IRI fallback below, which
+        # may still carry the real list identity
+        list_type = string_presence(entry['list_type']) ||
+                    string_presence(entry['listType'])
+        return list_type if list_type
 
-        # Try to extract from entry @id
-        entry_id = entry['@id'] || entry['id']
+        # Try to extract from entry @id (String rule: #match below)
+        entry_id = string_presence(entry['@id']) ||
+                   string_presence(entry['id'])
         return nil unless entry_id
 
         # Pattern: BASE_URI/entry/{source}/{list_type}/{local_id}
@@ -480,26 +504,37 @@ module Ammitto
         entity_type = entity['entityType'] || entity['entity_type']
         return nil unless entity_type == 'vessel'
 
-        # From identifiers
-        if entity['identifiers'].is_a?(Array)
-          imo = entity['identifiers'].find do |id|
-            id.is_a?(Hash) && (id['type']&.downcase == 'imo' || id['document_type']&.downcase == 'imo')
-          end
-          return imo['value'] if imo && imo['value']
-          return imo['identification'] if imo && imo['identification']
-        end
-
-        # From identifications (snake_case)
-        if entity['identifications'].is_a?(Array)
-          imo = entity['identifications'].find do |id|
-            id.is_a?(Hash) && (id['type']&.downcase == 'imo' || id['document_type']&.downcase == 'imo')
-          end
-          return imo['value'] if imo && imo['value']
-          return imo['identification'] if imo && imo['identification']
+        # From identifiers, then identifications (snake_case)
+        %w[identifiers identifications].each do |key|
+          value = imo_from_identifiers(entity[key])
+          return value if value
         end
 
         # From imo field
         entity['imo'] || entity['imoNumber'] || entity['imo_number']
+      end
+
+      # Find the IMO value in one identifier collection
+      # @param identifiers [Object] candidate identifier collection
+      # @return [Object, nil] raw IMO value (coerced by #scalar_presence)
+      def imo_from_identifiers(identifiers)
+        return nil unless identifiers.is_a?(Array)
+
+        imo = identifiers.find { |id| id.is_a?(Hash) && imo_identifier?(id) }
+        return nil unless imo
+
+        imo['value'] || imo['identification']
+      end
+
+      # Whether an identifier is an IMO number. The type discriminator
+      # takes the String rule: #downcase on a wrong-typed source value
+      # would raise NoMethodError instead of skipping the identifier
+      # @param identifier [Hash] identifier hash
+      # @return [Boolean]
+      def imo_identifier?(identifier)
+        %w[type document_type].any? do |key|
+          string_presence(identifier[key])&.downcase == 'imo'
+        end
       end
 
       # Export search index to file

--- a/lib/ammitto/sources/cn/announcement.rb
+++ b/lib/ammitto/sources/cn/announcement.rb
@@ -115,19 +115,25 @@ module Ammitto
           type == 'organization'
         end
 
-        # Get list type code
+        # Mapping of sanction_list values to list type codes. The data-cn
+        # YAML stores source-prefixed slugs (e.g. "cn/anti-sanction-list")
+        # while the schema enum documents the Chinese labels; both forms
+        # must resolve to the same code so entries keep their list identity.
+        LIST_TYPE_CODES = {
+          '反制裁清单' => 'anti_sanctions',
+          'anti-sanction-list' => 'anti_sanctions',
+          '不可靠实体清单' => 'unreliable_entity',
+          'unreliable-entity-list' => 'unreliable_entity',
+          '出口管制管控名单' => 'export_control',
+          'import-export-control-list' => 'export_control'
+        }.freeze
+
+        # Get list type code, accepting Chinese labels and data slugs
+        # (with or without the "cn/" prefix)
         # @return [String]
         def list_type_code
-          case sanction_list
-          when '反制裁清单'
-            'anti_sanctions'
-          when '不可靠实体清单'
-            'unreliable_entity'
-          when '出口管制管控名单'
-            'export_control'
-          else
-            'unknown'
-          end
+          key = sanction_list.to_s.strip.delete_prefix('cn/')
+          LIST_TYPE_CODES.fetch(key, 'unknown')
         end
       end
 

--- a/lib/ammitto/utils/list_types_registry.rb
+++ b/lib/ammitto/utils/list_types_registry.rb
@@ -153,12 +153,14 @@ module Ammitto
         }
       }.freeze
 
-      # Mapping of source codes to their list types
+      # Mapping of source codes to their list types.
+      # Keys use the gem's underscored source codes
+      # (Config::Defaults::ALL_SOURCES): eu_vessels, un_vessels.
       SOURCE_LIST_TYPES = {
         'cn' => CN,
         'ru' => RU,
         'eu' => EU,
-        'eu-vessels' => EU_VESSELS,
+        'eu_vessels' => EU_VESSELS,
         'uk' => UK,
         'us' => US,
         'au' => AU,
@@ -168,18 +170,20 @@ module Ammitto
         'nz' => NZ,
         'tr' => TR,
         'un' => UN,
-        'un-vessels' => UN_VESSELS,
+        'un_vessels' => UN_VESSELS,
         'wb' => WB
       }.freeze
 
       class << self
-        # Get list types for a source.
+        # Get list types for a source. Hyphenated aliases (legacy
+        # repo-derived codes like "eu-vessels") normalize to the
+        # underscored contract codes.
         #
         # @param source_code [String] Source code (e.g., "cn", "ru")
         # @return [Hash, nil] List types hash or nil if source not found
         #
         def list_types_for(source_code)
-          SOURCE_LIST_TYPES[source_code.to_s.downcase]
+          SOURCE_LIST_TYPES[source_code.to_s.downcase.tr('-', '_')]
         end
 
         # Get information about a specific list type.

--- a/spec/ammitto/cli/harmonize_command_spec.rb
+++ b/spec/ammitto/cli/harmonize_command_spec.rb
@@ -272,14 +272,17 @@ RSpec.describe Ammitto::Cmd::HarmonizeCommand do
         expect(files).to contain_exactly(entity, junk)
       end
 
-      it 'surfaces the load error for a mixed chosen directory' do
+      # The load error is attributed to the file that caused it rather
+      # than to the whole source, so the readable files still count and
+      # the run fails through the never-exempt per-file gate
+      it 'surfaces the load error against the file for a mixed directory' do
         write_file('data-us', 'processed', 'entity.yaml')
         make_dir('data-us', 'processed', 'broken.yaml')
 
         result = command.send(:harmonize_source, :us)
 
-        expect(result[:status]).to eq(:error)
-        expect(result[:error]).to match(/directory/i)
+        expect(result[:status]).to eq(:success)
+        expect(result[:errors].first).to match(/broken\.yaml.*directory/i)
       end
     end
   end

--- a/spec/ammitto/cli/harmonize_health_gates_spec.rb
+++ b/spec/ammitto/cli/harmonize_health_gates_spec.rb
@@ -1,0 +1,246 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+require 'fileutils'
+require 'yaml'
+require 'json'
+require 'ammitto'
+require 'ammitto/cli'
+require 'ammitto/cli/harmonize_command'
+
+RSpec.describe Ammitto::Cmd::HarmonizeCommand do
+  let(:sources_dir) { Dir.mktmpdir('ammitto_gates_sources') }
+  let(:output_dir) { Dir.mktmpdir('ammitto_gates_output') }
+  let(:options) { { sources_dir: sources_dir, output_dir: output_dir } }
+  let(:command) { described_class.new(options, ['us']) }
+
+  after do
+    FileUtils.rm_rf(sources_dir)
+    FileUtils.rm_rf(output_dir)
+  end
+
+  # Write one processed us YAML file
+  def write_us_yaml(basename, data)
+    dir = File.join(sources_dir, 'data-us', 'processed')
+    FileUtils.mkdir_p(dir)
+    File.write(File.join(dir, basename), data.to_yaml)
+  end
+
+  def healthy_entity(uid, last_name)
+    { 'uid' => uid, 'last_name' => last_name, 'sdn_type' => 'Individual' }
+  end
+
+  describe 'quality floors (integration)' do
+    before { allow($stdout).to receive(:write) }
+
+    it 'fails the gate for a single nameless entity (the us incident)' do
+      write_us_yaml('entity.yaml', { 'uid' => '9999' })
+
+      expect { command.run }.to raise_error(
+        Thor::Error, /us: named-entity ratio 0\.00 below floor/
+      )
+    end
+
+    it 'fails the gate when entity ids collapse (jp-style)' do
+      write_us_yaml('a.yaml', healthy_entity('5555', 'DOE'))
+      write_us_yaml('b.yaml', healthy_entity('5555', 'ROE'))
+      write_us_yaml('c.yaml', healthy_entity('5555', 'POE'))
+
+      expect { command.run }.to raise_error(
+        Thor::Error, /us: unique-id ratio 0\.33 below floor/
+      )
+    end
+
+    it 'passes healthy named entities with distinct ids' do
+      write_us_yaml('a.yaml', healthy_entity('1000', 'DOE'))
+      write_us_yaml('b.yaml', healthy_entity('1001', 'ROE'))
+
+      expect { command.run }.not_to raise_error
+    end
+
+    it 'exempts quality floors for --allow-empty sources' do
+      options[:allow_empty] = 'us'
+      write_us_yaml('entity.yaml', { 'uid' => '9999' })
+
+      expect { command.run }.not_to raise_error
+    end
+
+    it 'attaches quality metrics to the per-source result contract' do
+      write_us_yaml('a.yaml', healthy_entity('1000', 'DOE'))
+
+      captured = nil
+      allow(command).to receive(:enforce_health_gates)
+        .and_wrap_original do |original, results|
+          captured = results
+          original.call(results)
+        end
+
+      command.run
+
+      quality = captured.first[:quality]
+      expect(quality).to include(
+        unique_entities: 1,
+        unique_id_ratio: 1.0,
+        entity_nodes: 1,
+        named_entities: 1,
+        named_entity_ratio: 1.0
+      )
+    end
+  end
+
+  describe 'summary and gate agreement (integration)' do
+    it 'prints the quality failure as failed before raising' do
+      write_us_yaml('entity.yaml', { 'uid' => '9999' })
+
+      expect do
+        command.run
+      rescue Thor::Error
+        nil
+      end.to output(/0 succeeded, 1 failed/).to_stdout
+    end
+  end
+
+  describe '#aggregate_name_metrics' do
+    def write_aggregate(content)
+      FileUtils.mkdir_p(File.join(output_dir, 'sources'))
+      File.write(File.join(output_dir, 'sources', 'us.jsonld'), content)
+    end
+
+    def metrics
+      command.send(:aggregate_name_metrics, :us, output_dir)
+    end
+
+    it 'reports an unparseable aggregate instead of crashing' do
+      write_aggregate('{oops')
+
+      expect(metrics).to eq(aggregate_invalid: true)
+    end
+
+    it 'reports wrong-shaped JSON documents as invalid' do
+      ['null', '[]', '{"@graph": {}}', '{"nograph": []}',
+       '{"@graph": []}', '{"@graph": ["scalar"]}'].each do |content|
+        write_aggregate(content)
+
+        expect(metrics).to eq(aggregate_invalid: true), content
+      end
+    end
+
+    it 'counts only non-blank String names as usable' do
+      write_aggregate(JSON.generate(
+                        '@graph' => [
+                          { '@id' => 'https://x.org/entity/us/1',
+                            'names' => [{ 'fullName' => 0 }, {}] },
+                          { '@id' => 'https://x.org/entity/us/2',
+                            'names' => [], 'name' => '   ' }
+                        ]
+                      ))
+
+      expect(metrics).to include(named_entities: 0,
+                                 named_entity_ratio: 0.0)
+    end
+
+    it 'returns empty metrics when the aggregate is missing' do
+      expect(metrics).to eq({})
+    end
+  end
+
+  describe '#quality_floor_failures' do
+    it 'fails an invalid aggregate' do
+      result = { code: :us, entities: 1,
+                 quality: { aggregate_invalid: true } }
+
+      expect(command.send(:quality_floor_failures, result))
+        .to contain_exactly(/not a usable JSON-LD aggregate/)
+    end
+
+    it 'reports both floors when both are broken' do
+      result = {
+        code: :us, entities: 4,
+        quality: { unique_entities: 1, unique_id_ratio: 0.25,
+                   entity_nodes: 1, named_entities: 0,
+                   named_entity_ratio: 0.0 }
+      }
+
+      failures = command.send(:quality_floor_failures, result)
+
+      expect(failures).to contain_exactly(/unique-id ratio/,
+                                          /named-entity ratio/)
+    end
+
+    it 'passes metrics at the floors' do
+      result = {
+        code: :us, entities: 2,
+        quality: { unique_entities: 1, unique_id_ratio: 0.5,
+                   entity_nodes: 2, named_entities: 2,
+                   named_entity_ratio: 1.0 }
+      }
+
+      expect(command.send(:quality_floor_failures, result)).to be_empty
+    end
+  end
+
+  describe '#print_summary' do
+    # A healthy served aggregate so a clean source passes the floors
+    def write_healthy_aggregate(code)
+      FileUtils.mkdir_p(File.join(output_dir, 'sources'))
+      File.write(
+        File.join(output_dir, 'sources', "#{code}.jsonld"),
+        JSON.generate(
+          '@graph' => [{ '@id' => "https://x.org/entity/#{code}/1",
+                         'names' => [{ 'fullName' => 'Named' }] }]
+        )
+      )
+    end
+
+    it 'counts a source with per-file errors as failed' do
+      results = [{ code: :ch, status: :success, entities: 3, entries: 3,
+                   errors: ['x.yml: boom'] }]
+
+      expect { command.send(:print_summary, results) }
+        .to output(/0 succeeded, 1 failed/).to_stdout
+    end
+
+    it 'lists the per-file failure reason' do
+      results = [{ code: :ch, status: :success, entities: 3, entries: 3,
+                   errors: ['x.yml: boom', 'y.yml: kaboom'] }]
+
+      expect { command.send(:print_summary, results) }
+        .to output(/ch: 2 file\(s\) failed to transform \(first: x\.yml: boom\)/)
+        .to_stdout
+    end
+
+    it 'still counts clean sources as succeeded' do
+      write_healthy_aggregate(:au)
+      results = [{ code: :au, status: :success, entities: 3, entries: 3 },
+                 { code: :ch, status: :error, error: 'nope' }]
+
+      expect { command.send(:print_summary, results) }
+        .to output(/1 succeeded, 1 failed.*ch: nope/m).to_stdout
+    end
+
+    it 'counts a quality-floor failure as failed, matching the gates' do
+      results = [{ code: :us, status: :success, entities: 4, entries: 4,
+                   quality: { named_entity_ratio: 0.0, named_entities: 0,
+                              entity_nodes: 4 } }]
+      write_healthy_aggregate(:us)
+      allow(command).to receive(:attach_quality_metrics)
+
+      expect { command.send(:print_summary, results) }
+        .to output(/0 succeeded, 1 failed.*us: named-entity ratio/m)
+        .to_stdout
+    end
+
+    it 'prints deduplicated graph totals from the exporter stats' do
+      exporter = instance_double(
+        Ammitto::Serialization::JsonLdGraphExporter,
+        stats: { total_entities: 10, total_entries: 12 }
+      )
+      command.instance_variable_set(:@exporter, exporter)
+      results = [{ code: :au, status: :success, entities: 14, entries: 14 }]
+
+      expect { command.send(:print_summary, results) }
+        .to output(/Graph totals: 10 entities, 12 entries \(deduplicated\)/)
+        .to_stdout
+    end
+  end
+end

--- a/spec/ammitto/cli/harmonize_health_gates_spec.rb
+++ b/spec/ammitto/cli/harmonize_health_gates_spec.rb
@@ -88,6 +88,44 @@ RSpec.describe Ammitto::Cmd::HarmonizeCommand do
     end
   end
 
+  describe 'unparseable input files (integration)' do
+    before { allow($stdout).to receive(:write) }
+
+    def write_raw(basename, text)
+      dir = File.join(sources_dir, 'data-us', 'processed')
+      FileUtils.mkdir_p(dir)
+      File.write(File.join(dir, basename), text)
+    end
+
+    let(:broken) { "uid: '1\n  bad: [unclosed\n" }
+
+    it 'fails the gate even when the source is --allow-empty' do
+      options[:allow_empty] = 'us'
+      write_us_yaml('good.yaml', healthy_entity('1000', 'DOE'))
+      write_raw('broken.yaml', broken)
+
+      expect { command.run }.to raise_error(
+        Thor::Error, /us: 1 file\(s\) failed to transform/
+      )
+    end
+
+    it 'keeps the other files entities instead of failing the source' do
+      write_us_yaml('good.yaml', healthy_entity('1000', 'DOE'))
+      write_raw('broken.yaml', broken)
+
+      captured = nil
+      allow(command).to receive(:enforce_health_gates)
+        .and_wrap_original do |original, results|
+          captured = results
+          original.call(results)
+        end
+
+      expect { command.run }.to raise_error(Thor::Error)
+      expect(captured.first).to include(status: :success, entities: 1)
+      expect(captured.first[:errors].first).to match(/broken\.yaml/)
+    end
+  end
+
   describe 'summary and gate agreement (integration)' do
     it 'prints the quality failure as failed before raising' do
       write_us_yaml('entity.yaml', { 'uid' => '9999' })
@@ -167,12 +205,14 @@ RSpec.describe Ammitto::Cmd::HarmonizeCommand do
                                           /named-entity ratio/)
     end
 
+    # Both metrics sit exactly on their floors: the floors are inclusive,
+    # so a regression from < to <= in either check fails this example
     it 'passes metrics at the floors' do
       result = {
         code: :us, entities: 2,
         quality: { unique_entities: 1, unique_id_ratio: 0.5,
-                   entity_nodes: 2, named_entities: 2,
-                   named_entity_ratio: 1.0 }
+                   entity_nodes: 10, named_entities: 9,
+                   named_entity_ratio: 0.9 }
       }
 
       expect(command.send(:quality_floor_failures, result)).to be_empty

--- a/spec/ammitto/cli/harmonize_health_gates_spec.rb
+++ b/spec/ammitto/cli/harmonize_health_gates_spec.rb
@@ -230,6 +230,28 @@ RSpec.describe Ammitto::Cmd::HarmonizeCommand do
         .to_stdout
     end
 
+    # An --allow-empty source must not be printed as "failed" on a run
+    # that exits 0: the counts have to match what the gates will raise on
+    it 'reports an exempted errored source as exempted, not failed' do
+      options[:allow_empty] = 'ch'
+      results = [{ code: :ch, status: :error, error: 'No input directory found' }]
+
+      expect { command.send(:print_summary, results) }
+        .to output(
+          /0 succeeded, 0 failed, 1 exempted.*Exempted sources \(--allow-empty\):\s+ch: No input directory found/m
+        ).to_stdout
+      expect(results.first[:gate_failures]).to be_empty
+    end
+
+    it 'keeps a per-file failure in the failed count even when exempted' do
+      options[:allow_empty] = 'ch'
+      results = [{ code: :ch, status: :success, entities: 3, entries: 3,
+                   errors: ['x.yml: boom'] }]
+
+      expect { command.send(:print_summary, results) }
+        .to output(/0 succeeded, 1 failed, 0 exempted/).to_stdout
+    end
+
     it 'prints deduplicated graph totals from the exporter stats' do
       exporter = instance_double(
         Ammitto::Serialization::JsonLdGraphExporter,

--- a/spec/ammitto/serialization/search_index_exporter_spec.rb
+++ b/spec/ammitto/serialization/search_index_exporter_spec.rb
@@ -145,6 +145,146 @@ RSpec.describe Ammitto::Serialization::SearchIndexExporter do
     end
   end
 
+  describe '#add deduplication' do
+    let(:entity) do
+      {
+        '@id' => 'https://www.ammitto.org/entity/cn/test',
+        'entityType' => 'organization',
+        'names' => [{ 'fullName' => 'Test Corp', 'isPrimary' => true }]
+      }
+    end
+
+    let(:entry) do
+      {
+        '@id' => 'https://www.ammitto.org/entry/cn/unreliable-entity-list/test',
+        'authority' => { '@id' => 'https://www.ammitto.org/authority/cn' },
+        'regime' => { '@id' => 'https://www.ammitto.org/regime/cn_unreliable', 'name' => 'CN' },
+        'status' => 'active'
+      }
+    end
+
+    it 'keeps one row per entity id for duplicate pairs' do
+      exporter.add(entity, entry)
+      exporter.add(entity, entry)
+
+      expect(exporter.entities.length).to eq(1)
+    end
+
+    it 'recounts every facet from the deduplicated rows' do
+      exporter.add(entity, entry)
+      exporter.add(entity, entry)
+
+      expect(exporter.facets[:authorities]['cn']).to eq(1)
+      expect(exporter.facets[:list_types]['unreliable-entity-list']).to eq(1)
+      expect(exporter.facets[:regimes]['cn_unreliable'][:count]).to eq(1)
+      expect(exporter.facets[:types]['organization']).to eq(1)
+      expect(exporter.facets[:statuses]['active']).to eq(1)
+    end
+
+    it 'unions names across repeated pairs' do
+      exporter.add(entity, entry)
+      exporter.add(entity.merge('names' => [{ 'fullName' => '测试公司' }]),
+                   entry)
+
+      row = exporter.entities.first
+      expect(row[:names]).to contain_exactly('Test Corp', '测试公司')
+    end
+
+    it 'fills fields missing from the first-seen row' do
+      exporter.add(entity, entry)
+      exporter.add(entity.merge('nationalities' => [{ 'countryCode' => 'CN' }]),
+                   entry)
+
+      expect(exporter.entities.first[:country]).to eq('CN')
+      expect(exporter.facets[:countries]['CN']).to eq(1)
+    end
+
+    it 'keeps first-seen values for fields both pairs carry' do
+      exporter.add(entity, entry)
+      exporter.add(entity, entry.merge('status' => 'delisted'))
+
+      expect(exporter.entities.first[:status]).to eq('active')
+      expect(exporter.facets[:statuses]).to eq('active' => 1)
+    end
+
+    it 'lets a later real status fill a first pair without one' do
+      exporter.add(entity, entry.except('status'))
+      exporter.add(entity, entry.merge('status' => 'delisted'))
+
+      expect(exporter.entities.first[:status]).to eq('delisted')
+      expect(exporter.facets[:statuses]).to eq('delisted' => 1)
+    end
+
+    it 'applies type and status defaults only after aggregation' do
+      exporter.add(entity.except('entityType'), entry.except('status'))
+
+      row = exporter.entities.first
+      expect(row[:type]).to eq('person')
+      expect(row[:status]).to eq('active')
+      expect(exporter.facets[:types]).to eq('person' => 1)
+    end
+
+    it 'treats blank strings as missing so later data can fill them' do
+      exporter.add(entity.merge('nationalities' => [{ 'countryCode' => '' }]),
+                   entry)
+      exporter.add(entity.merge('nationalities' => [{ 'countryCode' => 'CN' }]),
+                   entry)
+
+      expect(exporter.entities.first[:country]).to eq('CN')
+      expect(exporter.facets[:countries]).to eq('CN' => 1)
+    end
+
+    it 'drops wrong-typed scalar values instead of crashing the export' do
+      exporter.add(entity.merge('nationalities' => [{ 'countryCode' => 0 }]),
+                   entry.merge('status' => {}))
+
+      row = exporter.entities.first
+      expect(row[:country]).to be_nil
+      expect(row[:status]).to eq('active')
+      expect(exporter.facets[:countries]).to eq({})
+      expect { exporter.export(output_dir) }.not_to raise_error
+    end
+
+    it 'keeps wrong-typed regime names out of the facets' do
+      exporter.add(entity,
+                   entry.merge('regime' => {
+                                 '@id' => 'https://www.ammitto.org/regime/x',
+                                 'name' => { 'oops' => true }
+                               }))
+
+      expect(exporter.facets[:regimes]['x'][:name]).to be_nil
+      expect { exporter.export(output_dir) }.not_to raise_error
+    end
+
+    it 'coerces numeric IMO numbers to strings' do
+      vessel = {
+        '@id' => 'https://www.ammitto.org/entity/eu_vessels/v1',
+        'entityType' => 'vessel',
+        'names' => [{ 'fullName' => 'Test Vessel' }],
+        'identifiers' => [{ 'type' => 'IMO', 'value' => 9_111_111 }]
+      }
+
+      exporter.add(vessel, entry)
+
+      expect(exporter.entities.first[:imo]).to eq('9111111')
+    end
+
+    it 'exports deduplicated totals' do
+      exporter.add(entity, entry)
+      exporter.add(entity, entry)
+      exporter.export(output_dir)
+
+      data = JSON.parse(File.read(File.join(output_dir, 'search-index.json')))
+      expect(data['metadata']['totalEntities']).to eq(1)
+      expect(data['entities'].length).to eq(1)
+
+      facets = JSON.parse(
+        File.read(File.join(output_dir, 'facets', 'authorities.json'))
+      )
+      expect(facets['facets'].first['count']).to eq(1)
+    end
+  end
+
   describe '#export' do
     before do
       # Add some test entities

--- a/spec/ammitto/serialization/search_index_exporter_spec.rb
+++ b/spec/ammitto/serialization/search_index_exporter_spec.rb
@@ -234,6 +234,50 @@ RSpec.describe Ammitto::Serialization::SearchIndexExporter do
       expect(exporter.facets[:countries]).to eq('CN' => 1)
     end
 
+    it 'drops blank and wrong-typed names from the row' do
+      noisy = entity.merge(
+        'names' => [{ 'fullName' => 0, 'lastName' => '   ' },
+                    { 'fullName' => 'Real Name' }],
+        'name' => { 'oops' => true },
+        'aliases' => [{ 'name' => 12.5 }, '', 'Real Alias']
+      )
+
+      exporter.add(noisy, entry)
+
+      expect(exporter.entities.first[:names])
+        .to contain_exactly('Real Name', 'Real Alias')
+    end
+
+    it 'keeps wrong-typed names out of the exported index' do
+      exporter.add(entity.merge('names' => [{ 'fullName' => 0 }]), entry)
+      exporter.export(output_dir)
+
+      data = JSON.parse(File.read(File.join(output_dir, 'search-index.json')))
+      expect(data['entities'].first['names']).to eq([])
+    end
+
+    it 'unions only real names across repeated pairs' do
+      exporter.add(entity.merge('names' => [{ 'fullName' => 0 }]), entry)
+      exporter.add(entity, entry)
+
+      expect(exporter.entities.first[:names]).to contain_exactly('Test Corp')
+    end
+
+    it 'falls back to id when @id is blank' do
+      exporter.add(entity.merge('@id' => '', 'id' => 'real-id'), entry)
+
+      expect(exporter.entities.map { |r| r[:id] }).to eq(['real-id'])
+    end
+
+    it 'never collapses distinct blank-id entities into one row' do
+      exporter.add(entity.merge('@id' => ''), entry)
+      exporter.add(entity.merge('@id' => '   '), entry)
+      exporter.add(entity.merge('@id' => 0), entry)
+
+      expect(exporter.entities).to be_empty
+      expect(exporter.facets[:authorities]).to eq({})
+    end
+
     it 'drops wrong-typed scalar values instead of crashing the export' do
       exporter.add(entity.merge('nationalities' => [{ 'countryCode' => 0 }]),
                    entry.merge('status' => {}))
@@ -254,6 +298,49 @@ RSpec.describe Ammitto::Serialization::SearchIndexExporter do
 
       expect(exporter.facets[:regimes]['x'][:name]).to be_nil
       expect { exporter.export(output_dir) }.not_to raise_error
+    end
+
+    # The lookup/discriminator fields reach #match and #downcase, so a
+    # wrong-typed source value raises NoMethodError mid-harmonize rather
+    # than dropping out of the row like the wrong-typed output fields
+    it 'drops wrong-typed authority and regime lookups without crashing' do
+      cases = [
+        [{ 'authority' => { '@id' => 0 } }, :authority],
+        [{ 'authority' => { 'countryCode' => {} } }, :authority],
+        [{ 'regime' => { '@id' => [] } }, :regime],
+        [{ 'regime' => { 'code' => {} } }, :regime],
+        [{ '@id' => 0, 'list_type' => nil }, :listType]
+      ]
+
+      cases.each do |bad_entry, dropped|
+        exporter = described_class.new
+        expect { exporter.add(entity, entry.merge(bad_entry)) }
+          .not_to raise_error
+        expect(exporter.entities.first[dropped]).to be_nil
+      end
+    end
+
+    it 'skips wrong-typed identifier types when reading the IMO' do
+      vessel = {
+        '@id' => 'https://www.ammitto.org/entity/eu_vessels/v1',
+        'entityType' => 'vessel',
+        'identifiers' => [{ 'type' => 0, 'value' => 'X' },
+                          { 'document_type' => 5, 'value' => 'Y' },
+                          { 'type' => 'imo', 'value' => 9_222_222 }]
+      }
+
+      exporter.add(vessel, entry)
+
+      expect(exporter.entities.first[:imo]).to eq('9222222')
+    end
+
+    it 'falls back to the entry IRI when list_type is wrong-typed' do
+      exporter.add(entity, entry.merge(
+                             'list_type' => 0,
+                             '@id' => 'https://www.ammitto.org/entry/cn/anti-sanction-list/1'
+                           ))
+
+      expect(exporter.entities.first[:listType]).to eq('anti-sanction-list')
     end
 
     it 'coerces numeric IMO numbers to strings' do

--- a/spec/ammitto/sources/cn_spec.rb
+++ b/spec/ammitto/sources/cn_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ammitto/sources/cn/announcement'
+require 'ammitto/sources/cn/transformer'
+
+RSpec.describe Ammitto::Sources::Cn::Entity do
+  describe '#list_type_code' do
+    def code_for(value)
+      described_class.new(sanction_list: value).list_type_code
+    end
+
+    it 'matches the Chinese labels from the schema enum' do
+      expect(code_for('反制裁清单')).to eq('anti_sanctions')
+      expect(code_for('不可靠实体清单')).to eq('unreliable_entity')
+      expect(code_for('出口管制管控名单')).to eq('export_control')
+    end
+
+    it 'matches the source-prefixed slugs the data stores' do
+      expect(code_for('cn/anti-sanction-list')).to eq('anti_sanctions')
+      expect(code_for('cn/unreliable-entity-list')).to eq('unreliable_entity')
+      expect(code_for('cn/import-export-control-list')).to eq('export_control')
+    end
+
+    it 'matches bare slugs without the source prefix' do
+      expect(code_for('anti-sanction-list')).to eq('anti_sanctions')
+      expect(code_for('unreliable-entity-list')).to eq('unreliable_entity')
+      expect(code_for('import-export-control-list')).to eq('export_control')
+    end
+
+    it 'ignores surrounding whitespace' do
+      expect(code_for(" cn/anti-sanction-list\n")).to eq('anti_sanctions')
+    end
+
+    it 'returns unknown for unrecognized, empty, and nil values' do
+      expect(code_for('no-such-list')).to eq('unknown')
+      expect(code_for('')).to eq('unknown')
+      expect(code_for(nil)).to eq('unknown')
+    end
+  end
+end
+
+RSpec.describe Ammitto::Sources::Cn::Transformer do
+  describe '#transform_announcement list identity' do
+    def announcement_data(sanction_list)
+      {
+        'announcement' => {
+          'title' => [{ 'zh-Hans' => '公告', 'en' => 'Announcement' }],
+          'document_id' => 'mofcom-2026-01',
+          'publish_date' => '2026-01-01'
+        },
+        'sanction_details' => {
+          'entities' => [
+            {
+              'name' => { 'zh-Hans' => '测试公司', 'en' => 'Test Corp' },
+              'type' => 'organization',
+              'effective_date' => '2026-01-01',
+              'sanction_list' => sanction_list
+            }
+          ]
+        }
+      }
+    end
+
+    def entry_for(sanction_list)
+      announcement = Ammitto::Sources::Cn::Announcement
+                     .from_hash(announcement_data(sanction_list))
+      described_class.new.transform_announcement(announcement)[:entries].first
+    end
+
+    it 'writes the real list slug into entry IRIs for slug data' do
+      entry = entry_for('cn/unreliable-entity-list')
+
+      expect(entry.id).to include('/entry/cn/unreliable-entity-list/')
+      expect(entry.id).not_to include('/unknown')
+    end
+
+    it 'writes the real regime for slug data' do
+      entry = entry_for('cn/anti-sanction-list')
+
+      expect(entry.regime.code).to eq('CN_ANTI_SANCTIONS')
+    end
+
+    it 'keeps matching Chinese label data' do
+      entry = entry_for('出口管制管控名单')
+
+      expect(entry.id).to include('/entry/cn/import-export-control-list/')
+      expect(entry.regime.code).to eq('CN_EXPORT_CONTROL')
+    end
+  end
+end

--- a/spec/ammitto/sources/vessels_list_identity_spec.rb
+++ b/spec/ammitto/sources/vessels_list_identity_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ammitto/sources/eu_vessels/transformer'
+require 'ammitto/sources/eu_vessels/vessel'
+require 'ammitto/sources/un_vessels/transformer'
+require 'ammitto/sources/un_vessels/vessel'
+
+RSpec.describe 'Vessel sources list identity' do
+  it 'writes the vessel list into eu_vessels entry IRIs' do
+    vessel = Ammitto::Sources::EuVessels::Vessel.new(
+      vessel_name: 'Test Vessel', imo_number: '9111111'
+    )
+
+    entry = Ammitto::Sources::EuVessels::Transformer.new
+                                                    .transform(vessel)[:entry]
+
+    expect(entry.id)
+      .to include('/entry/eu_vessels/vessel-sanctions-list/')
+    expect(entry.id).not_to include('/unknown')
+  end
+
+  it 'writes the vessel list into un_vessels entry IRIs' do
+    vessel = Ammitto::Sources::UnVessels::Vessel.new(imo_number: '9222222')
+
+    entry = Ammitto::Sources::UnVessels::Transformer.new
+                                                    .transform(vessel)[:entry]
+
+    expect(entry.id)
+      .to include('/entry/un_vessels/vessel-sanctions-list/')
+    expect(entry.id).not_to include('/unknown')
+  end
+end

--- a/spec/ammitto/utils/list_types_registry_spec.rb
+++ b/spec/ammitto/utils/list_types_registry_spec.rb
@@ -33,11 +33,41 @@ RSpec.describe Ammitto::Utils::ListTypesRegistry do
     end
   end
 
+  describe '::SOURCE_LIST_TYPES' do
+    it 'keys vessel sources with underscores (the gem source codes)' do
+      expect(described_class::SOURCE_LIST_TYPES)
+        .to include('eu_vessels', 'un_vessels')
+    end
+
+    it 'holds no hyphenated source keys' do
+      expect(described_class::SOURCE_LIST_TYPES.keys.grep(/-/)).to be_empty
+    end
+  end
+
   describe '.list_types_for' do
     it 'returns list types for China' do
       result = described_class.list_types_for('cn')
       expect(result).to be_a(Hash)
       expect(result.keys).to include('anti-sanction-list', 'import-export-control-list', 'unreliable-entity-list')
+    end
+
+    it 'resolves eu_vessels by its underscored source code' do
+      result = described_class.list_types_for('eu_vessels')
+      expect(result).to be_a(Hash)
+      expect(result.keys).to eq(['vessel-sanctions-list'])
+    end
+
+    it 'resolves un_vessels by its underscored source code' do
+      result = described_class.list_types_for(:un_vessels)
+      expect(result).to be_a(Hash)
+      expect(result.keys).to eq(['vessel-sanctions-list'])
+    end
+
+    it 'normalizes legacy hyphenated aliases from repo-derived codes' do
+      expect(described_class.list_types_for('eu-vessels'))
+        .to eq(described_class::EU_VESSELS)
+      expect(described_class.list_types_for('UN-Vessels'))
+        .to eq(described_class::UN_VESSELS)
     end
 
     it 'returns list types for Russia' do
@@ -104,6 +134,16 @@ RSpec.describe Ammitto::Utils::ListTypesRegistry do
     it 'returns first list type for Russia' do
       result = described_class.default_list_type('ru')
       expect(result).to eq('stop-list')
+    end
+
+    it 'returns the vessel list for eu_vessels' do
+      expect(described_class.default_list_type('eu_vessels'))
+        .to eq('vessel-sanctions-list')
+    end
+
+    it 'returns the vessel list for un_vessels' do
+      expect(described_class.default_list_type('un_vessels'))
+        .to eq('vessel-sanctions-list')
     end
 
     it 'returns nil for unknown source' do


### PR DESCRIPTION
Harmonized output lost list identity, inflated the search index, and published garbage as success. Fixed the cn list matcher to accept the slugs the data actually stores alongside the Chinese labels, so 322 entries leave `entry/cn/unknown`, and renamed the **`eu-vessels`**/**`un-vessels`** registry keys to underscores (hyphen aliases still resolve) so 597 eu_vessels entries get their real list. Deduplicated search-index rows by entity id — names unioned, facets recounted, totals now agreeing with `stats.json`. Added per-source quality gates (unique-id ratio, named-entity ratio, aggregates failing closed) and aligned the summary with them, so a crashed source no longer prints "1 succeeded" and an exempted source reports as exempted rather than failed. Entry IRIs change for cn and both vessel sources: `entry/{code}/unknown/…` becomes the real list slug, and cn regimes move off `UNKNOWN`.

Verified with the full suite and RuboCop.
