### PR TITLE
Key an authority node on its id instead of its country code

### DIFF
--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -404,19 +404,29 @@ module Ammitto
         authority = entry['authority']
         return unless authority
 
-        # Get authority code
-        code = authority['countryCode'] || authority['id'] || source_code
+        # An authority is identified by its id. BaseTransformer builds
+        # every authority as Authority.find(source_code) and
+        # Schema::Validator checks authority['id'] against
+        # Authority::REGISTRY, so the id is the vocabulary this exporter
+        # has to key on. countryCode is a coarser attribute distinct
+        # authorities share -- eu and eu_vessels both declare EU -- so
+        # preferring it merged them into one node whose name was decided
+        # by ingestion order, and for uk it minted authority/gb, an IRI
+        # that same validator rejects
+        code = authority['id'] || authority['countryCode'] || source_code
         return unless code
 
         auth_id = "#{BASE_URI}/authority/#{code.to_s.downcase}"
 
-        # Store full authority if not already present
+        # Store full authority if not already present. The country code is
+        # the authority's own declared value: it is no longer derivable
+        # from the node key now that the key is the source-grained id
         @authorities[code.to_s.downcase] ||= {
           '@context' => @context_url,
           '@id' => auth_id,
           '@type' => 'Authority',
           'name' => authority['name'],
-          'countryCode' => code.to_s.upcase,
+          'countryCode' => (authority['countryCode'] || code).to_s.upcase,
           'url' => authority['url']
         }.compact
 

--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -412,8 +412,12 @@ module Ammitto
         # authorities share -- eu and eu_vessels both declare EU -- so
         # preferring it merged them into one node whose name was decided
         # by ingestion order, and for uk it minted authority/gb, an IRI
-        # that same validator rejects
-        code = authority['id'] || authority['countryCode'] || source_code
+        # that same validator rejects. source_code precedes countryCode in
+        # the fallback for the same reason: an authority hash reaching here
+        # without an id still belongs to the source that ingested it, so
+        # falling back to countryCode would mint authority/gb again for a
+        # UK entry whose id was lost upstream
+        code = authority['id'] || source_code || authority['countryCode']
         return unless code
 
         auth_id = "#{BASE_URI}/authority/#{code.to_s.downcase}"

--- a/lib/ammitto/serialization/search_index_exporter.rb
+++ b/lib/ammitto/serialization/search_index_exporter.rb
@@ -275,7 +275,7 @@ module Ammitto
         # Direct string value
         return authority.downcase if authority.is_a?(String)
 
-        # Check for @id reference. Both lookups take the String rule:
+        # Check for @id reference. All three lookups take the String rule:
         # the extractor calls #match/#downcase, so a wrong-typed source
         # value would raise NoMethodError mid-harmonize instead of
         # dropping out of the row
@@ -286,6 +286,16 @@ module Ammitto
             match = id.match(%r{/authority/([^/]+)$})
             return match[1] if match
           end
+
+          # JsonLdSerializer emits 'id', never '@id'. Under harmonize the
+          # graph exporter rewrites that hash into the '@id' reference
+          # above first, but this exporter is documented for standalone
+          # use too, and there the authority's own id is the answer.
+          # countryCode is the last resort because distinct authorities
+          # share a country
+          own_id = string_presence(authority['id'])
+          return own_id.downcase if own_id
+
           return string_presence(authority['countryCode'])&.downcase
         end
 

--- a/spec/ammitto/serialization/authority_identity_spec.rb
+++ b/spec/ammitto/serialization/authority_identity_spec.rb
@@ -116,4 +116,30 @@ RSpec.describe 'Authority identity through the harmonize pipeline' do
     expect(File.exist?(File.join(dir, 'uk.jsonld'))).to be true
     expect(File.exist?(File.join(dir, 'gb.jsonld'))).to be false
   end
