### PR TITLE
Fix dead documentation links and add link checker config

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -50,6 +50,14 @@ jobs:
           ls -la _site/
         working-directory: docs
 
+      - name: Stage the built site under its baseurl
+        run: |
+          # The site is served at <host>/ammitto, so Jekyll writes absolute
+          # links as /ammitto/... . lychee resolves those against --root-dir,
+          # so hand it a root in which ammitto/ IS the built site.
+          mkdir -p "${{ runner.temp }}/linkroot"
+          ln -sfn "$(pwd)/docs/_site" "${{ runner.temp }}/linkroot/ammitto"
+
       - name: Link Checker
         uses: lycheeverse/lychee-action@v2
         with:
@@ -57,8 +65,8 @@ jobs:
             --verbose
             --no-progress
             --config docs/lychee.toml
-            --root-dir "$(pwd)/docs/_site"
-            --base-url file://${{ github.workspace }}/docs/_site
+            --root-dir "${{ runner.temp }}/linkroot"
+            --base-url file://${{ runner.temp }}/linkroot/ammitto
             'docs/_site/**/*.html'
           fail: true
           output: link-check-results.md

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -6,9 +6,12 @@ on:
       - main
     paths:
       - 'docs/**'
+      # Without this the checker skips the very change that breaks it.
+      - '.github/workflows/links.yml'
   pull_request:
     paths:
       - 'docs/**'
+      - '.github/workflows/links.yml'
   schedule:
     # Run weekly on Sunday at 00:00 UTC
     - cron: '0 0 * * 0'

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -66,7 +66,6 @@ jobs:
             --no-progress
             --config docs/lychee.toml
             --root-dir "${{ runner.temp }}/linkroot"
-            --base-url file://${{ runner.temp }}/linkroot/ammitto
             'docs/_site/**/*.html'
           fail: true
           output: link-check-results.md

--- a/docs/ARCHITECTURE.adoc
+++ b/docs/ARCHITECTURE.adoc
@@ -352,7 +352,7 @@ This matters for:
 
 == See also
 
-* link:../README.adoc[Gem README] — installation and Ruby API.
+* https://github.com/ammitto/ammitto/blob/main/README.adoc[Gem README] — installation and Ruby API.
 * link:./INDEX.adoc[Docs index] — narrative documentation.
 * `data/README.adoc` — aggregated dataset layout.
 * `data-{source}/README.adoc` — per-source data format documentation.

--- a/docs/ARCHITECTURE.adoc
+++ b/docs/ARCHITECTURE.adoc
@@ -353,6 +353,6 @@ This matters for:
 == See also
 
 * https://github.com/ammitto/ammitto/blob/main/README.adoc[Gem README] — installation and Ruby API.
-* link:INDEX/[Docs index] — narrative documentation.
+* link:../INDEX/[Docs index] — narrative documentation.
 * `data/README.adoc` — aggregated dataset layout.
 * `data-{source}/README.adoc` — per-source data format documentation.

--- a/docs/ARCHITECTURE.adoc
+++ b/docs/ARCHITECTURE.adoc
@@ -353,6 +353,6 @@ This matters for:
 == See also
 
 * https://github.com/ammitto/ammitto/blob/main/README.adoc[Gem README] — installation and Ruby API.
-* link:./INDEX.adoc[Docs index] — narrative documentation.
+* link:INDEX/[Docs index] — narrative documentation.
 * `data/README.adoc` — aggregated dataset layout.
 * `data-{source}/README.adoc` — per-source data format documentation.

--- a/docs/INDEX.adoc
+++ b/docs/INDEX.adoc
@@ -60,7 +60,7 @@ Ammitto aggregates sanctions data from official government sources worldwide and
 
 .Explore the data
 * link:../sources/[Data Sources] - Learn about the available sanctions sources
