### PR TITLE
Replace dead source URLs in comments and authority records

### DIFF
--- a/lib/ammitto/extractors/nz_extractor.rb
+++ b/lib/ammitto/extractors/nz_extractor.rb
@@ -8,7 +8,7 @@ module Ammitto
     # NzExtractor extracts sanctions data from New Zealand (MFAT)
     #
     # New Zealand maintains Russia sanctions under the Russia Sanctions Act 2022.
-    # Source: https://www.mfat.govt.nz/en/trade-and-country-services/sanctions/
+    # Source: https://www.mfat.govt.nz/en/countries-and-regions/europe/ukraine/russian-invasion-of-ukraine/sanctions/
     #
     # Note: NZ also implements UN sanctions, but those are covered by the UN source.
     #

--- a/lib/ammitto/extractors/us_extractor.rb
+++ b/lib/ammitto/extractors/us_extractor.rb
@@ -7,7 +7,7 @@ module Ammitto
   module Extractors
     # UsExtractor extracts sanctions data from the United States (OFAC)
     #
-    # Source: https://ofac.treasury.gov/sanctions-lists
+    # Source: https://ofac.treasury.gov/sanctions-list-service
     #
     # OFAC provides multiple lists:
     # - SDN (Specially Designated Nationals) - primary sanctions list

--- a/lib/ammitto/ontology.rb
+++ b/lib/ammitto/ontology.rb
@@ -192,7 +192,7 @@ module Ammitto
             id: 'eu',
             name: 'European Union',
             country_code: 'EU',
-            url: 'https://finance.ec.europa.eu/sanctions-dossier_en'
+            url: 'https://finance.ec.europa.eu/eu-and-world/sanctions-restrictive-measures_en'
           ),
           'un' => Sanction::Authority.new(
             id: 'un',
@@ -228,7 +228,7 @@ module Ammitto
             id: 'ch',
             name: 'Switzerland (SECO)',
             country_code: 'CH',
-            url: 'https://www.seco.admin.ch/seco/en/home/Aussenwirtschaft_Wirtschaftliche_Zusammenarbeit/Wirtschaftsbeziehungen/exportkontrollen-und-sanktionen/sanktionen-embargos.html'
+            url: 'https://www.seco.admin.ch/en/searching-for-subjects-sanctions'
           ),
           'cn' => Sanction::Authority.new(
             id: 'cn',

--- a/lib/ammitto/ontology/ontology.rb
+++ b/lib/ammitto/ontology/ontology.rb
@@ -58,7 +58,7 @@ module Ammitto
         'ch' => {
           name: 'Switzerland SECO',
           country_code: 'CH',
-          url: 'https://www.seco.admin.ch/seco/en/home/Aussenwirtschaftspolitik_Wirtschaftliche_Zusammenarbeit/Wirtschaftsbeziehungen/exportkontrollen-und-sanktionen/sanktionen-embargos.html'
+          url: 'https://www.seco.admin.ch/en/searching-for-subjects-sanctions'
         },
         'cn' => {
           name: 'China MOFCOM',

--- a/lib/ammitto/ontology/ontology.rb
+++ b/lib/ammitto/ontology/ontology.rb
@@ -68,7 +68,7 @@ module Ammitto
         'eu' => {
           name: 'European Union',
           country_code: 'EU',
-          url: 'https://finance.ec.europa.eu/sanctions-dossier_en'
+          url: 'https://finance.ec.europa.eu/eu-and-world/sanctions-restrictive-measures_en'
         },
         'eu_vessels' => {
           name: 'EU/Denmark DMA',
@@ -118,7 +118,7 @@ module Ammitto
         'wb' => {
           name: 'World Bank',
           country_code: 'WB',
-          url: 'https://www.worldbank.org/en/projects-operations/procurement/debarment-firms'
+          url: 'https://www.worldbank.org/en/projects-operations/procurement/debarred-firms'
         }
       }.freeze
 

--- a/lib/ammitto/ontology/sanction/authority.rb
+++ b/lib/ammitto/ontology/sanction/authority.rb
@@ -15,7 +15,7 @@ module Ammitto
       #     id: "eu",
       #     name: "European Union",
       #     country_code: "EU",
-      #     url: "https://finance.ec.europa.eu/sanctions-dossier_en"
+      #     url: "https://finance.ec.europa.eu/eu-and-world/sanctions-restrictive-measures_en"
       #   )
       #
       class Authority < Lutaml::Model::Serializable

--- a/lib/ammitto/sources/ch.rb
+++ b/lib/ammitto/sources/ch.rb
@@ -38,7 +38,7 @@ module Ammitto
       SOURCE_NAME = 'Switzerland (SECO)'
 
       # Source API endpoint
-      SOURCE_URL = 'https://www.seco.admin.ch/seco/de/home/Aussenwirtschaftspolitik_Wirtschaftliche_Zusammenarbeit/Wirtschaftsbeziehungen/exportkontrollen-und-sanktionen/sanktionsmassnahmen/sanktionsliste.html'
+      SOURCE_URL = 'https://www.seco.admin.ch/en/searching-for-subjects-sanctions'
 
       # Country code (ISO 3166-1 alpha-2)
       COUNTRY_CODE = 'CH'

--- a/lib/ammitto/sources/ch/source.rb
+++ b/lib/ammitto/sources/ch/source.rb
@@ -31,7 +31,7 @@ module Ammitto
         # Get the original Switzerland API endpoint
         # @return [String] the SECO sanctions list URL
         def original_api_endpoint
-          'https://www.seco.admin.ch/seco/en/home/Aussenwirtschaft_Warenhandel_aussenwirtschaft_wirtschaft-zusammenarbeit/exportkontrolle-und-sanktionen/sanktionen-embargos.html'
+          'https://www.seco.admin.ch/en/searching-for-subjects-sanctions'
         end
       end
     end


### PR DESCRIPTION
Nine source URLs in `lib/` return 404, so a reader following a comment or an authority record lands nowhere. Probed all 77 external URLs the tree carries and replaced only those proven dead against a replacement proven live: the OFAC list page in **`UsExtractor`**, the MFAT page in **`NzExtractor`** (now the Russia-sanctions page **`Sources::Nz`** already uses), the EU Commission sanctions dossier across **`Ontology`** and **`Authority`**, three legacy SECO paths, and the World Bank debarment page. Every replacement follows redirects to a 200.

Left alone deliberately: the EU export namespace, which is an XML identifier rather than a locator, and the SECO XSD and dfat.gov.au, neither of which failed in a way that proves the URL is wrong.

Verified by probing each old and new URL with a browser agent, plus the full suite and RuboCop.

Worth knowing separately: both CN scraper fetch URLs in `scrapers/cn/mofcom_page.rb` also return 404. Those are fetch targets rather than documentation, and no replacement was found that serves the same content, so they are untouched here.
