### PR TITLE
Fix silent entity loss and crashes in harmonize ingestion

### DIFF
--- a/lib/ammitto/cli/harmonize_command.rb
+++ b/lib/ammitto/cli/harmonize_command.rb
@@ -225,20 +225,23 @@ module Ammitto
         errors = []
         source_graph = []
 
+        # Parsing is inside the per-file rescue: a malformed YAML file is a
+        # per-file defect like any transform failure, so it must land in the
+        # never-exempt error collector. Escaping to the method-level rescue
+        # made it a source-level :error, which --allow-empty then cleared —
+        # one unparseable file silenced the whole source and exited 0.
         yaml_files.each do |file|
           data = YAML.safe_load_file(file, permitted_classes: [Date, Time], aliases: true)
           next unless data
 
-          begin
-            result = transform_data(source, data)
-            added = ingest_results(result, source, source_graph, errors, File.basename(file))
-            entities_count += added
-            entries_count += added
-          rescue StandardError => e
-            error_msg = "#{File.basename(file)}: #{e.message}"
-            puts "[#{source}] Error processing #{error_msg}" if options[:verbose]
-            errors << error_msg
-          end
+          result = transform_data(source, data)
+          added = ingest_results(result, source, source_graph, errors, File.basename(file))
+          entities_count += added
+          entries_count += added
+        rescue StandardError => e
+          error_msg = "#{File.basename(file)}: #{e.message}"
+          puts "[#{source}] Error processing #{error_msg}" if options[:verbose]
+          errors << error_msg
         end
 
         # Per-source aggregate: required by BaseSource downloads and

--- a/lib/ammitto/cli/harmonize_command.rb
+++ b/lib/ammitto/cli/harmonize_command.rb
@@ -18,6 +18,17 @@ module Ammitto
     # - Aggregated all.jsonld and all.ttl files
     # - Index files for each node type
     class HarmonizeCommand
+      # Raised when announcement-format YAML (the data-cn schema: one
+      # file per official announcement, several entities inside) reaches
+      # a source path that parses legacy per-entity models. Parsing it
+      # there either crashes (ch) or silently yields one nameless
+      # garbage entity (us), so the shape is rejected loudly instead.
+      class AnnouncementFormatError < StandardError; end
+
+      # Top-level YAML keys that mark the announcement format
+      ANNOUNCEMENT_FORMAT_KEYS = %w[announcement sanction_details
+                                    measure_modifications].freeze
+
       # @return [Hash] command options
       attr_reader :options
 
@@ -597,6 +608,29 @@ module Ammitto
         end
       end
 
+      # Reject announcement-format YAML on a legacy per-entity path.
+      # The error message names the format; the caller's per-file error
+      # collector prefixes the offending filename, and the health gates
+      # turn it into a non-zero exit.
+      # @param source [Symbol] source code
+      # @param data [Hash] source data
+      # @param expected [String] the schema this path parses
+      # @return [void]
+      # @raise [AnnouncementFormatError] on announcement-shaped data
+      def guard_announcement_format!(source, data, expected:)
+        return unless data.is_a?(Hash)
+
+        markers = ANNOUNCEMENT_FORMAT_KEYS & data.keys.map(&:to_s)
+        return if markers.empty?
+
+        raise AnnouncementFormatError,
+              'announcement-format YAML detected (top-level ' \
+              "#{markers.join(', ')}) — the #{source} path parses " \
+              "per-entity #{expected} records, and announcement " \
+              "ingestion is not implemented for #{source}; refusing " \
+              'to harmonize this file'
+      end
+
       # Transform UK data
       # @param transformer [Object] transformer instance
       # @param data [Hash] source data
@@ -604,7 +638,9 @@ module Ammitto
       def transform_uk(transformer, data)
         require_relative '../sources/uk/designation'
 
