### PR TITLE
Split AU citizenships on the separator the source uses and stop asserting unresolved dates

### DIFF
--- a/lib/ammitto/sources/au/sanctions_list.rb
+++ b/lib/ammitto/sources/au/sanctions_list.rb
@@ -217,12 +217,16 @@ module Ammitto
             cleaned = cleaned.sub(/^circa\s*|^c\.\s*|^c\s*/, '')
           end
 
-          # Try full date: "5 May 1957" or "May 5, 1957"
-          if (match = cleaned.match(/(\d{1,2})\s+(\w+)\s+(\d{4})/))
+          # Try full date: "5 May 1957" or "May 5, 1957".
+          #
+          # The day group is guarded with (?<!\d) so it cannot match inside a
+          # four-digit year. Without it, "Approximately: Between 1959 and 1965"
+          # matched "59 and 1965" and yielded day 59 of month 0.
+          if (match = cleaned.match(/(?<!\d)(\d{1,2})\s+(\w+)\s+(\d{4})/))
             flexible.day = match[1].to_i
             flexible.month = parse_month(match[2])
             flexible.year = match[3].to_i
-          elsif (match = cleaned.match(/(\w+)\s+(\d{1,2}),?\s+(\d{4})/))
+          elsif (match = cleaned.match(/(\w+)\s+(?<!\d)(\d{1,2}),?\s+(\d{4})/))
             flexible.month = parse_month(match[1])
             flexible.day = match[2].to_i
             flexible.year = match[3].to_i
@@ -238,7 +242,27 @@ module Ammitto
             flexible.precision = 'year' unless flexible.circa
           end
 
+          # parse_month yields 0 for a word that is not a month, and every
+          # branch above stored that unchecked. A record then asserted month 0
+          # at full precision -- a claim the source never made.
+          demote_unresolved_month(flexible)
+
           flexible
+        end
+
+        # Reduce a parse that never resolved its month to the precision it
+        # actually reached, so no record asserts a month or day the source did
+        # not state.
+        # @param flexible [FlexibleDate] the parse being finalised
+        # @return [void]
+        def self.demote_unresolved_month(flexible)
+          return unless flexible.month.nil? || flexible.month.to_i.zero?
+
+          flexible.month = nil
+          flexible.day = nil
+          return if flexible.circa
+
+          flexible.precision = flexible.year ? 'year' : 'unknown'
         end
 
         def self.parse_month(month_str)
@@ -522,11 +546,15 @@ module Ammitto
             end
           end
 
-          # Parse citizenships (comma-separated)
+          # Parse citizenships. DFAT separates them with a semicolon, not a
+          # comma: of 6304 non-empty cells, 389 carry ';' and 79 carry ','
+          # inside a single country name. "Congo, Democratic Republic of
+          # the;Rwanda" is both at once, so splitting on ',' tore one country
+          # into two that do not exist
           cit_str = row['Citizenship']
           return unless cit_str && !cit_str.empty?
 
-          cit_str.split(',').map(&:strip).reject(&:empty?).each do |cit|
+          cit_str.split(';').map(&:strip).reject(&:empty?).each do |cit|
             citizenships << cit unless citizenships.include?(cit)
           end
         end

--- a/lib/ammitto/sources/au/sanctions_list.rb
+++ b/lib/ammitto/sources/au/sanctions_list.rb
@@ -199,7 +199,10 @@ module Ammitto
         attribute :month, :integer
         attribute :day, :integer
         attribute :circa, :boolean       # Approximate date
-        attribute :precision, :string    # 'full', 'month', 'year', 'circa'
+        # 'full', 'month', 'year', 'circa', or 'unknown' when the cell held
+        # no resolvable date at all. Nothing in the gem branches on this
+        # value; it is descriptive metadata carried alongside raw_value.
+        attribute :precision, :string
 
         def self.parse(date_str)
           return nil if date_str.nil? || date_str.empty?
@@ -253,6 +256,17 @@ module Ammitto
         # Reduce a parse that never resolved its month to the precision it
         # actually reached, so no record asserts a month or day the source did
         # not state.
+        #
+        # Month and day are cleared, and precision becomes:
+        #   'circa'   — left as-is, the circa marker already says the date is
+        #               approximate and outranks the missing month
+        #   'year'    — a year resolved, so the record still carries one
+        #   'unknown' — nothing resolved at all, e.g. the cell "5/06/1978,  "
+        #               whose second comma-separated element is a lone space
+        #
+        # 'unknown' is a state callers did not previously see. It is emitted
+        # into the serialized YAML.
+        #
         # @param flexible [FlexibleDate] the parse being finalised
         # @return [void]
         def self.demote_unresolved_month(flexible)

--- a/spec/ammitto/sources/au/flexible_date_spec.rb
+++ b/spec/ammitto/sources/au/flexible_date_spec.rb
@@ -41,6 +41,30 @@ RSpec.describe Ammitto::Sources::Au::FlexibleDate do
     it 'returns nil for nil' do
       expect(described_class.parse(nil)).to be_nil
     end