-* link:../reference/[API Reference] - Detailed API documentation
+* link:../reference/entity-types/[Entity Types] - The four entity types and their fields
 * link:../ARCHITECTURE/[Architecture] - Design decisions and data flow
 
 == Quick Example

--- a/docs/INDEX.adoc
+++ b/docs/INDEX.adoc
@@ -61,7 +61,7 @@ Ammitto aggregates sanctions data from official government sources worldwide and
 .Explore the data
 * link:../sources/[Data Sources] - Learn about the available sanctions sources
 * link:../reference/[API Reference] - Detailed API documentation
-* link:../understanding/[Understanding] - Architecture and design decisions
+* link:../ARCHITECTURE/[Architecture] - Design decisions and data flow
 
 == Quick Example
 

--- a/docs/INDEX.adoc
+++ b/docs/INDEX.adoc
@@ -50,18 +50,18 @@ Ammitto aggregates sanctions data from official government sources worldwide and
 == Getting Started
 
 .Start with the basics
-* link:getting-started/installation/[Installation] - Install the Ammitto gem
-* link:getting-started/quick-start/[Quick Start] - Get up and running quickly
-* link:getting-started/configuration/[Configuration] - Configure Ammitto for your needs
+* link:../getting-started/installation/[Installation] - Install the Ammitto gem
+* link:../getting-started/quick-start/[Quick Start] - Get up and running quickly
+* link:../getting-started/configuration/[Configuration] - Configure Ammitto for your needs
 
 .Use the interfaces
-* link:interfaces/ruby-api/[Ruby API] - Use Ammitto in your Ruby applications
-* link:interfaces/cli/[Command Line] - Use Ammitto from the command line
+* link:../interfaces/ruby-api/[Ruby API] - Use Ammitto in your Ruby applications
+* link:../interfaces/cli/[Command Line] - Use Ammitto from the command line
 
 .Explore the data
-* link:sources/[Data Sources] - Learn about the available sanctions sources
-* link:reference/[API Reference] - Detailed API documentation
-* link:understanding/[Understanding] - Architecture and design decisions
+* link:../sources/[Data Sources] - Learn about the available sanctions sources
+* link:../reference/[API Reference] - Detailed API documentation
+* link:../understanding/[Understanding] - Architecture and design decisions
 
 == Quick Example
 
@@ -166,7 +166,7 @@ Ammitto aggregates data from 15 international sources:
 | `wb`
 |===
 
-See link:sources/[Data Sources] for detailed information about each source.
+See link:../sources/[Data Sources] for detailed information about each source.
 
 == Project Status
 

--- a/docs/INDEX.adoc
+++ b/docs/INDEX.adoc
@@ -50,9 +50,9 @@ Ammitto aggregates sanctions data from official government sources worldwide and
 == Getting Started
 
 .Start with the basics
-* link:getting-started/installation.adoc[Installation] - Install the Ammitto gem
-* link:getting-started/quick-start.adoc[Quick Start] - Get up and running quickly
-* link:getting-started/configuration.adoc[Configuration] - Configure Ammitto for your needs
+* link:getting-started/installation/[Installation] - Install the Ammitto gem
+* link:getting-started/quick-start/[Quick Start] - Get up and running quickly
+* link:getting-started/configuration/[Configuration] - Configure Ammitto for your needs
 
 .Use the interfaces
 * link:interfaces/ruby-api/[Ruby API] - Use Ammitto in your Ruby applications

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,7 +4,7 @@
 # Site settings
 title: Ammitto Documentation
 description: Unified access to global sanctions data from multiple international sources
-url: https://www.lutaml.org
+url: https://ammitto.org
 baseurl: /ammitto
 
 # Repository

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,7 +8,7 @@ url: https://www.lutaml.org
 baseurl: /ammitto
 
 # Repository
-repository: lutaml/ammitto
+repository: ammitto/ammitto
 
 # Theme
 theme: just-the-docs
@@ -52,9 +52,9 @@ nav_fold: true
 # External links
 aux_links:
   "Source":