-        designation = Ammitto::Sources::Uk::Designation.from_yaml(data.to_yaml)
+        guard_announcement_format!(:uk, data, expected: 'Uk::Designation')
+
+        designation = Ammitto::Sources::Uk::Designation.from_hash(data)
         result = transformer.transform(designation)
 
         {
@@ -622,7 +658,7 @@ module Ammitto
 
         # The fetch pipeline saves Eu::SanctionEntity YAML (one per record);
         # parsing with ProcessedEntity collapsed every EU id and dropped names
-        entity = Ammitto::Sources::Eu::SanctionEntity.from_yaml(data.to_yaml)
+        entity = Ammitto::Sources::Eu::SanctionEntity.from_hash(data)
         result = transformer.transform(entity)
 
         {
@@ -649,10 +685,10 @@ module Ammitto
                         data.key?('fourth_name')
 
         if is_individual
-          source = Ammitto::Sources::Un::Individual.from_yaml(data.to_yaml)
+          source = Ammitto::Sources::Un::Individual.from_hash(data)
           result = transformer.transform_individual(source)
         else
-          source = Ammitto::Sources::Un::Entity.from_yaml(data.to_yaml)
+          source = Ammitto::Sources::Un::Entity.from_hash(data)
           result = transformer.transform_entity(source)
         end
 
@@ -669,7 +705,9 @@ module Ammitto
       def transform_us(transformer, data)
         require_relative '../sources/us/sdn_entry'
 
-        sdn_entry = Ammitto::Sources::Us::SdnEntry.from_yaml(data.to_yaml)
+        guard_announcement_format!(:us, data, expected: 'Us::SdnEntry')
+
+        sdn_entry = Ammitto::Sources::Us::SdnEntry.from_hash(data)
         result = transformer.transform(sdn_entry)
 
         {
@@ -685,7 +723,7 @@ module Ammitto
       def transform_wb(transformer, data)
         require_relative '../sources/wb/sanctioned_firm'
 
-        firm = Ammitto::Sources::Wb::SanctionedFirm.from_yaml(data.to_yaml)
+        firm = Ammitto::Sources::Wb::SanctionedFirm.from_hash(data)
         result = transformer.transform(firm)
 
         {
@@ -704,11 +742,11 @@ module Ammitto
         # Detect record type: vessels carry imo_number, individuals carry
         # dates_of_birth; the rest are organizations
         source = if data.key?('imo_number')
-                   Ammitto::Sources::Au::Vessel.from_yaml(data.to_yaml)
+                   Ammitto::Sources::Au::Vessel.from_hash(data)
                  elsif data.key?('dates_of_birth')
-                   Ammitto::Sources::Au::Individual.from_yaml(data.to_yaml)
+                   Ammitto::Sources::Au::Individual.from_hash(data)
                  else
-                   Ammitto::Sources::Au::Organization.from_yaml(data.to_yaml)
+                   Ammitto::Sources::Au::Organization.from_hash(data)
                  end
         result = transformer.transform(source)
 
@@ -727,7 +765,7 @@ module Ammitto
 
         # Use Record class - it handles both individuals and entities
         # The YAML has given_name, not first_name
-        source = Ammitto::Sources::Ca::Record.from_yaml(data.to_yaml)
+        source = Ammitto::Sources::Ca::Record.from_hash(data)
         result = transformer.transform(source)
 
         {
@@ -743,9 +781,11 @@ module Ammitto
       def transform_ch(transformer, data)
         require_relative '../sources/ch/sanctions_list'
 
+        guard_announcement_format!(:ch, data, expected: 'Ch::Identity')
+
         # The fetch pipeline saves bare Identity records
         # (SanctionsList#all_identities), not Target wrappers
-        source = Ammitto::Sources::Ch::Identity.from_yaml(data.to_yaml)
+        source = Ammitto::Sources::Ch::Identity.from_hash(data)
         result = transformer.transform(source)
 
         {
@@ -823,7 +863,7 @@ module Ammitto
       def transform_ru(transformer, data)
         require_relative '../sources/ru/sanctions_list'
 
-        source = Ammitto::Sources::Ru::SanctionedEntity.from_yaml(data.to_yaml)
+        source = Ammitto::Sources::Ru::SanctionedEntity.from_hash(data)
         result = transformer.transform(source)
 
         {
@@ -842,11 +882,11 @@ module Ammitto
         # Determine type
         source = case data['type']
                  when 'Individual'
-                   Ammitto::Sources::Nz::Individual.from_yaml(data.to_yaml)
+                   Ammitto::Sources::Nz::Individual.from_hash(data)
                  when 'Ship'
-                   Ammitto::Sources::Nz::Ship.from_yaml(data.to_yaml)
+                   Ammitto::Sources::Nz::Ship.from_hash(data)
                  else
-                   Ammitto::Sources::Nz::Entity.from_yaml(data.to_yaml)
+                   Ammitto::Sources::Nz::Entity.from_hash(data)
                  end
         result = transformer.transform(source)
 
@@ -863,7 +903,7 @@ module Ammitto
       def transform_tr(transformer, data)
         require_relative '../sources/tr/sanctions_list'
 
-        source = Ammitto::Sources::Tr::Entity.from_yaml(data.to_yaml)
+        source = Ammitto::Sources::Tr::Entity.from_hash(data)
         result = transformer.transform(source)
 
         {
@@ -879,7 +919,7 @@ module Ammitto
       def transform_eu_vessels(transformer, data)
         require_relative '../sources/eu_vessels/vessel'
 
-        source = Ammitto::Sources::EuVessels::Vessel.from_yaml(data.to_yaml)
+        source = Ammitto::Sources::EuVessels::Vessel.from_hash(data)
         result = transformer.transform(source)
 
         {
@@ -895,7 +935,7 @@ module Ammitto
       def transform_jp(transformer, data)
         require_relative '../sources/jp/entity'
 
-        source = Ammitto::Sources::Jp::Entity.from_yaml(data.to_yaml)
+        source = Ammitto::Sources::Jp::Entity.from_hash(data)
         result = transformer.transform(source)
 
         {
@@ -911,7 +951,7 @@ module Ammitto
       def transform_un_vessels(transformer, data)
         require_relative '../sources/un_vessels/vessel'
 
-        source = Ammitto::Sources::UnVessels::Vessel.from_yaml(data.to_yaml)
+        source = Ammitto::Sources::UnVessels::Vessel.from_hash(data)
         result = transformer.transform(source)
 
         {

--- a/lib/ammitto/data/knowledge_graph_loader.rb
+++ b/lib/ammitto/data/knowledge_graph_loader.rb
@@ -273,6 +273,8 @@ module Ammitto
       #
       # @param local_id [String] Local entity ID
       # @return [String] Full entity IRI
+      # @raise [Utils::IriSanitizer::MissingLocalIdError] when local_id
+      #   is blank or sanitizes to nothing
       #
       def entity_iri(local_id)
         Utils::IriSanitizer.entity_iri(source_code, local_id)
@@ -283,6 +285,8 @@ module Ammitto
       # @param list_type [String] List type
       # @param local_id [String] Local entry ID
       # @return [String] Full entry IRI
+      # @raise [Utils::IriSanitizer::MissingLocalIdError] when local_id
+      #   is blank or sanitizes to nothing
       #
       def entry_iri(list_type, local_id)
         Utils::IriSanitizer.entry_iri(source_code, list_type, local_id)
@@ -292,6 +296,8 @@ module Ammitto
       #
       # @param local_id [String] Local announcement ID
       # @return [String] Full announcement IRI
+      # @raise [Utils::IriSanitizer::MissingLocalIdError] when local_id
+      #   is blank or sanitizes to nothing
       #
       def announcement_iri(local_id)
         Utils::IriSanitizer.announcement_iri(source_code, local_id)
@@ -301,6 +307,8 @@ module Ammitto
       #
       # @param local_id [String] Local legal instrument ID
       # @return [String] Full legal instrument IRI
+      # @raise [Utils::IriSanitizer::MissingLocalIdError] when local_id
+      #   is blank or sanitizes to nothing
       #
       def legal_instrument_iri(local_id)
         Utils::IriSanitizer.legal_instrument_iri(source_code, local_id)

--- a/lib/ammitto/ontology.rb
+++ b/lib/ammitto/ontology.rb
@@ -74,6 +74,8 @@ module Ammitto
       # @param source [Symbol, String] source code (eu, un, us, etc.)
       # @param local_id [String] local entity identifier
       # @return [String]
+      # @raise [Utils::IriSanitizer::MissingLocalIdError] when local_id
+      #   is blank or sanitizes to nothing
       #
       # @example
       #   entity_uri("cn", "mitsubishi-heavy-industries")
@@ -91,6 +93,8 @@ module Ammitto
       # @param list_type [String] list type (e.g., "import-export-control-list")
       # @param local_id [String] local entry identifier
       # @return [String]
+      # @raise [Utils::IriSanitizer::MissingLocalIdError] when local_id
+      #   is blank or sanitizes to nothing
       #
       # @example Same entity, different lists
       #   entry_uri("cn", "import-export-control-list", "mitsubishi-heavy-industries")
@@ -124,6 +128,8 @@ module Ammitto
       # @param source [Symbol, String] source code
       # @param local_id [String] local announcement identifier
       # @return [String]
+      # @raise [Utils::IriSanitizer::MissingLocalIdError] when local_id
+      #   is blank or sanitizes to nothing
       #
       # @example
       #   announcement_uri("cn", "mofcom-2026-11")
@@ -140,6 +146,8 @@ module Ammitto
       # @param source [Symbol, String] source code
       # @param local_id [String] local legal instrument identifier
       # @return [String]
+      # @raise [Utils::IriSanitizer::MissingLocalIdError] when local_id
+      #   is blank or sanitizes to nothing
       #
       # @example
       #   legal_instrument_uri("cn", "export-control-law")

--- a/lib/ammitto/sources/au/transformer.rb
+++ b/lib/ammitto/sources/au/transformer.rb
@@ -125,12 +125,12 @@ module Ammitto
           source = if entity_type == 'person' || entity_type == 'Individual' ||
                       data.key?('dates_of_birth') || data.key?('birth_info') ||
                       data.key?('person_details')
-                     Ammitto::Sources::Au::Individual.from_yaml(data.to_yaml)
+                     Ammitto::Sources::Au::Individual.from_hash(data)
                    elsif entity_type == 'vessel' || entity_type == 'Vessel' ||
                          data.key?('vessel_details') || data.key?('imo_number')
-                     Ammitto::Sources::Au::Vessel.from_yaml(data.to_yaml)
+                     Ammitto::Sources::Au::Vessel.from_hash(data)
                    else
-                     Ammitto::Sources::Au::Organization.from_yaml(data.to_yaml)
+                     Ammitto::Sources::Au::Organization.from_hash(data)
                    end
 
           transform(source)

--- a/lib/ammitto/sources/jp/entity.rb
+++ b/lib/ammitto/sources/jp/entity.rb
@@ -2,12 +2,16 @@
 
 require 'lutaml/model'
 
+require_relative '../scalar_field'
+
 module Ammitto
   module Sources
     module Jp
       # Entity represents a sanctioned entity in the Japan End-User List
       #
       class Entity < Lutaml::Model::Serializable
+        extend ScalarField
+
         attribute :id, :string
         attribute :name, :string
         attribute :name_ja, :string
@@ -16,18 +20,24 @@ module Ammitto
         attribute :source_url, :string
         attribute :remarks, :string
 
-        # Create Entity from row data hash
+        # Create Entity from row data hash.
+        #
+        # Every scalar field is read through fetch_scalar: this reader
+        # shadows the Lutaml one, so it owes callers the same refusal of
+        # a container in a single-value slot (see ScalarField).
         # @param data [Hash] row data
         # @return [Entity]
+        # @raise [ArgumentError] when a scalar field holds a container
         def self.from_hash(data)
           entity = new
-          entity.id = data['id']
-          entity.name = data['name']
-          entity.name_ja = data['name_ja']
-          entity.entity_type = map_entity_type(data['entity_type'])
+          entity.id = fetch_scalar(data, 'id')
+          entity.name = fetch_scalar(data, 'name')
+          entity.name_ja = fetch_scalar(data, 'name_ja')
+          entity.entity_type =
+            map_entity_type(fetch_scalar(data, 'entity_type'))
           entity.addresses = Array(data['addresses'])
-          entity.source_url = data['source_url']
-          entity.remarks = data['remarks']
+          entity.source_url = fetch_scalar(data, 'source_url')
+          entity.remarks = fetch_scalar(data, 'remarks')
           entity
         end
 

--- a/lib/ammitto/sources/jp/entity.rb
+++ b/lib/ammitto/sources/jp/entity.rb
@@ -43,8 +43,15 @@ module Ammitto
           end
         end
 
-        # Get unique identifier
+        # Get unique identifier. Returns nil when the record's id holds
+        # no sanitizable content (nil, empty, whitespace or
+        # punctuation-only): a bare "JP-" prefix — or "JP-!!!" — would
+        # sanitize to the constant "jp" and collapse every such Japanese
+        # entity into entity/jp/jp, so the unusable id must flow through
+        # to the IRI layer's MissingLocalIdError instead.
         def unique_identifier
+          return nil unless id.to_s.match?(/[a-zA-Z0-9_]/)
+
           "JP-#{id}"
         end
 

--- a/lib/ammitto/sources/scalar_field.rb
+++ b/lib/ammitto/sources/scalar_field.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Ammitto
+  module Sources
+    # Guards hand-written from_hash readers against container values
+    # landing in scalar slots.
+    #
+    # Models deserialized by Lutaml never need this: a collection in a
+    # non-collection attribute raises CollectionTrueMissingError, and
+    # from_yaml runs the same check. The two hand-written from_hash
+    # readers (Jp::Entity, UnVessels::Vessel) assign straight from the
+    # hash and had no equivalent, so an Array survived, stringified, and
+    # sanitized into a colliding IRI: an id of ["a", "b"] and an id of
+    # "a-b" both become entity/jp/jp-a-b, merging two distinct designees
+    # into one record — the exact collapse this pipeline must refuse.
+    #
+    # Array rejection restores the from_yaml behaviour these readers
+    # replaced. Hash is rejected on the same grounds even though
+    # from_yaml stringifies it, because it flattens into a colliding
+    # identifier the same way and is never a valid scalar value.
+    module ScalarField
+      # Read a field that must hold a single value.
+      #
+      # @param data [Hash] source data
+      # @param field [String] key to read
+      # @return [Object, nil] the value, unchanged
+      # @raise [ArgumentError] when the value is an Array or a Hash
+      def fetch_scalar(data, field)
+        value = data[field]
+        return value unless value.is_a?(Array) || value.is_a?(Hash)
+
+        raise ArgumentError,
+              "#{field} must hold a single value, got #{value.class} " \
+              '— a container here flattens into a colliding identifier'
+      end
+    end
+  end
+end

--- a/lib/ammitto/sources/uk/designation.rb
+++ b/lib/ammitto/sources/uk/designation.rb
@@ -20,11 +20,7 @@ module Ammitto
           map_element 'Name', to: :items
         end
 
-        yaml do
-          map 'names', to: :items
-        end
-
-        json do
+        key_value do
           map 'names', to: :items
         end
       end
@@ -38,11 +34,7 @@ module Ammitto
           map_element 'NonLatinName', to: :items
         end
 
-        yaml do
-          map 'names', to: :items
-        end
-
-        json do
+        key_value do
           map 'names', to: :items
         end
       end
@@ -56,11 +48,7 @@ module Ammitto
           map_element 'Address', to: :items
         end
 
-        yaml do
-          map 'addresses', to: :items
-        end
-
-        json do
+        key_value do
           map 'addresses', to: :items
         end
       end
@@ -117,26 +105,13 @@ module Ammitto
           map_element 'IndividualDetails', to: :individual_details
         end
 
-        yaml do
-          map 'last_updated', to: :last_updated
-          map 'date_designated', to: :date_designated
-          map 'unique_id', to: :unique_id
-          map 'ofsi_group_id', to: :ofsi_group_id
-          map 'un_reference_number', to: :un_reference_number
-          map 'names', to: :names_wrapper
-          map 'non_latin_names', to: :non_latin_names_wrapper
-          map 'regime_name', to: :regime_name
-          map 'individual_entity_ship', to: :individual_entity_ship
-          map 'designation_source', to: :designation_source
-          map 'sanctions_imposed', to: :sanctions_imposed
-          map 'sanctions_imposed_indicators', to: :sanctions_imposed_indicators
-          map 'other_information', to: :other_information
-          map 'uk_statement_of_reasons', to: :uk_statement_of_reasons
-          map 'addresses', to: :addresses_wrapper
-          map 'individual_details', to: :individual_details
-        end
-
-        json do
+        # One mapping for every key-value format so from_hash — the
+        # harmonize path since the anchored-YAML round-trip fix —
+        # parses the same keys from_yaml does. This deliberately also
+        # covers the formats that previously fell back to attribute
+        # names (toml, jsonl, yamls): these keys are the canonical
+        # serialized form, and the gem has no consumer of those three.
+        key_value do
           map 'last_updated', to: :last_updated
           map 'date_designated', to: :date_designated
           map 'unique_id', to: :unique_id

--- a/lib/ammitto/sources/un_vessels/vessel.rb
+++ b/lib/ammitto/sources/un_vessels/vessel.rb
@@ -84,7 +84,11 @@ module Ammitto
           vessel.flag_state = data['flag_state']
           vessel.tonnage = data['tonnage']&.to_i
           vessel.build_year = data['build_year']&.to_i
-          raw_date = [data['designation_date'], data['date_designated']]
+          # Canonical serialized key first: 'date_designated' is what
+          # the yaml mapping reads and what #to_hash emits, so a file
+          # carrying both keys resolves the same way from_yaml resolves
+          # it. 'designation_date' is only the fetch-time row alias.
+          raw_date = [data['date_designated'], data['designation_date']]
                      .find { |value| value && value.to_s.strip != '' }
           vessel.designation_date = parse_date(raw_date)
           vessel.resolution = data['resolution']

--- a/lib/ammitto/sources/un_vessels/vessel.rb
+++ b/lib/ammitto/sources/un_vessels/vessel.rb
@@ -33,7 +33,12 @@ module Ammitto
         attribute :designation_date, :date
         attribute :resolution, :string
 
-        # YAML mapping for actual YAML structure
+        # YAML mapping for actual YAML structure. Deliberately NOT
+        # key_value: the custom self.from_hash below shadows the Lutaml
+        # hash deserializer, so hash parsing never consults these
+        # mappings, and widening them would change the JSON contract
+        # (JSON has no explicit block, so it keeps the attribute-name
+        # key 'designation_date').
         yaml do
           map 'id', to: :id
           map 'entity_type', to: :entity_type
@@ -61,18 +66,27 @@ module Ammitto
           names.reject(&:is_primary).map(&:full_name).compact
         end
 
-        # Create Vessel from row data hash
-        # @param data [Hash] row data
+        # Create Vessel from a data hash. Handles both the fetch-time
+        # row shape (date under 'designation_date', no names) and the
+        # serialized YAML shape the harmonize path loads (date under
+        # 'date_designated', names present) — this method shadows the
+        # Lutaml from_hash, so it must not drop the YAML-shape fields.
+        # @param data [Hash] row or YAML data
         # @return [Vessel]
         def self.from_hash(data)
           vessel = new
           vessel.id = data['id']
           vessel.entity_type = data['entity_type']
+          vessel.names = Array(data['names']).map do |name|
+            name.is_a?(NameVariant) ? name : NameVariant.from(:hash, name)
+          end
           vessel.imo_number = data['imo_number']&.to_s
           vessel.flag_state = data['flag_state']
           vessel.tonnage = data['tonnage']&.to_i
           vessel.build_year = data['build_year']&.to_i
-          vessel.designation_date = parse_date(data['designation_date'])
+          raw_date = [data['designation_date'], data['date_designated']]
+                     .find { |value| value && value.to_s.strip != '' }
+          vessel.designation_date = parse_date(raw_date)
           vessel.resolution = data['resolution']
           vessel
         end

--- a/lib/ammitto/sources/un_vessels/vessel.rb
+++ b/lib/ammitto/sources/un_vessels/vessel.rb
@@ -2,6 +2,8 @@
 
 require 'lutaml/model'
 
+require_relative '../scalar_field'
+
 module Ammitto
   module Sources
     module UnVessels
@@ -23,6 +25,8 @@ module Ammitto
       # Vessel represents a sanctioned vessel in the UN Designated Vessels List
       #
       class Vessel < Lutaml::Model::Serializable
+        extend ScalarField
+
         attribute :id, :string
         attribute :entity_type, :string
         attribute :names, NameVariant, collection: true
@@ -71,23 +75,27 @@ module Ammitto
         # serialized YAML shape the harmonize path loads (date under
         # 'date_designated', names present) — this method shadows the
         # Lutaml from_hash, so it must not drop the YAML-shape fields.
+        # Every scalar field is read through fetch_scalar: this reader
+        # shadows the Lutaml one, so it owes callers the same refusal of
+        # a container in a single-value slot (see ScalarField).
         # @param data [Hash] row or YAML data
         # @return [Vessel]
+        # @raise [ArgumentError] when a scalar field holds a container
         def self.from_hash(data)
           vessel = new
-          vessel.id = data['id']
-          vessel.entity_type = data['entity_type']
+          vessel.id = fetch_scalar(data, 'id')
+          vessel.entity_type = fetch_scalar(data, 'entity_type')
           vessel.names = Array(data['names']).map do |name|
             name.is_a?(NameVariant) ? name : NameVariant.from(:hash, name)
           end
-          vessel.imo_number = data['imo_number']&.to_s
-          vessel.flag_state = data['flag_state']
+          vessel.imo_number = fetch_scalar(data, 'imo_number')&.to_s
+          vessel.flag_state = fetch_scalar(data, 'flag_state')
           # Assigned raw so the attribute's own Integer cast runs, as it
           # does for every string attribute here. A prior &.to_i
           # defeated that cast: "12,500" tonnage became 12 where
           # from_yaml yields nil, quietly inventing a plausible number.
-          vessel.tonnage = data['tonnage']
-          vessel.build_year = data['build_year']
+          vessel.tonnage = fetch_scalar(data, 'tonnage')
+          vessel.build_year = fetch_scalar(data, 'build_year')
           # The canonical serialized key wins whenever it is PRESENT,
           # even holding a blank — that is what the yaml mapping reads
           # and what #to_hash emits, so a serialized file resolves
@@ -95,12 +103,12 @@ module Ammitto
           # fetch-time row alias, consulted only when the canonical key
           # is absent entirely.
           raw_date = if data.key?('date_designated')
-                       data['date_designated']
+                       fetch_scalar(data, 'date_designated')
                      else
-                       data['designation_date']
+                       fetch_scalar(data, 'designation_date')
                      end
           vessel.designation_date = parse_date(raw_date)
-          vessel.resolution = data['resolution']
+          vessel.resolution = fetch_scalar(data, 'resolution')
           vessel
         end
 

--- a/lib/ammitto/sources/un_vessels/vessel.rb
+++ b/lib/ammitto/sources/un_vessels/vessel.rb
@@ -82,14 +82,23 @@ module Ammitto
           end
           vessel.imo_number = data['imo_number']&.to_s
           vessel.flag_state = data['flag_state']
-          vessel.tonnage = data['tonnage']&.to_i
-          vessel.build_year = data['build_year']&.to_i
-          # Canonical serialized key first: 'date_designated' is what
-          # the yaml mapping reads and what #to_hash emits, so a file
-          # carrying both keys resolves the same way from_yaml resolves
-          # it. 'designation_date' is only the fetch-time row alias.
-          raw_date = [data['date_designated'], data['designation_date']]
-                     .find { |value| value && value.to_s.strip != '' }
+          # Assigned raw so the attribute's own Integer cast runs, as it
+          # does for every string attribute here. A prior &.to_i
+          # defeated that cast: "12,500" tonnage became 12 where
+          # from_yaml yields nil, quietly inventing a plausible number.
+          vessel.tonnage = data['tonnage']
+          vessel.build_year = data['build_year']
+          # The canonical serialized key wins whenever it is PRESENT,
+          # even holding a blank — that is what the yaml mapping reads
+          # and what #to_hash emits, so a serialized file resolves
+          # exactly as from_yaml resolves it. 'designation_date' is the
+          # fetch-time row alias, consulted only when the canonical key
+          # is absent entirely.
+          raw_date = if data.key?('date_designated')
+                       data['date_designated']
+                     else
+                       data['designation_date']
+                     end
           vessel.designation_date = parse_date(raw_date)
           vessel.resolution = data['resolution']
           vessel

--- a/lib/ammitto/transformers/base_transformer.rb
+++ b/lib/ammitto/transformers/base_transformer.rb
@@ -61,6 +61,8 @@ module Ammitto
       #
       # @param local_id [String] the local entity identifier
       # @return [String] the full entity URI
+      # @raise [Utils::IriSanitizer::MissingLocalIdError] when local_id
+      #   is blank or sanitizes to nothing
       #
       # @example
       #   generate_entity_id("mitsubishi-heavy-industries")
@@ -76,6 +78,8 @@ module Ammitto
       # @param local_id [String] the local entry identifier
       # @param entry_list_type [String, nil] optional list type override
       # @return [String] the full entry URI
+      # @raise [Utils::IriSanitizer::MissingLocalIdError] when local_id
+      #   is blank or sanitizes to nothing
       #
       # @example
       #   generate_entry_id("mitsubishi-heavy-industries")
@@ -100,6 +104,8 @@ module Ammitto
       #
       # @param local_id [String] the local announcement identifier
       # @return [String] the full announcement URI
+      # @raise [Utils::IriSanitizer::MissingLocalIdError] when local_id
+      #   is blank or sanitizes to nothing
       #
       def generate_announcement_id(local_id)
         Utils::IriSanitizer.announcement_iri(source_code.to_s, local_id)
@@ -109,6 +115,8 @@ module Ammitto
       #
       # @param local_id [String] the local legal instrument identifier
       # @return [String] the full legal instrument URI
+      # @raise [Utils::IriSanitizer::MissingLocalIdError] when local_id
+      #   is blank or sanitizes to nothing
       #
       def generate_legal_instrument_id(local_id)
         Utils::IriSanitizer.legal_instrument_iri(source_code.to_s, local_id)

--- a/lib/ammitto/utils/iri_sanitizer.rb
+++ b/lib/ammitto/utils/iri_sanitizer.rb
@@ -90,11 +90,11 @@ module Ammitto
         # @param value [Object] the rejected local id
         # @return [String] the error message
         def self.describe(source, kind, value)
-          "#{safe_label { source_label(source) }}: cannot build " \
-            "#{kind} IRI from blank or unusable local id " \
-            "#{safe_label { preview(value) }} — the source record is " \
-            'missing a usable identifier (refusing to emit an ' \
-            '"unknown" IRI)'
+          "#{safe_label { short_label(source) }}: cannot build " \
+            "#{safe_label { short_label(kind) }} IRI from blank or " \
+            "unusable local id #{safe_label { preview(value) }} — the " \
+            'source record is missing a usable identifier (refusing ' \
+            'to emit an "unknown" IRI)'
         end
 
         # Run a label builder, degrading to a placeholder if the value's
@@ -149,19 +149,22 @@ module Ammitto
           FIXED_SIZE_TYPES.include?(value.class)
         end
 
-        # Bounded source label for the message. Source codes are short
-        # strings or symbols drawn from a fixed list; anything else
-        # reports its class rather than risking an unbounded or
-        # overridable #to_s.
-        # @param source [Object] the source the IRI was requested for
+        # Bounded label for a short message component (the source code
+        # and the IRI kind). Both are short strings or symbols drawn
+        # from fixed lists; anything else reports its class rather than
+        # risking an unbounded or overridable #to_s. Applied to the kind
+        # as well as the source so no component of a diagnostic can
+        # outgrow or outlive the error it describes, even though every
+        # caller passes a literal kind today.
+        # @param value [Object] the component to label
         # @return [String] label, at most ~32 chars
-        def self.source_label(source)
-          label = if source.instance_of?(String)
-                    source
-                  elsif source.instance_of?(Symbol)
-                    source.name
+        def self.short_label(value)
+          label = if value.instance_of?(String)
+                    value
+                  elsif value.instance_of?(Symbol)
+                    value.name
                   else
-                    "#{source.class} instance"
+                    "#{value.class} instance"
                   end
           label.length > 32 ? "#{label[0, 29]}..." : label
         end

--- a/lib/ammitto/utils/iri_sanitizer.rb
+++ b/lib/ammitto/utils/iri_sanitizer.rb
@@ -223,6 +223,14 @@ module Ammitto
         # health gates surface the defective source file, rather than
         # collapsing distinct records into one shared "unknown" IRI.
         #
+        # The id is converted to a string exactly once. Local ids reach
+        # this method straight from parsed YAML, so #to_s may be
+        # heavyweight (an Array id materializes its whole contents) or
+        # non-idempotent; converting twice would double that cost and
+        # let the blank check and the sanitizer disagree about the same
+        # id. The unconverted id is still what MissingLocalIdError
+        # receives, so #preview keeps its exact-class dispatch.
+        #
         # @param local_id [Object] the raw local id
         # @param source [String] source code, for error attribution
         # @param kind [String] IRI kind (entity, entry, announcement, ...)
@@ -230,12 +238,9 @@ module Ammitto
         # @raise [MissingLocalIdError] when the id is nil/empty or
         #   sanitizes to an empty string
         def sanitize_local_id!(local_id, source:, kind:)
+          text = local_id.nil? ? '' : local_id.to_s
           sanitized =
-            if local_id.nil? || local_id.to_s.strip.empty?
-              ''
-            else
-              apply_sanitization_rules(local_id)
-            end
+            text.strip.empty? ? '' : apply_sanitization_rules(text)
           return sanitized unless sanitized.empty?
 
           raise MissingLocalIdError.new(source: source, kind: kind,

--- a/lib/ammitto/utils/iri_sanitizer.rb
+++ b/lib/ammitto/utils/iri_sanitizer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'date' # FIXED_SIZE_TYPES references Date at load time
+
 module Ammitto
   module Utils
     # IriSanitizer provides methods for sanitizing strings and generating
@@ -51,8 +53,126 @@ module Ammitto
       # Maximum length for a sanitized identifier
       MAX_ID_LENGTH = 64
 
-      # Default identifier when sanitization results in empty string
+      # Default identifier when sanitization results in empty string.
+      # Only non-identifying IRI components (source codes, list types,
+      # authority codes) may fall back to it — never a local id, where a
+      # shared "unknown" would merge distinct sanctioned parties into one
+      # record (the 2026-07-28 harvest audit: 37 Turkish designees
+      # collapsed into a single entity/tr/unknown).
       DEFAULT_ID = 'unknown'
+
+      # Raised when an IRI is requested for a record whose local id is
+      # nil, empty, or sanitizes to nothing. Carries the source code so
+      # per-file error attribution in the harmonize pipeline names the
+      # offending source record instead of silently emitting a shared
+      # ".../unknown" IRI.
+      class MissingLocalIdError < StandardError
+        attr_reader :source, :kind, :value
+
+        # @param source [String] source code the IRI was requested for
+        # @param kind [String] IRI kind (entity, entry, announcement, ...)
+        # @param value [Object] the rejected local id
+        def initialize(source:, kind:, value:)
+          @source = source
+          @kind = kind
+          @value = value
+          super(self.class.describe(source, kind, value))
+        end
+
+        # Build the message. Each label is produced defensively: a
+        # diagnostic must never mask the error it describes, so a value
+        # whose own methods raise (a singleton #size, an overridden
+        # #inspect) degrades to a placeholder instead of escaping as an
+        # unrelated exception. This complements the exact-class dispatch
+        # in #preview, which bounds how much work those labels can do.
+        # @param source [Object] source the IRI was requested for
+        # @param kind [String] IRI kind (entity, entry, ...)
+        # @param value [Object] the rejected local id
+        # @return [String] the error message
+        def self.describe(source, kind, value)
+          "#{safe_label { source_label(source) }}: cannot build " \
+            "#{kind} IRI from blank or unusable local id " \
+            "#{safe_label { preview(value) }} — the source record is " \
+            'missing a usable identifier (refusing to emit an ' \
+            '"unknown" IRI)'
+        end
+
+        # Run a label builder, degrading to a placeholder if the value's
+        # own methods raise
+        # @return [String]
+        def self.safe_label
+          yield
+        rescue StandardError
+          '(unprintable)'
+        end
+
+        # Classes whose #inspect is inherently short, so calling it to
+        # build a diagnostic cannot materialize a large string. Matched
+        # by EXACT class (see #renderable?): a subclass may override
+        # #inspect. Symbol and Integer are deliberately absent — their
+        # representations are unbounded (a 200k-character symbol, a
+        # million-digit integer), so they report their class instead.
+        FIXED_SIZE_TYPES = [NilClass, TrueClass, FalseClass, Float,
+                            Date, Time].freeze
+
+        # Bounded preview of the rejected id. No branch calls an
+        # unbounded or overridable conversion: a String is sliced before
+        # #inspect (escape expansion is capped afterwards), exact
+        # containers report class and size instead of inspecting
+        # elements, only exact fixed-size classes are inspected, and
+        # anything else — unknown objects, ANY subclass (whose #size or
+        # #inspect could raise or run long), Symbol, Integer — reports
+        # its class alone. Every branch is matched by exact class, and
+        # the result is capped regardless.
+        # @param value [Object] the rejected local id
+        # @return [String] inspect-style preview, at most ~64 chars
+        def self.preview(value)
+          text =
+            if value.instance_of?(Array) || value.instance_of?(Hash)
+              "#{value.class}(#{value.size} entries)"
+            elsif value.instance_of?(String)
+              sliced = value.length > 61 ? "#{value[0, 61]}..." : value
+              sliced.inspect
+            elsif renderable?(value)
+              value.inspect
+            else
+              "#{value.class} instance"
+            end
+          truncate(text)
+        end
+
+        # Whether a value may be rendered by #inspect: exact class only,
+        # so an overriding subclass never reaches #inspect
+        # @param value [Object] the value to test
+        # @return [Boolean]
+        def self.renderable?(value)
+          FIXED_SIZE_TYPES.include?(value.class)
+        end
+
+        # Bounded source label for the message. Source codes are short
+        # strings or symbols drawn from a fixed list; anything else
+        # reports its class rather than risking an unbounded or
+        # overridable #to_s.
+        # @param source [Object] the source the IRI was requested for
+        # @return [String] label, at most ~32 chars
+        def self.source_label(source)
+          label = if source.instance_of?(String)
+                    source
+                  elsif source.instance_of?(Symbol)
+                    source.name
+                  else
+                    "#{source.class} instance"
+                  end
+          label.length > 32 ? "#{label[0, 29]}..." : label
+        end
+
+        # Cap an already-built preview string
+        # @param str [String] inspect output
+        # @return [String] at most 64 characters
+        def self.truncate(str)
+          str.length > 64 ? "#{str[0, 61]}..." : str
+        end
+      end
 
       class << self
         # Sanitize a string for use as a URL-safe identifier.
@@ -90,15 +210,36 @@ module Ammitto
         def sanitize(str)
           return DEFAULT_ID if str.nil? || str.to_s.strip.empty?
 
-          sanitized = str.to_s
-                         .gsub(/\s+/, '-') # Replace whitespace with hyphens
-                         .gsub(/[^a-zA-Z0-9\-_]/, '') # Remove non-alphanumeric/hyphen/underscore chars
-                         .gsub(/--+/, '-')           # Collapse multiple hyphens
-                         .gsub(/^-|-$/, '')          # Remove leading/trailing hyphens
-                         .downcase                   # Lowercase
-                         .slice(0, MAX_ID_LENGTH)    # Truncate
+          sanitized = apply_sanitization_rules(str)
 
           sanitized.empty? ? DEFAULT_ID : sanitized
+        end
+
+        # Sanitize a local id for use in an identifying IRI, raising
+        # instead of falling back to DEFAULT_ID.
+        #
+        # Local ids identify individual records; a nil/empty id (or one
+        # that sanitizes to nothing) must fail loudly so the harmonize
+        # health gates surface the defective source file, rather than
+        # collapsing distinct records into one shared "unknown" IRI.
+        #
+        # @param local_id [Object] the raw local id
+        # @param source [String] source code, for error attribution
+        # @param kind [String] IRI kind (entity, entry, announcement, ...)
+        # @return [String] sanitized identifier
+        # @raise [MissingLocalIdError] when the id is nil/empty or
+        #   sanitizes to an empty string
+        def sanitize_local_id!(local_id, source:, kind:)
+          sanitized =
+            if local_id.nil? || local_id.to_s.strip.empty?
+              ''
+            else
+              apply_sanitization_rules(local_id)
+            end
+          return sanitized unless sanitized.empty?
+
+          raise MissingLocalIdError.new(source: source, kind: kind,
+                                        value: local_id)
         end
 
         # Generate an entity IRI (LIST-AGNOSTIC).
@@ -109,13 +250,16 @@ module Ammitto
         # @param source [String] Source code (e.g., "cn", "ru", "au")
         # @param local_id [String] Local entity identifier (unique within source)
         # @return [String] Full entity IRI
+        # @raise [MissingLocalIdError] when local_id is blank or
+        #   sanitizes to nothing
         #
         # @example
         #   entity_iri("cn", "mitsubishi-heavy-industries")
         #   # => "https://www.ammitto.org/entity/cn/mitsubishi-heavy-industries"
         #
         def entity_iri(source, local_id)
-          "#{BASE_URI}/entity/#{sanitize(source)}/#{sanitize(local_id)}"
+          id = sanitize_local_id!(local_id, source: source, kind: 'entity')
+          "#{BASE_URI}/entity/#{sanitize(source)}/#{id}"
         end
 
         # Generate an entry IRI (LIST-SPECIFIC).
@@ -127,6 +271,8 @@ module Ammitto
         # @param list_type [String] List type (e.g., "import-export-control-list")
         # @param local_id [String] Local entry identifier
         # @return [String] Full entry IRI
+        # @raise [MissingLocalIdError] when local_id is blank or
+        #   sanitizes to nothing
         #
         # @example Same entity, different lists
         #   entry_iri("cn", "import-export-control-list", "mitsubishi-heavy-industries")
@@ -136,7 +282,8 @@ module Ammitto
         #   # => "https://www.ammitto.org/entry/cn/unreliable-entity-list/mitsubishi-heavy-industries"
         #
         def entry_iri(source, list_type, local_id)
-          "#{BASE_URI}/entry/#{sanitize(source)}/#{sanitize(list_type)}/#{sanitize(local_id)}"
+          id = sanitize_local_id!(local_id, source: source, kind: 'entry')
+          "#{BASE_URI}/entry/#{sanitize(source)}/#{sanitize(list_type)}/#{id}"
         end
 
         # Generate an announcement IRI (LIST-AGNOSTIC).
@@ -146,13 +293,17 @@ module Ammitto
         # @param source [String] Source code (e.g., "cn", "ru", "au")
         # @param local_id [String] Local announcement identifier
         # @return [String] Full announcement IRI
+        # @raise [MissingLocalIdError] when local_id is blank or
+        #   sanitizes to nothing
         #
         # @example
         #   announcement_iri("cn", "mofcom-2026-11")
         #   # => "https://www.ammitto.org/announcement/cn/mofcom-2026-11"
         #
         def announcement_iri(source, local_id)
-          "#{BASE_URI}/announcement/#{sanitize(source)}/#{sanitize(local_id)}"
+          id = sanitize_local_id!(local_id, source: source,
+                                            kind: 'announcement')
+          "#{BASE_URI}/announcement/#{sanitize(source)}/#{id}"
         end
 
         # Generate a legal instrument IRI (LIST-AGNOSTIC).
@@ -162,13 +313,17 @@ module Ammitto
         # @param source [String] Source code (e.g., "cn", "ru", "au")
         # @param local_id [String] Local legal instrument identifier
         # @return [String] Full legal instrument IRI
+        # @raise [MissingLocalIdError] when local_id is blank or
+        #   sanitizes to nothing
         #
         # @example
         #   legal_instrument_iri("cn", "export-control-law")
         #   # => "https://www.ammitto.org/legal_instrument/cn/export-control-law"
         #
         def legal_instrument_iri(source, local_id)
-          "#{BASE_URI}/legal_instrument/#{sanitize(source)}/#{sanitize(local_id)}"
+          id = sanitize_local_id!(local_id, source: source,
+                                            kind: 'legal_instrument')
+          "#{BASE_URI}/legal_instrument/#{sanitize(source)}/#{id}"
         end
 
         # Generate an authority IRI.
@@ -323,6 +478,8 @@ module Ammitto
         #
         # @param entry_iri [String] An entry IRI
         # @return [String, nil] The corresponding entity IRI
+        # @raise [MissingLocalIdError] when the parsed local id segment
+        #   sanitizes to nothing
         #
         # @example
         #   entity_iri_from_entry("https://www.ammitto.org/entry/cn/import-export-control-list/mitsubishi-heavy-industries")
@@ -341,11 +498,29 @@ module Ammitto
         # @param local_id [String] Entity local ID
         # @param list_types [Array<String>] List of list types
         # @return [Array<String>] Array of entry IRIs
+        # @raise [MissingLocalIdError] when local_id is blank or
+        #   sanitizes to nothing
         #
         def entry_iris_for_entity(source, local_id, list_types)
           list_types.map do |list_type|
             entry_iri(source, list_type, local_id)
           end
+        end
+
+        private
+
+        # The shared sanitization pipeline; may return an empty string
+        # (callers decide between DEFAULT_ID fallback and raising)
+        # @param str [Object] the string to sanitize
+        # @return [String] sanitized identifier, possibly empty
+        def apply_sanitization_rules(str)
+          str.to_s
+             .gsub(/\s+/, '-') # Replace whitespace with hyphens
+             .gsub(/[^a-zA-Z0-9\-_]/, '') # Remove non-alphanumeric/hyphen/underscore chars
+             .gsub(/--+/, '-')           # Collapse multiple hyphens
+             .gsub(/^-|-$/, '')          # Remove leading/trailing hyphens
+             .downcase                   # Lowercase
+             .slice(0, MAX_ID_LENGTH)    # Truncate
         end
       end
     end

--- a/spec/ammitto/cli/harmonize_command_spec.rb
+++ b/spec/ammitto/cli/harmonize_command_spec.rb
@@ -278,8 +278,11 @@ RSpec.describe Ammitto::Cmd::HarmonizeCommand do
 
         result = command.send(:harmonize_source, :us)
 
-        expect(result[:status]).to eq(:error)
-        expect(result[:error]).to match(/directory/i)
+        # A load error is a per-file defect, attributed to its file and
+        # collected in :errors — the gate treats those as never exempt,
+        # where a source-level :error would have been --allow-empty'able
+        expect(result[:status]).to eq(:success)
+        expect(result[:errors].join).to match(/broken\.yaml.*directory/i)
       end
     end
   end

--- a/spec/ammitto/utils/iri_sanitizer_spec.rb
+++ b/spec/ammitto/utils/iri_sanitizer_spec.rb
@@ -79,6 +79,196 @@ RSpec.describe Ammitto::Utils::IriSanitizer do
     end
   end
 
+  describe 'blank local ids' do
+    it 'raises MissingLocalIdError for a nil entity local id' do
+      expect { described_class.entity_iri('tr', nil) }.to raise_error(
+        described_class::MissingLocalIdError,
+        /tr: cannot build entity IRI from blank or unusable local id nil/
+      )
+    end
+
+    it 'raises for an empty or whitespace-only local id' do
+      expect { described_class.entity_iri('tr', '') }
+        .to raise_error(described_class::MissingLocalIdError)
+      expect { described_class.entity_iri('tr', '   ') }
+        .to raise_error(described_class::MissingLocalIdError)
+    end
+
+    it 'raises for a local id that sanitizes to an empty string' do
+      expect { described_class.entity_iri('us', '!!!') }.to raise_error(
+        described_class::MissingLocalIdError,
+        /us: cannot build entity IRI from blank or unusable local id "!!!"/
+      )
+    end
+
+    it 'raises for blank entry, announcement, and instrument local ids' do
+      expect { described_class.entry_iri('tr', 'list', nil) }
+        .to raise_error(described_class::MissingLocalIdError, /entry IRI/)
+      expect { described_class.announcement_iri('cn', nil) }
+        .to raise_error(described_class::MissingLocalIdError,
+                        /announcement IRI/)
+      expect { described_class.legal_instrument_iri('cn', ' ') }
+        .to raise_error(described_class::MissingLocalIdError,
+                        /legal_instrument IRI/)
+    end
+
+    it 'carries source, kind, and value on the error' do
+      expect { described_class.entity_iri('jp', nil) }
+        .to raise_error(described_class::MissingLocalIdError) do |error|
+          expect(error.source).to eq('jp')
+          expect(error.kind).to eq('entity')
+          expect(error.value).to be_nil
+        end
+    end
+
+    it 'truncates oversized rejected ids in the message' do
+      huge = '!' * 5000 # sanitizes to nothing, preview stays bounded
+
+      expect { described_class.entity_iri('us', huge) }
+        .to raise_error(described_class::MissingLocalIdError) do |error|
+          expect(error.message.length).to be < 300
+          expect(error.value).to eq(huge)
+        end
+    end
+
+    it 'summarizes container ids instead of inspecting every element' do
+      # Inspecting the whole container would build a ~500 KB string
+      # just to report the error
+      bulky = ['!'] * 100_000
+
+      expect { described_class.entity_iri('us', bulky) }
+        .to raise_error(described_class::MissingLocalIdError) do |error|
+          expect(error.message).to include('Array(100000 entries)')
+          expect(error.message.length).to be < 300
+        end
+    end
+
+    it 'never inspects an unknown object type' do
+      # #to_s is legitimately called to sanitize the id; #inspect is
+      # purely diagnostic and could return anything, so it must not run
+      hostile = Class.new do
+        def to_s
+          '!' # sanitizes to nothing, so the id is rejected
+        end
+
+        def inspect
+          raise 'inspect must not be called on an unknown object type'
+        end
+      end.new
+
+      expect { described_class.entity_iri('us', hostile) }
+        .to raise_error(described_class::MissingLocalIdError) do |error|
+          expect(error.message).to include('instance')
+          expect(error.message.length).to be < 300
+        end
+    end
+
+    it 'never calls to_s on an unknown source object' do
+      hostile_source = Class.new do
+        def to_s
+          raise 'to_s must not be called on an unknown source'
+        end
+      end.new
+
+      expect { described_class.entity_iri(hostile_source, nil) }
+        .to raise_error(described_class::MissingLocalIdError) do |error|
+          expect(error.message.length).to be < 300
+        end
+    end
+
+    it 'reports variable-length id types by class, not by value' do
+      # A symbol's representation is unbounded, so it is never rendered
+      huge_symbol = ('!' * 200_000).to_sym
+
+      expect { described_class.entity_iri('us', huge_symbol) }
+        .to raise_error(described_class::MissingLocalIdError) do |error|
+          expect(error.message).to include('Symbol instance')
+          expect(error.message.length).to be < 300
+        end
+    end
+
+    it 'still raises MissingLocalIdError when the id itself misbehaves' do
+      # Singleton overrides can defeat any dispatch rule, so the message
+      # builder degrades rather than letting a foreign exception escape
+      hostile = []
+      def hostile.size
+        raise 'size must not escape'
+      end
+
+      def hostile.to_s
+        '!' # sanitizes to nothing, so the id is rejected
+      end
+
+      expect { described_class.entity_iri('us', hostile) }
+        .to raise_error(described_class::MissingLocalIdError,
+                        /\(unprintable\)/)
+    end
+
+    it 'never calls size on a container subclass' do
+      # An overridden #size must not escape as an arbitrary exception
+      # in place of MissingLocalIdError
+      hostile = Class.new(Array) do
+        def to_s
+          '!' # sanitizes to nothing, so the id is rejected
+        end
+
+        def size
+          raise 'size must not be called on a container subclass'
+        end
+      end.new
+
+      expect { described_class.entity_iri('us', hostile) }
+        .to raise_error(described_class::MissingLocalIdError) do |error|
+          expect(error.message.length).to be < 300
+        end
+    end
+
+    it 'never inspects a subclass that could override inspect' do
+      hostile = Class.new(Numeric) do
+        def to_s
+          '!' # sanitizes to nothing, so the id is rejected
+        end
+
+        def inspect
+          raise 'inspect must not be called on a subclass'
+        end
+      end.new
+
+      expect { described_class.entity_iri('us', hostile) }
+        .to raise_error(described_class::MissingLocalIdError) do |error|
+          expect(error.message.length).to be < 300
+        end
+    end
+
+    it 'still renders fixed-size id types by value' do
+      expect { described_class.entity_iri('us', nil) }
+        .to raise_error(described_class::MissingLocalIdError, /\bnil\b/)
+    end
+
+    it 'bounds an oversized source in the message' do
+      expect { described_class.entity_iri('x' * 100_000, nil) }
+        .to raise_error(described_class::MissingLocalIdError) do |error|
+          expect(error.message.length).to be < 300
+        end
+    end
+
+    it 'keeps the preview bounded when escapes expand under inspect' do
+      # Control characters inspect to 4 chars each ("\x01"); the cap
+      # must apply to the inspected form, not just the raw slice
+      noisy = "\x01" * 5000
+
+      expect { described_class.entity_iri('us', noisy) }
+        .to raise_error(described_class::MissingLocalIdError) do |error|
+          expect(error.message.length).to be < 300
+        end
+    end
+
+    it 'still accepts a literal "unknown" id string' do
+      expect(described_class.entity_iri('cn', 'unknown'))
+        .to eq('https://www.ammitto.org/entity/cn/unknown')
+    end
+  end
+
   describe '.entity_iri' do
     it 'generates LIST-AGNOSTIC entity IRI (no list_type)' do
       iri = described_class.entity_iri('cn', 'mitsubishi-heavy-industries')

--- a/spec/ammitto/utils/iri_sanitizer_spec.rb
+++ b/spec/ammitto/utils/iri_sanitizer_spec.rb
@@ -101,6 +101,35 @@ RSpec.describe Ammitto::Utils::IriSanitizer do
       )
     end
 
+    it 'converts a local id to a string exactly once' do
+      # #to_s may be heavyweight (an Array id materializes its whole
+      # contents) and reaches this method straight from parsed YAML,
+      # so neither the accepted nor the rejected path may convert twice
+      counter = Class.new do
+        attr_reader :calls
+
+        def initialize(text)
+          @text = text
+          @calls = 0
+        end
+
+        def to_s
+          @calls += 1
+          @text
+        end
+      end
+
+      accepted = counter.new('abc-123')
+      expect(described_class.entity_iri('tr', accepted))
+        .to eq('https://www.ammitto.org/entity/tr/abc-123')
+      expect(accepted.calls).to eq(1)
+
+      rejected = counter.new('!!!')
+      expect { described_class.entity_iri('tr', rejected) }
+        .to raise_error(described_class::MissingLocalIdError)
+      expect(rejected.calls).to eq(1)
+    end
+
     it 'raises for blank entry, announcement, and instrument local ids' do
       expect { described_class.entry_iri('tr', 'list', nil) }
         .to raise_error(described_class::MissingLocalIdError, /entry IRI/)

--- a/spec/ammitto/utils/iri_sanitizer_spec.rb
+++ b/spec/ammitto/utils/iri_sanitizer_spec.rb
@@ -281,6 +281,33 @@ RSpec.describe Ammitto::Utils::IriSanitizer do
         end
     end
 
+    it 'bounds the kind the same way as the source' do
+      # Every caller passes a literal kind, but no component of a
+      # diagnostic may outgrow or outlive the error it describes
+      error = described_class::MissingLocalIdError.new(
+        source: 'jp', kind: 'k' * 100_000, value: nil
+      )
+
+      expect(error.message.length).to be < 300
+    end
+
+    it 'still raises MissingLocalIdError when the kind misbehaves' do
+      # A kind whose #to_s raises must not replace the error with an
+      # unrelated exception, and must not reach #to_s at all
+      hostile = Class.new do
+        def to_s
+          raise 'kind #to_s must not escape'
+        end
+      end.new
+
+      error = described_class::MissingLocalIdError.new(
+        source: 'jp', kind: hostile, value: nil
+      )
+
+      expect(error).to be_a(described_class::MissingLocalIdError)
+      expect(error.message.length).to be < 300
+    end
+
     it 'keeps the preview bounded when escapes expand under inspect' do
       # Control characters inspect to 4 chars each ("\x01"); the cap
       # must apply to the inspected form, not just the raw slice

--- a/spec/integration/ingestion_robustness_spec.rb
+++ b/spec/integration/ingestion_robustness_spec.rb
@@ -240,6 +240,19 @@ RSpec.describe 'harmonize ingestion robustness (integration)' do
       expect(result[:entry]['period']['listedDate']).to be_nil
     end
 
+    it 'routes a jp "individual" record to a person entity' do
+      # Jp::Entity is the other model carrying a custom from_hash, and
+      # its map_entity_type normalization only reaches harmonize now
+      # that the round-trip is gone. The old from_yaml path handed the
+      # transformer a raw "individual", which fell to the else branch
+      # and filed a natural person as an organization.
+      data = { 'id' => '1', 'name' => 'John Doe',
+               'entity_type' => 'individual', 'addresses' => ['Tokyo'] }
+
+      result = transform(:jp, data)
+      expect(result[:entity]['entityType']).to eq('person')
+    end
+
     it 'casts un_vessels integers the way the yaml path casts them' do
       # A bare to_i defeated the attribute's own Integer cast, turning a
       # grouped "12,500" tonnage into 12 — a plausible-looking number

--- a/spec/integration/ingestion_robustness_spec.rb
+++ b/spec/integration/ingestion_robustness_spec.rb
@@ -1,0 +1,381 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+require 'fileutils'
+require 'date'
+require 'ammitto'
+require 'ammitto/cli'
+require 'ammitto/cli/harmonize_command'
+
+%w[uk/designation eu/sanction_entity un/individual un/entity us/sdn_entry
+   wb/sanctioned_firm au/sanctions_list ca/sanctions_list ch/sanctions_list
+   ru/sanctions_list nz/sanctions_list tr/sanctions_list eu_vessels/vessel
+   jp/entity un_vessels/vessel].each { |f| require "ammitto/sources/#{f}" }
+
+# Ingestion robustness: every per-entity source path must survive YAML
+# anchors in its input (no from_yaml(data.to_yaml) round-trip through the
+# aliases-disabled Lutaml loader), announcement-format YAML must be
+# rejected loudly on the legacy ch/us/uk paths, and records without a
+# usable local id must raise instead of collapsing into a shared
+# ".../unknown" IRI.
+RSpec.describe 'harmonize ingestion robustness (integration)' do
+  # Minimal fetch-shaped data per source path, keyed by the dispatch
+  # source symbol. Multi-model sources (un, au, nz) carry one fixture
+  # per model branch.
+  source_fixtures = {
+    uk: [{
+      'unique_id' => 'UK0001', 'regime_name' => 'Russia',
+      'individual_entity_ship' => 'Individual',
+      'names' => { 'names' => [{ 'name6' => 'John Doe',
+                                 'name_type' => 'Primary Name' }] }
+    }],
+    eu: [{
+      'logical_id' => '55', 'eu_reference_number' => 'EU.55',
+      'subject_type' => { 'code' => 'person' },
+      'name_aliases' => [{ 'whole_name' => 'John Doe' }],
+      'birthdates' => [{ 'birthdate' => '1964-07-17' }]
+    }],
+    un: [
+      { 'dataid' => '123', 'reference_number' => 'QDi.001',
+        'first_name' => 'John', 'second_name' => 'Doe',
+        'gender' => 'male', 'listed_on' => '2001-10-08' },
+      { 'dataid' => '124', 'reference_number' => 'QDe.001',
+        'first_name' => 'ACME CORP', 'listed_on' => '2001-10-08' }
+    ],
+    us: [{
+      'uid' => '12345', 'first_name' => 'John', 'last_name' => 'DOE',
+      'sdn_type' => 'Individual'
+    }],
+    wb: [{
+      'supp_id' => 100, 'supp_name' => 'ACME LTD',
+      'entity_type' => 'organization', 'country_name' => 'Utopia',
+      'debar_from_date' => Date.new(2020, 1, 2),
+      'debar_to_date' => '2025-01-02'
+    }],
+    au: [
+      { 'reference' => '7', 'imo_number' => 'IMO 12345',
+        'names' => [{ 'text' => 'SHIP X', 'name_type' => 'primary' }] },
+      { 'reference' => '8577', 'dates_of_birth' => [],
+        'names' => [{ 'text' => 'John Doe', 'name_type' => 'primary' }] },
+      { 'reference' => '9000',
+        'names' => [{ 'text' => 'ACME', 'name_type' => 'primary' }] }
+    ],
+    ca: [{
+      'country' => 'Iran', 'schedule' => '1', 'item' => '5',
+      'last_name' => 'DOE', 'given_name' => 'John',
+      'entity_type' => 'person', 'date_of_listing' => '2020-01-01'
+    }],
+    ch: [{
+      'ssid' => '111',
+      'names' => [{ 'name_parts' => [
+        { 'name_part_type' => 'given-name', 'value' => 'Vladimir' },
+        { 'name_part_type' => 'family-name', 'value' => 'Testov' }
+      ] }]
+    }],
+    ru: [{
+      'russian_name' => 'Иванов', 'english_name' => 'Ivanov',
+      'entity_type' => 'person', 'announcement_number' => '123',
+      'list_type' => 'stop_list'
+    }],
+    nz: [
+      { 'type' => 'Individual', 'unique_identifier' => 'IND-001' },
+      { 'type' => 'Ship', 'unique_identifier' => 'SHP-001',
+        'imo_number' => '999', 'name' => 'SHIP Y',
+        'date_of_sanction' => Date.new(2022, 3, 4) },
+      { 'type' => 'Entity', 'unique_identifier' => 'ENT-001',
+        'name' => 'ACME' }
+    ],
+    tr: [{
+      'name' => 'ACME', 'entity_type' => 'Entity', 'program' => '6415',
+      'listed_date' => '2020-01-01', 'reference_number' => 'TR-1'
+    }],
+    eu_vessels: [{
+      'vessel_name' => 'SHIP Z', 'imo_number' => '12345',
+      'date_of_application' => Date.new(2024, 5, 6)
+    }],
+    jp: [{
+      'id' => '1', 'name' => 'ACME', 'entity_type' => 'organization',
+      'addresses' => ['Tokyo']
+    }],
+    un_vessels: [{
+      'id' => 'V1', 'imo_number' => '456',
+      'names' => [{ 'full_name' => 'SHIP W', 'is_primary' => true }],
+      'date_designated' => Date.new(2021, 2, 3), 'resolution' => 'RES 1'
+    }]
+  }.freeze
+
+  announcement_data = {
+    'announcement' => { 'id' => 'mofcom-2026-11',
+                        'date' => '2026-11-01' },
+    'sanction_details' => { 'entities' => [{ 'name' => 'ACME' }] }
+  }.freeze
+
+  let(:exporter_dir) { Dir.mktmpdir('ammitto_ingestion_robustness') }
+  let(:command) { Ammitto::Cmd::HarmonizeCommand.new({}, []) }
+
+  before do
+    command.instance_variable_set(
+      :@exporter,
+      Ammitto::Serialization::JsonLdGraphExporter.new(output_dir: exporter_dir)
+    )
+  end
+
+  after do
+    FileUtils.rm_rf(exporter_dir)
+  end
+
+  def transform(source, data)
+    command.send(:transform_data, source, data)
+  end
+
+  def expect_complete_pair(result)
+    pair = result.is_a?(Array) ? result.first : result
+    expect(pair[:entity]).to include('@id')
+    expect(pair[:entry]).to include('@id')
+  end
+
+  # A hash shared between two keys re-emits YAML anchors on any
+  # to_yaml re-dump — exactly what jp harvest files carry after
+  # YAML.safe_load_file(..., aliases: true). The old
+  # from_yaml(data.to_yaml) round-trip fed those anchors back into the
+  # aliases-disabled Lutaml loader (Psych::AliasesNotEnabled).
+  def with_anchor(data)
+    shared = { 'shared' => 'anchored block' }
+    data.merge('anchored_a' => shared, 'anchored_b' => shared)
+  end
+
+  describe 'anchored-YAML round-trip immunity' do
+    source_fixtures.each do |source, fixtures|
+      fixtures.each_with_index do |data, index|
+        it "harmonizes #{source} fixture #{index} with YAML anchors" do
+          anchored = with_anchor(data)
+          # Sanity: the fixture genuinely re-emits an alias when dumped
+          expect(anchored.to_yaml).to include('*')
+
+          expect_complete_pair(transform(source, anchored))
+        end
+      end
+    end
+
+    it 'parses an alias-consuming mapped field through the hash path' do
+      # The consumed name_parts array IS the aliased node (*p): loading
+      # yields one shared array object, so any to_yaml re-dump re-emits
+      # the anchor — the exact shape that killed the old round-trip
+      data = YAML.safe_load(<<~YAML, aliases: true)
+        ssid: '111'
+        shared_parts: &p
+          - name_part_type: given-name
+            value: Vladimir
+          - name_part_type: family-name
+            value: Testov
+        names:
+          - name_parts: *p
+      YAML
+      expect(data.to_yaml).to include('*') # genuinely re-anchored
+
+      result = transform(:ch, data)
+      expect(result[:entity]['names'].first['fullName'])
+        .to include('Vladimir')
+    end
+
+    it 'preserves uk wrapper-mapped names through the hash path' do
+      result = transform(:uk, with_anchor(source_fixtures[:uk].first))
+
+      expect(result[:entity]['names'].map { |n| n['fullName'] })
+        .to include('John Doe')
+    end
+
+    it 'preserves un_vessels names and designation date' do
+      result = transform(:un_vessels,
+                         with_anchor(source_fixtures[:un_vessels].first))
+
+      expect(result[:entity]['names'].map { |n| n['fullName'] })
+        .to include('SHIP W')
+      expect(result[:entry]['period']['listedDate'])
+        .to eq(Date.new(2021, 2, 3))
+    end
+
+    it 'accepts the un_vessels fetch-time date key too' do
+      data = source_fixtures[:un_vessels].first.dup
+      data.delete('date_designated')
+      data['designation_date'] = '2021-02-03'
+
+      result = transform(:un_vessels, data)
+      expect(result[:entry]['period']['listedDate'])
+        .to eq(Date.new(2021, 2, 3))
+    end
+
+    it 'falls past a blank un_vessels date key to the serialized one' do
+      data = source_fixtures[:un_vessels].first
+                                         .merge('designation_date' => '')
+
+      result = transform(:un_vessels, data)
+      expect(result[:entry]['period']['listedDate'])
+        .to eq(Date.new(2021, 2, 3))
+    end
+  end
+
+  # Au::Transformer#transform_from_hash is a second, independent entry
+  # point (external callers reach it directly, not through
+  # HarmonizeCommand#transform_au), so its three model constructions
+  # need their own anchored coverage.
+  describe 'Au::Transformer#transform_from_hash' do
+    let(:transformer) { Ammitto::Sources::Au::Transformer.new }
+
+    {
+      'person' => { 'type' => 'person', 'reference' => '8577',
+                    'names' => [{ 'text' => 'John Doe',
+                                  'name_type' => 'primary' }] },
+      'vessel' => { 'type' => 'vessel', 'reference' => '7',
+                    'imo_number' => 'IMO 12345',
+                    'names' => [{ 'text' => 'SHIP X',
+                                  'name_type' => 'primary' }] },
+      'organization' => { 'reference' => '9000',
+                          'names' => [{ 'text' => 'ACME',
+                                        'name_type' => 'primary' }] }
+    }.each do |kind, data|
+      it "transforms an anchored #{kind} hash" do
+        anchored = with_anchor(data)
+        expect(anchored.to_yaml).to include('*') # genuinely re-anchored
+
+        result = transformer.transform_from_hash(anchored)
+
+        expect(result[:entity].id).to include('entity/au/')
+        expect(result[:entry].id).to include('entry/au/')
+      end
+    end
+  end
+
+  # The from_hash migration must not widen any mapping block beyond the
+  # format it already covered. UnVessels::Vessel declares only a yaml
+  # block, so JSON keeps the attribute-name key 'designation_date';
+  # converting it to key_value would silently repoint JSON at
+  # 'date_designated' and break existing payloads.
+  describe 'un_vessels JSON contract' do
+    let(:vessel) do
+      Ammitto::Sources::UnVessels::Vessel.new.tap do |v|
+        v.id = 'V1'
+        v.imo_number = '456'
+        v.designation_date = Date.new(2021, 2, 3)
+      end
+    end
+
+    it 'still emits the attribute-name JSON key' do
+      expect(JSON.parse(vessel.to_json)).to include(
+        'designation_date' => '2021-02-03'
+      )
+    end
+
+    it 'still parses the attribute-name JSON key' do
+      parsed = Ammitto::Sources::UnVessels::Vessel.from_json(
+        { 'id' => 'V1', 'designation_date' => '2021-02-03' }.to_json
+      )
+
+      expect(parsed.designation_date).to eq(Date.new(2021, 2, 3))
+    end
+
+    it 'still maps the YAML key to the same attribute' do
+      parsed = Ammitto::Sources::UnVessels::Vessel.from_yaml(
+        { 'id' => 'V1', 'date_designated' => '2021-02-03' }.to_yaml
+      )
+
+      expect(parsed.designation_date).to eq(Date.new(2021, 2, 3))
+    end
+  end
+
+  describe 'announcement-format guards (ch/us/uk)' do
+    %i[ch us uk].each do |source|
+      it "rejects announcement-format YAML on the #{source} path" do
+        expect { transform(source, announcement_data) }
+          .to raise_error(
+            Ammitto::Cmd::HarmonizeCommand::AnnouncementFormatError,
+            /announcement-format YAML detected.*#{source}/m
+          )
+      end
+
+      it "keeps correct-schema #{source} input working" do
+        expect_complete_pair(transform(source, source_fixtures[source].first))
+      end
+    end
+
+    %w[announcement sanction_details measure_modifications].each do |marker|
+      it "rejects a lone #{marker} marker key" do
+        expect { transform(:ch, { marker => { 'id' => 'x' } }) }
+          .to raise_error(
+            Ammitto::Cmd::HarmonizeCommand::AnnouncementFormatError,
+            /top-level #{marker}\b/
+          )
+      end
+    end
+
+    it 'fails the run non-zero with per-file attribution (end to end)' do
+      Dir.mktmpdir do |dir|
+        processed = File.join(dir, 'data-ch', 'processed')
+        FileUtils.mkdir_p(processed)
+        File.write(File.join(processed, '20261101.yaml'),
+                   announcement_data.to_yaml)
+
+        options = { sources_dir: dir,
+                    output_dir: File.join(dir, 'api', 'v1') }
+        expect { Ammitto::Cmd::HarmonizeCommand.new(options, ['ch']).run }
+          .to raise_error(Thor::Error,
+                          /20261101\.yaml: announcement-format YAML detected/)
+      end
+    end
+  end
+
+  describe 'blank local ids raise instead of collapsing to "unknown"' do
+    it 'fails the tr path loudly for a record without reference_number' do
+      data = source_fixtures[:tr].first.merge('reference_number' => nil)
+
+      expect { transform(:tr, data) }.to raise_error(
+        Ammitto::Utils::IriSanitizer::MissingLocalIdError,
+        /tr: cannot build entity IRI from blank or unusable local id/
+      )
+    end
+
+    it 'fails the jp path loudly for a record without id' do
+      data = source_fixtures[:jp].first.merge('id' => nil)
+
+      expect { transform(:jp, data) }.to raise_error(
+        Ammitto::Utils::IriSanitizer::MissingLocalIdError,
+        /jp: cannot build entity IRI from blank or unusable local id/
+      )
+    end
+
+    it 'fails the jp path for a punctuation-only id (the jp/jp trap)' do
+      # "JP-!!!" would sanitize to the constant "jp" and collapse into
+      # entity/jp/jp; the unusable id must raise instead
+      data = source_fixtures[:jp].first.merge('id' => '!!!')
+
+      expect { transform(:jp, data) }.to raise_error(
+        Ammitto::Utils::IriSanitizer::MissingLocalIdError, /jp:/
+      )
+    end
+
+    it 'fails the us path loudly for an SDN record without uid' do
+      data = source_fixtures[:us].first.merge('uid' => nil)
+
+      expect { transform(:us, data) }.to raise_error(
+        Ammitto::Utils::IriSanitizer::MissingLocalIdError,
+        /us: cannot build entity IRI from blank or unusable local id/
+      )
+    end
+
+    it 'fails the whole tr slice at the health gate (end to end)' do
+      Dir.mktmpdir do |dir|
+        processed = File.join(dir, 'data-tr', 'processed')
+        FileUtils.mkdir_p(processed)
+        File.write(File.join(processed, 'tr-1.yaml'),
+                   source_fixtures[:tr].first
+                     .merge('reference_number' => nil).to_yaml)
+
+        options = { sources_dir: dir,
+                    output_dir: File.join(dir, 'api', 'v1') }
+        expect { Ammitto::Cmd::HarmonizeCommand.new(options, ['tr']).run }
+          .to raise_error(Thor::Error,
+                          /tr-1\.yaml: tr: cannot build entity IRI/)
+      end
+    end
+  end
+end

--- a/spec/integration/ingestion_robustness_spec.rb
+++ b/spec/integration/ingestion_robustness_spec.rb
@@ -215,6 +215,55 @@ RSpec.describe 'harmonize ingestion robustness (integration)' do
     end
   end
 
+  # The from_hash migration claims every converted call site accepts
+  # exactly the shape from_yaml accepted. Asserting only that a
+  # harmonized pair carries an @id would still pass if names, dates, or
+  # nested collections were silently dropped — the very failure mode
+  # this PR exists to remove — so compare the built models themselves.
+  #
+  # This differential is deliberately not the whole guarantee. A
+  # key_value mapping governs from_hash AND from_yaml, so losing one
+  # degrades both sides equally and stays invisible here; the two sites
+  # that carry that risk (the uk wrapper mappings and the un_vessels
+  # from_hash override) are pinned by value above, and dropping either
+  # fails those examples.
+  describe 'from_hash/from_yaml model equivalence' do
+    # Capture the model the dispatcher actually built, without
+    # duplicating its source-to-class branching here: stand a recorder
+    # in for the transformer and keep the first argument it is handed.
+    # Throwing unwinds the dispatcher the moment the model exists, so
+    # nothing downstream of the transformer has to be simulated.
+    def captured_model(source, data)
+      recorder = Object.new
+      recorder.define_singleton_method(:respond_to_missing?) do |*|
+        true
+      end
+      recorder.define_singleton_method(:method_missing) do |_name, *args|
+        throw :captured_model, args.first
+      end
+      allow(Ammitto::Transformers::Registry)
+        .to receive(:get).and_return(recorder)
+
+      catch(:captured_model) do
+        command.send(:transform_data, source, data)
+        nil
+      end
+    end
+
+    source_fixtures.each do |source, fixtures|
+      fixtures.each_with_index do |data, index|
+        it "builds #{source} fixture #{index} the same either way" do
+          model = captured_model(source, data)
+          expect(model).not_to be_nil
+
+          # Same class both ways: the only variable is the deserializer
+          legacy = model.class.from_yaml(data.to_yaml)
+          expect(model.to_yaml).to eq(legacy.to_yaml)
+        end
+      end
+    end
+  end
+
   # Au::Transformer#transform_from_hash is a second, independent entry
   # point (external callers reach it directly, not through
   # HarmonizeCommand#transform_au), so its three model constructions

--- a/spec/integration/ingestion_robustness_spec.rb
+++ b/spec/integration/ingestion_robustness_spec.rb
@@ -450,27 +450,35 @@ RSpec.describe 'harmonize ingestion robustness (integration)' do
         .to raise_error(ArgumentError, /id must hold a single value/)
     end
 
-    it 'refuses a container in any other jp scalar slot' do
-      expect { transform(:jp, { 'id' => '1', 'name' => %w[a b] }) }
-        .to raise_error(ArgumentError, /name must hold a single value/)
+    # Every guarded slot gets its own example, so dropping fetch_scalar
+    # from any single field fails the suite rather than hiding behind a
+    # sibling field's coverage
+    {
+      jp: %w[id name name_ja entity_type source_url remarks],
+      un_vessels: %w[id entity_type imo_number flag_state tonnage
+                     build_year date_designated resolution]
+    }.each do |source, fields|
+      fields.each do |field|
+        it "refuses a container in the #{source} #{field} slot" do
+          data = source_fixtures[source].first.merge(field => %w[a b])
+
+          expect { transform(source, data) }
+            .to raise_error(ArgumentError,
+                            /#{field} must hold a single value/)
+        end
+      end
     end
 
-    it 'refuses a un_vessels list imo_number' do
+    it 'refuses the un_vessels row alias when canonical is absent' do
+      # The alias is only consulted when the canonical key is missing,
+      # so its guard needs the canonical key genuinely absent
       data = source_fixtures[:un_vessels].first
-                                         .merge('imo_number' => %w[a b])
+                                         .except('date_designated')
+                                         .merge('designation_date' => %w[a b])
 
       expect { transform(:un_vessels, data) }
         .to raise_error(ArgumentError,
-                        /imo_number must hold a single value/)
-    end
-
-    it 'refuses a un_vessels list date without consulting the alias' do
-      data = source_fixtures[:un_vessels].first
-                                         .merge('date_designated' => %w[a b])
-
-      expect { transform(:un_vessels, data) }
-        .to raise_error(ArgumentError,
-                        /date_designated must hold a single value/)
+                        /designation_date must hold a single value/)
     end
 
     # The guard must reject containers only: every scalar YAML scalar

--- a/spec/integration/ingestion_robustness_spec.rb
+++ b/spec/integration/ingestion_robustness_spec.rb
@@ -378,4 +378,33 @@ RSpec.describe 'harmonize ingestion robustness (integration)' do
       end
     end
   end
+
+  describe 'unparseable YAML is a per-file error, not a source error' do
+    run_with = lambda do |dir, extra|
+      processed = File.join(dir, 'data-tr', 'processed')
+      FileUtils.mkdir_p(processed)
+      File.write(File.join(processed, 'ok.yaml'),
+                 source_fixtures[:tr].first.to_yaml)
+      File.write(File.join(processed, 'broken.yaml'), "a:\n  - [unterminated\n")
+
+      options = { sources_dir: dir,
+                  output_dir: File.join(dir, 'api', 'v1') }.merge(extra)
+      Ammitto::Cmd::HarmonizeCommand.new(options, ['tr']).run
+    end
+
+    it 'attributes the parse failure to its file and keeps the good ones' do
+      Dir.mktmpdir do |dir|
+        expect { run_with.call(dir, {}) }
+          .to raise_error(Thor::Error, /broken\.yaml/)
+      end
+    end
+
+    it 'is not cleared by --allow-empty (per-file errors never are)' do
+      Dir.mktmpdir do |dir|
+        expect { run_with.call(dir, allow_empty: 'tr') }
+          .to raise_error(Thor::Error,
+                          /tr: 1 file\(s\) failed to transform/)
+      end
+    end
+  end
 end

--- a/spec/integration/ingestion_robustness_spec.rb
+++ b/spec/integration/ingestion_robustness_spec.rb
@@ -226,6 +226,36 @@ RSpec.describe 'harmonize ingestion robustness (integration)' do
       expect(result[:entry]['period']['listedDate'])
         .to eq(Date.new(2021, 2, 3))
     end
+
+    it 'keeps a blank canonical un_vessels date blank' do
+      # A present-but-blank canonical key means "no date" — reaching
+      # past it to the row alias would invent a date from_yaml, which
+      # reads only the canonical key, would never produce
+      data = source_fixtures[:un_vessels].first
+                                         .merge('date_designated' => '',
+                                                'designation_date' =>
+                                                 '2024-01-01')
+
+      result = transform(:un_vessels, data)
+      expect(result[:entry]['period']['listedDate']).to be_nil
+    end
+
+    it 'casts un_vessels integers the way the yaml path casts them' do
+      # A bare to_i defeated the attribute's own Integer cast, turning a
+      # grouped "12,500" tonnage into 12 — a plausible-looking number
+      # invented from unparseable text
+      data = source_fixtures[:un_vessels].first
+                                         .merge('tonnage' => '12,500',
+                                                'build_year' => '19x8')
+
+      model = Ammitto::Sources::UnVessels::Vessel.from_hash(data)
+      legacy = Ammitto::Sources::UnVessels::Vessel.from_yaml(data.to_yaml)
+
+      expect(model.tonnage).to be_nil
+      expect(model.build_year).to be_nil
+      expect(model.tonnage).to eq(legacy.tonnage)
+      expect(model.build_year).to eq(legacy.build_year)
+    end
   end
 
   # The from_hash migration claims every converted call site accepts

--- a/spec/integration/ingestion_robustness_spec.rb
+++ b/spec/integration/ingestion_robustness_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe 'harmonize ingestion robustness (integration)' do
         .to eq(Date.new(2021, 2, 3))
     end
 
-    it 'falls past a blank un_vessels date key to the serialized one' do
+    it 'ignores a blank un_vessels row alias when canonical is set' do
       data = source_fixtures[:un_vessels].first
                                          .merge('designation_date' => '')
 
@@ -426,6 +426,68 @@ RSpec.describe 'harmonize ingestion robustness (integration)' do
           .to raise_error(Thor::Error,
                           /20261101\.yaml: announcement-format YAML detected/)
       end
+    end
+  end
+
+  # The two hand-written from_hash readers assign straight from the
+  # hash, so they carry a check Lutaml performs for every other model.
+  # Without it a container in a scalar slot survives, stringifies, and
+  # sanitizes into an identifier indistinguishable from a real one —
+  # the from_yaml path these readers replaced raised instead.
+  describe 'containers in scalar slots are refused' do
+    it 'does not let a jp list id collide with a scalar id' do
+      # Both flatten to "jp-a-b": accepting the list would file two
+      # distinct designees under one entity IRI
+      scalar = transform(:jp, { 'id' => 'a-b', 'name' => 'X' })
+      expect(scalar[:entity]['@id']).to end_with('/jp/jp-a-b')
+
+      expect { transform(:jp, { 'id' => %w[a b], 'name' => 'X' }) }
+        .to raise_error(ArgumentError, /id must hold a single value/)
+    end
+
+    it 'refuses a jp hash id' do
+      expect { transform(:jp, { 'id' => { 'a' => 1 }, 'name' => 'X' }) }
+        .to raise_error(ArgumentError, /id must hold a single value/)
+    end
+
+    it 'refuses a container in any other jp scalar slot' do
+      expect { transform(:jp, { 'id' => '1', 'name' => %w[a b] }) }
+        .to raise_error(ArgumentError, /name must hold a single value/)
+    end
+
+    it 'refuses a un_vessels list imo_number' do
+      data = source_fixtures[:un_vessels].first
+                                         .merge('imo_number' => %w[a b])
+
+      expect { transform(:un_vessels, data) }
+        .to raise_error(ArgumentError,
+                        /imo_number must hold a single value/)
+    end
+
+    it 'refuses a un_vessels list date without consulting the alias' do
+      data = source_fixtures[:un_vessels].first
+                                         .merge('date_designated' => %w[a b])
+
+      expect { transform(:un_vessels, data) }
+        .to raise_error(ArgumentError,
+                        /date_designated must hold a single value/)
+    end
+
+    # The guard must reject containers only: every scalar YAML scalar
+    # type still has to build a record, or it would reject real data
+    it 'still accepts every scalar id type' do
+      { 'a-b' => 'jp-a-b', 123 => 'jp-123', 1.5 => 'jp-15',
+        true => 'jp-true' }.each do |id, expected|
+        result = transform(:jp, { 'id' => id, 'name' => 'X' })
+        expect(result[:entity]['@id']).to end_with("/jp/#{expected}")
+      end
+    end
+
+    it 'leaves the real collection fields alone' do
+      result = transform(:jp, { 'id' => '1', 'name' => 'X',
+                                'addresses' => %w[Tokyo Osaka] })
+
+      expect(result[:entity]['@id']).to end_with('/jp/jp-1')
     end
   end
 

--- a/spec/integration/ingestion_robustness_spec.rb
+++ b/spec/integration/ingestion_robustness_spec.rb
@@ -488,6 +488,22 @@ RSpec.describe 'harmonize ingestion robustness (integration)' do
                                 'addresses' => %w[Tokyo Osaka] })
 
       expect(result[:entity]['@id']).to end_with('/jp/jp-1')
+      expect(result[:entity]['addresses'].map { |a| a['street'] })
+        .to eq(%w[Tokyo Osaka])
+    end
+
+    # Deliberate, and the one place from_hash is MORE permissive than
+    # the from_yaml path it replaced: a lone scalar address used to
+    # reach Jp::Transformer as a bare String and crash it on #map.
+    # Reading it as a one-element list is the only sensible meaning, it
+    # loses no record and collides with nothing, so harmonize now
+    # accepts the file the old path merely failed on.
+    it 'reads a lone scalar address as a one-element list' do
+      result = transform(:jp, { 'id' => '1', 'name' => 'X',
+                                'addresses' => 'Tokyo' })
+
+      expect(result[:entity]['addresses'].map { |a| a['street'] })
+        .to eq(['Tokyo'])
     end
   end
 

--- a/spec/integration/ingestion_robustness_spec.rb
+++ b/spec/integration/ingestion_robustness_spec.rb
@@ -213,6 +213,19 @@ RSpec.describe 'harmonize ingestion robustness (integration)' do
       expect(result[:entry]['period']['listedDate'])
         .to eq(Date.new(2021, 2, 3))
     end
+
+    it 'prefers the canonical un_vessels date key over the row alias' do
+      # Both keys present: the yaml mapping reads 'date_designated', so
+      # from_hash has to resolve it the same way or the two parsers
+      # disagree on a file carrying the fetch-time alias as well
+      data = source_fixtures[:un_vessels].first
+                                         .merge('designation_date' =>
+                                                 '2024-01-01')
+
+      result = transform(:un_vessels, data)
+      expect(result[:entry]['period']['listedDate'])
+        .to eq(Date.new(2021, 2, 3))
+    end
   end
 
   # The from_hash migration claims every converted call site accepts


### PR DESCRIPTION
Harmonize dropped sanctioned entities three ways: **`from_yaml(data.to_yaml)`** re-emitted YAML anchors into lutaml's aliases-off loader (`Psych::AliasesNotEnabled`, 15 of 101 jp files), announcement-format YAML crashed ch and served us one nameless entity, and blank local ids merged distinct records into shared `unknown` IRIs (37 tr designees, every jp entity). Replaced all 22 round-trips with **`from_hash`**, widening **`Uk::Designation`** to **`key_value`** and extending the custom **`UnVessels::Vessel.from_hash`** so its JSON contract stays untouched. Added **`AnnouncementFormatError`** guards on ch/us/uk naming the format and the file, made **`IriSanitizer`** raise **`MissingLocalIdError`** with source attribution, and moved **`YAML.safe_load_file`** inside the per-file rescue so an unparseable file is a per-file error rather than a source-level one `--allow-empty` would clear. Sources holding blank-id records now fail loudly — tr on 37 files, jp on 101 — but the combined harvest already exits 1 on main today, so this names existing defects rather than introducing them.

Verified with identical `harmonize --all --combine` runs over the same fifteen data repos on main and on this branch: both exit 1 (four failed sources against eight, all named), and placeholder rows in the generated search index fall from 124 — three distinct ids, `entity/jp/jp`, `entity/tr/unknown`, `entity/us/unknown` — to zero.