+
+    # DFAT publishes ranges in this shape. The day group used to match the
+    # "59" inside 1959, and parse_month returned 0 for "and", so the record
+    # asserted day 59 of month 0 at full precision.
+    it 'does not read a day out of the middle of a year' do
+      date = described_class.parse('Approximately: Between 1959 and 1965')
+
+      expect(date.day).to be_nil
+      expect(date.month).to be_nil
+      expect(date.precision).to eq('year')
+    end
+
+    it 'drops a month that did not resolve rather than storing zero' do
+      date = described_class.parse('Approximately 1958')
+
+      expect(date.month).to be_nil
+      expect(date.year).to eq(1958)
+      expect(date.precision).to eq('year')
+    end
+
+    it 'reports full precision only when the month actually resolved' do
+      expect(described_class.parse('5 May 1957').precision).to eq('full')
+      expect(described_class.parse('5 Foo 1957').precision).to eq('year')
+    end
   end
 
   describe '#to_date' do

--- a/spec/ammitto/sources/au/sanctions_list_spec.rb
+++ b/spec/ammitto/sources/au/sanctions_list_spec.rb
@@ -15,6 +15,29 @@ RSpec.describe Ammitto::Sources::Au::SanctionsList do
     CSV
   end
 
+  # DFAT separates citizenships with a semicolon and leaves commas inside
+  # country names. "Congo, Democratic Republic of the;Rwanda" is both at once:
+  # splitting on the comma invented two countries that do not exist and lost
+  # Rwanda entirely. Measured on the live workbook, 389 of 6304 non-empty
+  # cells carry a semicolon and 79 carry a comma.
+  describe 'citizenship separator' do
+    let(:multi_citizenship_csv) do
+      header, individual = sample_csv.lines.first(2)
+      fields = individual.chomp.split(',', -1)
+      # Citizenship is the eighth column; quote it so the comma inside the
+      # country name survives CSV parsing the way DFAT's export does.
+      fields[7] = '"Congo, Democratic Republic of the;Rwanda"'
+      "#{header}#{fields.join(',')}\n"
+    end
+
+    it 'splits on the semicolon and keeps a comma inside a country name' do
+      list = described_class.from_csv(multi_citizenship_csv)
+
+      expect(list.individuals.first.citizenships)
+        .to eq(['Congo, Democratic Republic of the', 'Rwanda'])
+    end
+  end
+
   describe '.from_csv' do
     subject(:list) { described_class.from_csv(sample_csv) }
 


### PR DESCRIPTION
`ammitto fetch au` wrote values the DFAT workbook never stated. A pre-merge
simulation of `ammitto/data-au#3` — which makes `processed/` trackable, so the
first automated commit enters permanent history — found two parser defects
across the fetched corpus: 22 date objects carrying `month: 0`, one carrying
`day: 59`, and 85 records whose citizenship was a single semicolon-joined
string.

## Citizenship separator

DFAT separates citizenships with `;` and leaves `,` inside country names. Read
from the raw workbook: of 6,304 non-empty Citizenship cells, 389 contain a
semicolon and 79 contain a comma. One cell is both at once:

    Congo, Democratic Republic of the;Rwanda

Splitting on `,` invented two countries that do not exist and dropped Rwanda.
`SanctionedEntity` now splits on `;`.

Note the measurement is taken from the workbook, not from parsed output —
commas were absent from the parsed values only because they had already been
consumed as separators.

## Dates asserting values the source never gave

`FlexibleDate.parse` had two faults that compounded:

- The full-date regex was unanchored, so `Approximately: Between 1959 and 1965`
  matched `59 and 1965` inside the year 1959 and yielded `day: 59`.
- `parse_month` returns `0` for any unrecognised word, and every branch stored
  that unchecked. `parse_month('and')` is `0`.

The record was then emitted as `day: 59, month: 0, precision: full` — a
full-precision claim over a date the source expressed as a range.

- Both day groups are guarded with `(?<!\d)` so a day cannot be read out of a
  four-digit year.
- `demote_unresolved_month` clears an unresolved month and day and reports the
  precision actually reached.

## Effect on the corpus

Re-running the fetch with these changes, measured by walking every emitted
YAML rather than by counting files:

- `month: 0` — 22 occurrences before, 0 after
- day outside 1..31 — 1 before, 0 after
- `precision: full` without a month — 1 before, 0 after
- all five surviving full-precision dates read back correctly against their
  raw value, so no legitimate date was lost to the guard
- filenames are identical between runs, so no tracked record is orphaned
- 121 already-committed records are corrected by the same run

One record now reports `precision: unknown`: its source cell is `5/06/1978,  `
and the second comma-separated element is a single space. The previous parser
reported that as `full`.

## Known limitation

`Between 1959 and 1965` now resolves to 1959 rather than 1965. Neither endpoint
is what the source said. The source elsewhere expresses uncertainty as an
explicit list of candidate years (`1968, 1969, 1970, 1971, 1972, 1973`), which
this parser already models as a collection, so the range is better expanded
into its candidate years. Seven cells are affected; that change is not in this
PR.

## Test plan

- `bundle exec rake` — 1274 examples, 0 failures
- `bundle exec rubocop` — 411 files, no offenses
- All four new specs verified to fail on `main` before the fix was committed.