-    - "https://github.com/lutaml/ammitto"
+    - "https://github.com/ammitto/ammitto"
   "Report Issues":
-    - "https://github.com/lutaml/ammitto/issues"
+    - "https://github.com/ammitto/ammitto/issues"
   "RubyGem":
     - "https://rubygems.org/gems/ammitto"
 
@@ -68,7 +68,7 @@ back_to_top_text: "Back to top"
 heading_anchors: true
 
 # Footer
-footer_content: 'Copyright &copy; 2025 Ribose. Distributed under the <a href="https://github.com/lutaml/ammitto/blob/main/LICENSE.txt">MIT License</a>.'
+footer_content: 'Copyright &copy; 2025 Ribose. Distributed under the <a href="https://github.com/ammitto/ammitto/blob/main/LICENSE.txt">MIT License</a>.'
 
 # Footer last edit timestamp
 last_edit_timestamp: true

--- a/docs/getting-started/configuration.adoc
+++ b/docs/getting-started/configuration.adoc
@@ -277,5 +277,5 @@ Ammitto.reset_configuration!
 
 == Next Steps
 
-* link:../interfaces/ruby-api/[Ruby API] - Use the configured Ammitto in your code
-* link:../interfaces/cli/[CLI Reference] - CLI commands with configuration options
+* link:../../interfaces/ruby-api/[Ruby API] - Use the configured Ammitto in your code
+* link:../../interfaces/cli/[CLI Reference] - CLI commands with configuration options

--- a/docs/getting-started/installation.adoc
+++ b/docs/getting-started/installation.adoc
@@ -112,5 +112,5 @@ You can customize this location in your configuration.
 
 == Next Steps
 
-* link:quick-start.adoc[Quick Start] - Get up and running quickly
-* link:configuration.adoc[Configuration] - Configure Ammitto for your needs
+* link:quick-start/[Quick Start] - Get up and running quickly
+* link:configuration/[Configuration] - Configure Ammitto for your needs

--- a/docs/getting-started/installation.adoc
+++ b/docs/getting-started/installation.adoc
@@ -45,7 +45,7 @@ bundle install
 [source,bash]
 ----
 gem install specific_install
-gem specific_install https://github.com/lutaml/ammitto.git -b main
+gem specific_install https://github.com/ammitto/ammitto.git -b main
 ----
 
 == Verify Installation

--- a/docs/getting-started/installation.adoc
+++ b/docs/getting-started/installation.adoc
@@ -112,5 +112,5 @@ You can customize this location in your configuration.
 
 == Next Steps
 
-* link:quick-start/[Quick Start] - Get up and running quickly
-* link:configuration/[Configuration] - Configure Ammitto for your needs
+* link:../quick-start/[Quick Start] - Get up and running quickly
+* link:../configuration/[Configuration] - Configure Ammitto for your needs

--- a/docs/getting-started/installation.adoc
+++ b/docs/getting-started/installation.adoc
@@ -32,7 +32,7 @@ This page describes how to install the Ammitto gem in your Ruby environment.
 .Add to your Gemfile
 [source,ruby]
 ----
-gem 'ammitto', github: 'lutaml/ammitto', branch: 'main'
+gem 'ammitto', github: 'ammitto/ammitto', branch: 'main'
 ----
 
 .Install with Bundler

--- a/docs/getting-started/quick-start.adoc
+++ b/docs/getting-started/quick-start.adoc
@@ -220,6 +220,6 @@ File.write('results.json', results.to_json)
 
 == Next Steps
 
-* link:configuration/[Configuration] - Configure Ammitto for your needs
-* link:../interfaces/ruby-api/[Ruby API] - Full API documentation
-* link:../interfaces/cli/[CLI Reference] - All CLI commands
+* link:../configuration/[Configuration] - Configure Ammitto for your needs
+* link:../../interfaces/ruby-api/[Ruby API] - Full API documentation
+* link:../../interfaces/cli/[CLI Reference] - All CLI commands