+
+  # An authority hash can reach the exporter without an id -- a cached
+  # payload, or a transformer that assembled the hash by hand. It still
+  # belongs to the source that ingested it, so the fallback has to be
+  # source_code; falling back to countryCode would remint authority/gb
+  it 'falls back to the ingesting source when the authority carries no id' do
+    entity = {
+      '@id' => 'https://www.ammitto.org/entity/uk/t1',
+      'entityType' => 'person',
+      'names' => [{ 'fullName' => 'Subject uk', 'isPrimary' => true }]
+    }
+    entry = {
+      '@id' => 'https://www.ammitto.org/entry/uk/t1',
+      'authority' => {
+        'countryCode' => 'GB',
+        'name' => 'United Kingdom (OFSI)'
+      }
+    }
+
+    graph.add_node(entity: entity, entry: entry, source: 'uk')
+    graph.export
+
+    dir = File.join(output_dir, 'node', 'authority')
+    expect(File.exist?(File.join(dir, 'uk.jsonld'))).to be true
+    expect(File.exist?(File.join(dir, 'gb.jsonld'))).to be false
+  end
 end

--- a/spec/ammitto/serialization/authority_identity_spec.rb
+++ b/spec/ammitto/serialization/authority_identity_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ammitto/serialization/json_ld_serializer'
+require 'ammitto/serialization/json_ld_graph_exporter'
+require 'ammitto/serialization/search_index_exporter'
+require 'fileutils'
+require 'tmpdir'
+
+# The search index's `authority` column is what public consumers filter on,
+# and Ammitto has no authority concept coarser than the source that issued
+# the listing: BaseTransformer builds every authority as
+# Authority.find(source_code), Authority::REGISTRY is keyed by source code,
+# and Schema::Validator checks authority['id'] against that registry.
+#
+# Neither exporter is exercised against a real registered authority
+# anywhere else in the suite, and only their combination is what harmonize
+# actually runs, so these examples drive the exact component order of
+# HarmonizeCommand#ingest_results -- JsonLdGraphExporter#add_node first,
+# then SearchIndexExporter#add on the same, now-rewritten entry hash.
+RSpec.describe 'Authority identity through the harmonize pipeline' do
+  let(:output_dir) { Dir.mktmpdir('ammitto_authority_identity') }
+  let(:serializer) { Ammitto::Serialization::JsonLdSerializer.new }
+  let(:graph) do
+    Ammitto::Serialization::JsonLdGraphExporter.new(output_dir: output_dir)
+  end
+  let(:index) { Ammitto::Serialization::SearchIndexExporter.new }
+
+  after { FileUtils.rm_rf(output_dir) }
+
+  # Mirrors HarmonizeCommand#ingest_results for one entity/entry pair
+  def ingest(source)
+    entity = {
+      '@id' => "https://www.ammitto.org/entity/#{source}/t1",
+      'entityType' => 'person',
+      'names' => [{ 'fullName' => "Subject #{source}", 'isPrimary' => true }]
+    }
+    entry = serializer.serialize_entry(
+      Ammitto::SanctionEntry.new(
+        id: "https://www.ammitto.org/entry/#{source}/t1",
+        authority: Ammitto::Authority.find(source),
+        status: 'active'
+      )
+    )
+
+    graph.add_node(entity: entity, entry: entry, source: source)
+    index.add(entity, entry)
+  end
+
+  # uk declares countryCode GB, so a country-keyed authority publishes 'gb'
+  # for it. eu_vessels and un_vessels declare EU and UN, so a country-keyed
+  # authority hides them inside their parent's bucket.
+  %w[uk eu_vessels un_vessels].each do |source|
+    it "indexes #{source} under its own authority code" do
+      ingest(source)
+
+      expect(index.entities.first[:authority]).to eq(source)
+    end
+  end
+
+  it 'gives every registered source a code its own validator accepts' do
+    validator = Ammitto::Schema::Validator.new
+    Ammitto::Authority::REGISTRY.each_key { |source| ingest(source) }
+
+    codes = index.entities.map { |row| row[:authority] }.uniq
+    unknown = codes.reject do |code|
+      validator.validate_sanction_entry('authority' => { 'id' => code })
+               .grep(/Unknown authority/).empty?
+    end
+
+    expect(unknown).to be_empty
+  end
+
+  it 'counts a vessel source separately from its parent authority' do
+    ingest('eu')
+    ingest('eu_vessels')
+
+    expect(index.facets[:authorities]).to include('eu' => 1, 'eu_vessels' => 1)
+  end
+
+  # AUTHORITY_NAMES already carries 'EU Vessels'; it was unreachable while
+  # the code collapsed to 'eu'
+  it 'names the vessel facet from AUTHORITY_NAMES' do
+    ingest('eu_vessels')
+    index.export(output_dir)
+
+    facets = JSON.parse(
+      File.read(File.join(output_dir, 'facets', 'authorities.json'))
+    )['facets']
+
+    expect(facets).to include(
+      hash_including('code' => 'eu_vessels', 'name' => 'EU Vessels')
+    )
+  end
+
+  it 'gives a vessel source its own authority node keyed by id' do
+    ingest('eu')
+    ingest('eu_vessels')
+    graph.export
+
+    node = File.join(output_dir, 'node', 'authority', 'eu_vessels.jsonld')
+    expect(File.exist?(node)).to be true
+
+    data = JSON.parse(File.read(node))
+    expect(data['@id']).to eq('https://www.ammitto.org/authority/eu_vessels')
+    expect(data['name']).to eq('EU Designated Vessels (via Denmark DMA)')
+    # the declared country code survives the id-keyed node
+    expect(data['countryCode']).to eq('EU')
+  end
+
+  it 'stops minting an authority node for a country that is not a source' do
+    ingest('uk')
+    graph.export
+
+    dir = File.join(output_dir, 'node', 'authority')
+    expect(File.exist?(File.join(dir, 'uk.jsonld'))).to be true
+    expect(File.exist?(File.join(dir, 'gb.jsonld'))).to be false
+  end
+end