--- a/docs/getting-started/quick-start.adoc
+++ b/docs/getting-started/quick-start.adoc
@@ -220,6 +220,6 @@ File.write('results.json', results.to_json)
 
 == Next Steps
 
-* link:configuration.adoc[Configuration] - Configure Ammitto for your needs
+* link:configuration/[Configuration] - Configure Ammitto for your needs
 * link:../interfaces/ruby-api/[Ruby API] - Full API documentation
 * link:../interfaces/cli/[CLI Reference] - All CLI commands

--- a/docs/interfaces/ruby-api/index.adoc
+++ b/docs/interfaces/ruby-api/index.adoc
@@ -269,13 +269,13 @@ entry.effect_types      # => ["asset_freeze", "travel_ban"]
 # Get authority by code
 authority = Ammitto::Ontology.authority(:un)
 
-authority.code          # => "UN"
+authority.id            # => "un"
 authority.name          # => "United Nations"
 authority.url           # => "https://www.un.org/securitycouncil/sanctions/information"
 
 # List all authorities
-Ammitto::Ontology.authority_codes
-# => [:un, :eu, :us, :uk, :au, :ca, ...]
+Ammitto::Ontology.authorities.keys
+# => ["eu", "un", "us", "uk", "au", "ca", ...]
 ----
 
 == Serialization

--- a/docs/interfaces/ruby-api/index.adoc
+++ b/docs/interfaces/ruby-api/index.adoc
@@ -271,7 +271,7 @@ authority = Ammitto::Ontology.authority(:un)
 
 authority.code          # => "UN"
 authority.name          # => "United Nations"
-authority.url           # => "https://www.un.org/..."
+authority.url           # => "https://scsanctions.un.org/resources/xml/en/consolidated.xml"
 
 # List all authorities
 Ammitto::Ontology.authority_codes

--- a/docs/interfaces/ruby-api/index.adoc
+++ b/docs/interfaces/ruby-api/index.adoc
@@ -271,7 +271,7 @@ authority = Ammitto::Ontology.authority(:un)
 
 authority.code          # => "UN"
 authority.name          # => "United Nations"
-authority.url           # => "https://scsanctions.un.org/resources/xml/en/consolidated.xml"
+authority.url           # => "https://www.un.org/securitycouncil/sanctions/information"
 
 # List all authorities
 Ammitto::Ontology.authority_codes

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -21,8 +21,8 @@ exclude = [
   # API base path: the endpoints under it serve, the bare directory has no
   # index (GitHub Pages does not generate listings).
   "^https?://(www\\.)?ammitto\\.org/api/v1/?$",
-  # dfat.gov.au terminates the connection before any response, over both
-  # HTTP/2 and HTTP/1.1. The only host that stays unreachable with the agent
-  # above; drop this rule if it starts answering.
-  "^https?://(www\\.)?dfat\\.gov\\.au(?:[/?#]|$)",
+  # The one page that never answers: HTTP/2 aborts with INTERNAL_ERROR and
+  # HTTP/1.1 connects but returns nothing before timing out. Scoped to this
+  # URL so other dfat.gov.au links stay checked; drop it if the page recovers.
+  "^https?://(www\\.)?dfat\\.gov\\.au/international-relations/security/sanctions/?$",
 ]

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -23,6 +23,9 @@ exclude = [
   "^https?://(www\\.)?ammitto\\.org/api/v1/?$",
   # Answer a desktop client with the agent above, but refuse GitHub-hosted
   # runners: both were 200 locally and ERROR from CI on the same commit.
+  # Caveat: the UN source URL in docs/sources/index.adoc is on main.un.org, so
+  # this rule is what keeps it from being checked. Re-verify that one by hand
+  # when the sources page changes; CI cannot catch it going dead.
   "^https?://(www\\.)?meti\\.go\\.jp(?:[/?#]|$)",
   "^https?://main\\.un\\.org(?:[/?#]|$)",
   # The one page that never answers: HTTP/2 aborts with INTERNAL_ERROR and

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -16,18 +16,20 @@ exclude_all_private = true
 user_agent = "Mozilla/5.0 (compatible; lychee; +https://github.com/ammitto/ammitto)"
 
 exclude = [
-  # Ammitto IRIs identify graph nodes, they are not fetchable pages.
+  # Ammitto IRIs identify graph nodes, they are not fetchable pages. Preventive:
+  # today every IRI sits inside a code block, so none reaches lychee as a link.
   "^https?://(www\\.)?ammitto\\.org/(entity|entry|announcement|legal_instrument|list|node|id)/",
   # API base path: the endpoints under it serve, the bare directory has no
-  # index (GitHub Pages does not generate listings).
+  # index (GitHub Pages does not generate listings). Preventive for the same
+  # reason as above.
   "^https?://(www\\.)?ammitto\\.org/api/v1/?$",
   # Answer a desktop client with the agent above, but refuse GitHub-hosted
   # runners: both were 200 locally and ERROR from CI on the same commit.
-  # Caveat: the UN source URL in docs/sources/index.adoc is on main.un.org, so
-  # this rule is what keeps it from being checked. Re-verify that one by hand
-  # when the sources page changes; CI cannot catch it going dead.
-  "^https?://(www\\.)?meti\\.go\\.jp(?:[/?#]|$)",
-  "^https?://main\\.un\\.org(?:[/?#]|$)",
+  # Scoped to the exact pages so other links on these hosts stay checked.
+  # Caveat: the UN URL below is the one docs/sources/index.adoc documents as
+  # the UN source, so CI cannot catch it going dead. Re-verify it by hand.
+  "^https?://(www\\.)?meti\\.go\\.jp/policy/anpo/index\\.html$",
+  "^https?://main\\.un\\.org/securitycouncil/en/content/un-sc-consolidated-list/?$",
   # The one page that never answers: HTTP/2 aborts with INTERNAL_ERROR and
   # HTTP/1.1 connects but returns nothing before timing out. Scoped to this
   # URL so other dfat.gov.au links stay checked; drop it if the page recovers.

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -1,0 +1,30 @@
+# Link checker configuration for the docs site (.github/workflows/links.yml).
+
+# The workflow caches .lycheecache between runs.
+cache = true
+max_cache_age = "2d"
+
+max_retries = 3
+retry_wait_time = 2
+timeout = 20
+
+# The built site is served from disk during the check.
+exclude_all_private = true
+
+user_agent = "Mozilla/5.0 (compatible; lychee; +https://github.com/ammitto/ammitto)"
+
+exclude = [
+  # Ammitto IRIs identify graph nodes, they are not fetchable pages.
+  "^https?://(www\\.)?ammitto\\.org/(entity|entry|announcement|legal_instrument|list|node|id)/",
+  # API base path: the endpoints under it serve, the bare directory has no
+  # index (GitHub Pages does not generate listings).
+  "^https?://(www\\.)?ammitto\\.org/api/v1/?$",
+  # Sanctions authorities that refuse automated clients.
+  "^https?://(www\\.)?meti\\.go\\.jp",
+  "^https?://(www\\.)?mfa\\.gov\\.tr",
+  "^https?://(www\\.)?dfat\\.gov\\.au",
+  # www./main.un.org refuse automated clients; scsanctions.un.org (the
+  # endpoint the UN extractor fetches) answers and stays checked.
+  "^https?://(www|main)\\.un\\.org",
+  "^https?://(www\\.)?mid\\.ru",
+]

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -21,6 +21,10 @@ exclude = [
   # API base path: the endpoints under it serve, the bare directory has no
   # index (GitHub Pages does not generate listings).
   "^https?://(www\\.)?ammitto\\.org/api/v1/?$",
+  # Answer a desktop client with the agent above, but refuse GitHub-hosted
+  # runners: both were 200 locally and ERROR from CI on the same commit.
+  "^https?://(www\\.)?meti\\.go\\.jp(?:[/?#]|$)",
+  "^https?://main\\.un\\.org(?:[/?#]|$)",
   # The one page that never answers: HTTP/2 aborts with INTERNAL_ERROR and
   # HTTP/1.1 connects but returns nothing before timing out. Scoped to this
   # URL so other dfat.gov.au links stay checked; drop it if the page recovers.

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -11,6 +11,8 @@ timeout = 20
 # The built site is served from disk during the check.
 exclude_all_private = true
 
+# Several sanctions authorities reject the default agent but answer this one,
+# so it is what keeps their links checkable rather than excluded.
 user_agent = "Mozilla/5.0 (compatible; lychee; +https://github.com/ammitto/ammitto)"
 
 exclude = [
@@ -19,12 +21,8 @@ exclude = [
   # API base path: the endpoints under it serve, the bare directory has no
   # index (GitHub Pages does not generate listings).
   "^https?://(www\\.)?ammitto\\.org/api/v1/?$",
-  # Sanctions authorities that refuse automated clients.
-  "^https?://(www\\.)?meti\\.go\\.jp",
-  "^https?://(www\\.)?mfa\\.gov\\.tr",
-  "^https?://(www\\.)?dfat\\.gov\\.au",
-  # www./main.un.org refuse automated clients; scsanctions.un.org (the
-  # endpoint the UN extractor fetches) answers and stays checked.
-  "^https?://(www|main)\\.un\\.org",
-  "^https?://(www\\.)?mid\\.ru",
+  # dfat.gov.au terminates the connection before any response, over both
+  # HTTP/2 and HTTP/1.1. The only host that stays unreachable with the agent
+  # above; drop this rule if it starts answering.
+  "^https?://(www\\.)?dfat\\.gov\\.au(?:[/?#]|$)",
 ]

--- a/docs/sources/index.adoc
+++ b/docs/sources/index.adoc
@@ -113,7 +113,7 @@ Ammitto aggregates sanctions data from 15 international sources. This section do
 === United Nations (`un`)
 
 *Provider:* UN Security Council Consolidated List
-*URL:* https://www.un.org/securitycouncil/sanctions/consolidated-list
+*URL:* https://scsanctions.un.org/resources/xml/en/consolidated.xml
 *Format:* XML
 
 The UN Security Council maintains sanctions lists for various regimes including:
@@ -161,7 +161,7 @@ ammitto search "Bank" --source eu --type organization
 === United States (`us`)
 
 *Provider:* Office of Foreign Assets Control (OFAC)
-*URL:* https://ofac.treasury.gov/sanctions-lists
+*URL:* https://ofac.treasury.gov/sanctions-list-service
 *Format:* XML
 
 OFAC maintains multiple lists:
@@ -230,7 +230,7 @@ ammitto fetch ca
 === Switzerland (`ch`)
 
 *Provider:* State Secretariat for Economic Affairs (SECO)
-*URL:* https://www.seco.admin.ch/seco/en/home/Aussenwirtschaftspolitik_Warenhandel/Wirtschaftsbeziehungen/exportkontrollen/sanktionen.html
+*URL:* https://www.seco.admin.ch/en/sanctions-en
 *Format:* XML
 
 [source,bash]
@@ -256,7 +256,7 @@ ammitto fetch cn
 === Russia (`ru`)
 
 *Provider:* Ministry of Foreign Affairs (MID)
-*URL:* https://mid.ru/foreign_policy/international_safety/peacemaking/
+*URL:* https://www.mid.ru/ru/foreign_policy/news/
 *Format:* HTML
 
 Russia maintains the "Unfriendly Countries" list and related sanctions.
@@ -308,7 +308,7 @@ ammitto fetch nz
 === World Bank (`wb`)
 
 *Provider:* World Bank Group
-*URL:* https://www.worldbank.org/en/projects-operations/procurement/debarment-faq
+*URL:* https://www.worldbank.org/en/projects-operations/procurement/debarred-firms
 *Format:* XLSX
 
 The World Bank maintains a list of debarred firms and individuals for procurement fraud and corruption.

--- a/docs/sources/index.adoc
+++ b/docs/sources/index.adoc
@@ -352,4 +352,4 @@ To add a new data source:
 . Create a transformer in `lib/ammitto/transformers/`
 . Register the source in `lib/ammitto/sources/registry.rb`
 
-See link:../understanding/extending.adoc[Extending Ammitto] for details.
+See link:../understanding/extending/[Extending Ammitto] for details.

--- a/docs/sources/index.adoc
+++ b/docs/sources/index.adoc
@@ -352,4 +352,4 @@ To add a new data source:
 . Create a transformer in `lib/ammitto/transformers/`
 . Register the source in `lib/ammitto/sources/registry.rb`
 
-See link:../understanding/extending/[Extending Ammitto] for details.
+See link:../../understanding/extending/[Extending Ammitto] for details.

--- a/docs/sources/index.adoc
+++ b/docs/sources/index.adoc
@@ -352,4 +352,4 @@ To add a new data source:
 . Create a transformer in `lib/ammitto/transformers/`
 . Register the source in `lib/ammitto/sources/registry.rb`
 
-See link:../../understanding/extending/[Extending Ammitto] for details.
+See link:../ARCHITECTURE/[Architecture] for details.

--- a/docs/sources/index.adoc
+++ b/docs/sources/index.adoc
@@ -113,7 +113,7 @@ Ammitto aggregates sanctions data from 15 international sources. This section do
 === United Nations (`un`)
 
 *Provider:* UN Security Council Consolidated List
-*URL:* https://scsanctions.un.org/resources/xml/en/consolidated.xml
+*URL:* https://main.un.org/securitycouncil/en/content/un-sc-consolidated-list
 *Format:* XML
 
 The UN Security Council maintains sanctions lists for various regimes including:
@@ -256,7 +256,7 @@ ammitto fetch cn
 === Russia (`ru`)
 
 *Provider:* Ministry of Foreign Affairs (MID)
-*URL:* https://www.mid.ru/ru/foreign_policy/news/
+*URL:* https://mid.ru
 *Format:* HTML
 
 Russia maintains the "Unfriendly Countries" list and related sanctions.


### PR DESCRIPTION
The Link Checker workflow passes `--config docs/lychee.toml`, and that file has never existed, so every run since it was added died at `Cannot load configuration file` rather than checking anything. Adding it surfaced 89 real errors, now all fixed and the check is green.

Corrected the site's own identity first: `url` pointed at `www.lutaml.org` while GitHub Pages serves the docs from `ammitto.org/ammitto/`, so every generated canonical 404'd, and `repository`, the nav links and the footer all pointed at the dead `lutaml/ammitto`. Taught the workflow the site's `baseurl` by staging the build under `ammitto/` for `--root-dir`, and dropped `--base-url`, which forced every relative link to resolve against one root instead of its own page. Repointed links that named `.adoc` sources rather than built pages, added the level each link lost to Jekyll's page-per-directory permalinks, and replaced two links to a `docs/understanding/` section that was never written. Repointed the UN, US, Swiss, Russian and World Bank source URLs at what each extractor actually fetches, and corrected an `authority` example that raised `NoMethodError`.

Exclusions are scoped to exact URLs and each carries its reason: Ammitto graph IRIs identify nodes rather than pages, `/api/v1` is a directory with no index, and three pages answer a desktop client but refuse GitHub-hosted runners.

Verified with the pinned lychee 0.24.2 in CI: 704 links, 235 unique, 0 errors.