--- a/spec/ammitto/serialization/json_ld_graph_exporter_spec.rb
+++ b/spec/ammitto/serialization/json_ld_graph_exporter_spec.rb
@@ -53,6 +53,92 @@ RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
       expect(entry['authority']).to eq({ '@id' => 'https://www.ammitto.org/authority/un' })
     end
 
+    # An authority's identity is its id. Authority::REGISTRY is keyed by
+    # source code and Schema::Validator checks authority['id'] against it,
+    # so keying the node on the coarser countryCode both merged distinct
+    # authorities and minted IRIs that validator rejects ('gb' is not a
+    # registry key; 'uk' is).
+    it 'keys the authority node on its id rather than its country code' do
+      entity = { '@id' => 'https://www.ammitto.org/entity/uk/test1' }
+      entry = {
+        '@id' => 'https://www.ammitto.org/entry/uk/test1',
+        'authority' => {
+          'id' => 'uk',
+          'name' => 'United Kingdom (OFSI)',
+          'countryCode' => 'GB'
+        }
+      }
+
+      exporter.add_node(entity: entity, entry: entry, source: :uk)
+
+      expect(exporter.authorities).to have_key('uk')
+      expect(exporter.authorities).not_to have_key('gb')
+      expect(entry['authority'])
+        .to eq({ '@id' => 'https://www.ammitto.org/authority/uk' })
+    end
+
+    it 'keeps the declared country code on the id-keyed authority node' do
+      entity = { '@id' => 'https://www.ammitto.org/entity/uk/test1' }
+      entry = {
+        '@id' => 'https://www.ammitto.org/entry/uk/test1',
+        'authority' => {
+          'id' => 'uk',
+          'name' => 'United Kingdom (OFSI)',
+          'countryCode' => 'GB'
+        }
+      }
+
+      exporter.add_node(entity: entity, entry: entry, source: :uk)
+
+      expect(exporter.authorities['uk']['countryCode']).to eq('GB')
+    end
+
+    # eu and eu_vessels are separate registry entries that both declare
+    # countryCode EU. Keyed by country they collapsed into one node whose
+    # name was decided by ingestion order.
+    it 'keeps authorities sharing a country code distinct' do
+      exporter.add_node(
+        entity: { '@id' => 'https://www.ammitto.org/entity/eu/test1' },
+        entry: {
+          '@id' => 'https://www.ammitto.org/entry/eu/test1',
+          'authority' => {
+            'id' => 'eu', 'name' => 'European Union', 'countryCode' => 'EU'
+          }
+        },
+        source: :eu
+      )
+      exporter.add_node(
+        entity: { '@id' => 'https://www.ammitto.org/entity/eu_vessels/test1' },
+        entry: {
+          '@id' => 'https://www.ammitto.org/entry/eu_vessels/test1',
+          'authority' => {
+            'id' => 'eu_vessels',
+            'name' => 'EU Designated Vessels (via Denmark DMA)',
+            'countryCode' => 'EU'
+          }
+        },
+        source: :eu_vessels
+      )
+
+      expect(exporter.authorities.keys).to contain_exactly('eu', 'eu_vessels')
+      expect(exporter.authorities['eu']['name']).to eq('European Union')
+      expect(exporter.authorities['eu_vessels']['name'])
+        .to eq('EU Designated Vessels (via Denmark DMA)')
+    end
+
+    it 'still falls back to the country code when there is no id' do
+      entity = { '@id' => 'https://www.ammitto.org/entity/un/test1' }
+      entry = {
+        '@id' => 'https://www.ammitto.org/entry/un/test1',
+        'authority' => { 'name' => 'United Nations', 'countryCode' => 'UN' }
+      }
+
+      exporter.add_node(entity: entity, entry: entry, source: :un)
+
+      expect(exporter.authorities).to have_key('un')
+      expect(exporter.authorities['un']['countryCode']).to eq('UN')
+    end
+
     it 'extracts and deduplicates regimes' do
       entity = { '@id' => 'https://www.ammitto.org/entity/un/test1', '@type' => 'PersonEntity' }
       entry = {

--- a/spec/ammitto/serialization/search_index_exporter_spec.rb
+++ b/spec/ammitto/serialization/search_index_exporter_spec.rb
@@ -43,6 +43,34 @@ RSpec.describe Ammitto::Serialization::SearchIndexExporter do
       expect(exporter.entities.first[:status]).to eq('active')
     end
 
+    # JsonLdSerializer#serialize_authority emits 'id', never '@id'. Under
+    # harmonize the graph exporter rewrites that hash into an '@id'
+    # reference before the indexer sees it, but this exporter is also
+    # documented for standalone use, and there the row must carry the
+    # authority's own id, not the country it happens to sit in.
+    it 'reads the authority id from an unrewritten authority hash' do
+      entity = {
+        '@id' => 'https://www.ammitto.org/entity/eu_vessels/9999999',
+        'entityType' => 'vessel',
+        'names' => [{ 'fullName' => 'Test Vessel', 'isPrimary' => true }]
+      }
+
+      entry = {
+        '@id' => 'https://www.ammitto.org/entry/eu_vessels/9999999',
+        'authority' => {
+          '@type' => 'Authority',
+          'id' => 'eu_vessels',
+          'name' => 'EU Designated Vessels (via Denmark DMA)',
+          'countryCode' => 'EU'
+        },
+        'status' => 'active'
+      }
+
+      exporter.add(entity, entry)
+
+      expect(exporter.entities.first[:authority]).to eq('eu_vessels')
+    end
+
     it 'extracts multiple names' do
       entity = {
         '@id' => 'https://www.ammitto.org/entity/un/test',


### PR DESCRIPTION
`JsonLdGraphExporter#extract_authority` keyed each authority node on
`authority['countryCode']` before `authority['id']`, so an authority whose id
differs from its country code lost its identity in the published graph. UK
became `/authority/gb`, and `eu_vessels`, `un_vessels` and `jp_meti` collapsed
into `eu`, `un` and `jp`.

`gb` is not a valid authority in this gem. `Schema::Validator` checks
`authority['id']` against `Authority::REGISTRY` and rejects it as
`Unknown authority: gb`, it has no display name, and the committed `api/v1`
carries `/authority/uk` 6,036 times and `/authority/gb` zero times. So the
current code would move every published UK authority reference the next time
harmonize runs.

## Changes

- Prefer `authority['id']` over `authority['countryCode']` when keying an
  authority node, so the IRI carries the authority's own identifier.
- Derive the stored `countryCode` from `authority['countryCode']` rather than
  from the IRI key. Without this the corrected key would write
  `countryCode: "EU_VESSELS"`.
- Apply the same ordering to the Hash fallback in
  `SearchIndexExporter#extract_authority_code`, which carried an independent
  copy of the defect and is reachable when the graph exporter has not run.
- Add `spec/ammitto/serialization/authority_identity_spec.rb` covering the four
  registered authorities whose id and country code differ.

## Why now

`Authority::REGISTRY` has distinguished `uk` from `GB` since February, so this
is not a regression introduced by the vessel sources; those additions widened
an existing latent error to authorities sharing `EU`, `UN` and `JP`.

## Test plan

- `bundle exec rake` — 1283 examples, 0 failures
- `bundle exec rubocop` — 412 files, no offenses
- The new spec fails on `main` and passes here.

`ammitto.github.io#7` renames the site's vessel source codes to the underscore
forms and filters on this field; its search filter returns nothing until this
lands.
