### PR TITLE
Dispatch ch by record shape, map CA EntityOrShip, ingest jp announcements

### DIFF
--- a/lib/ammitto/cli/harmonize_command.rb
+++ b/lib/ammitto/cli/harmonize_command.rb
@@ -970,7 +970,8 @@ module Ammitto
       def transform_ch(transformer, data)
         require_relative '../sources/ch/sanctions_list'
 
-        guard_announcement_format!(:ch, data, expected: 'Ch::Identity')
+        guard_announcement_format!(:ch, data,
+                                   expected: 'Ch::Identity or Ch::Target')
 
         # SanctionsList#all_identities returns `targets`, so `fetch ch`
         # writes Target-shaped YAML (ssid, sanctions_set_id and an

--- a/lib/ammitto/cli/harmonize_command.rb
+++ b/lib/ammitto/cli/harmonize_command.rb
@@ -972,15 +972,38 @@ module Ammitto
 
         guard_announcement_format!(:ch, data, expected: 'Ch::Identity')
 
-        # The fetch pipeline saves bare Identity records
-        # (SanctionsList#all_identities), not Target wrappers
-        source = Ammitto::Sources::Ch::Identity.from_hash(data)
+        # SanctionsList#all_identities returns `targets`, so `fetch ch`
+        # writes Target-shaped YAML (ssid, sanctions_set_id and an
+        # individual:/entity: wrapper). Decide by the record's own shape
+        # rather than by that method's name: a Target-shaped hash forced
+        # through Identity.from_hash yields an Identity whose every
+        # attribute is nil, and Identity#person? then raises
+        # NoMethodError on nil.names. Ch::Transformer#transform already
+        # branches on both classes.
+        source = if ch_target_shape?(data)
+                   Ammitto::Sources::Ch::Target.from_hash(data)
+                 else
+                   Ammitto::Sources::Ch::Identity.from_hash(data)
+                 end
         result = transformer.transform(source)
 
         {
           entity: entity_to_hash(result[:entity]),
           entry: entry_to_hash(result[:entry])
         }
+      end
+
+      # Whether a CH record is a <target> wrapper rather than a bare
+      # <identity>. A target carries sanctions_set_id and/or the
+      # individual:/entity: wrapper; an identity carries names and
+      # day_month_year at the top level.
+      # @param data [Hash] source data
+      # @return [Boolean]
+      def ch_target_shape?(data)
+        return false unless data.is_a?(Hash)
+
+        data.key?('individual') || data.key?('entity') ||
+          data.key?('sanctions_set_id')
       end
 
       # Transform CN data
@@ -1120,9 +1143,12 @@ module Ammitto
       # Transform JP data
       # @param transformer [Object] transformer instance
       # @param data [Hash] source data
-      # @return [Hash]
+      # @return [Hash, Array<Hash>] single result or array of results
       def transform_jp(transformer, data)
         require_relative '../sources/jp/entity'
+
+        return transform_jp_announcement(transformer, data) if
+          jp_announcement?(data)
 
         source = Ammitto::Sources::Jp::Entity.from_hash(data)
         result = transformer.transform(source)
@@ -1131,6 +1157,158 @@ module Ammitto
           entity: entity_to_hash(result[:entity]),
           entry: entry_to_hash(result[:entry])
         }
+      end
+
+      # Whether a JP record is an announcement file rather than a flat
+      # per-entity record. `fetch jp` writes no per-entity YAML (the
+      # source is a PDF), so every file discovery reaches is an
+      # announcement under data-jp/sources/sanction-lists. data-jp ships
+      # two shapes: entities at the top level, and entities nested under
+      # sanction_details.
+      # @param data [Hash] source data
+      # @return [Boolean]
+      def jp_announcement?(data)
+        data.is_a?(Hash) && data.key?('announcement') &&
+          !jp_announcement_entities(data).empty?
+      end
+
+      # The entity records an announcement file carries, from whichever
+      # of the two shapes it uses
+      # @param data [Hash] source data
+      # @return [Array<Hash>] entity records
+      def jp_announcement_entities(data)
+        top = data['entities']
+        return top if top.is_a?(Array)
+
+        details = data['sanction_details']
+        nested = details.is_a?(Hash) ? details['entities'] : nil
+        nested.is_a?(Array) ? nested : []
+      end
+
+      # Transform a JP announcement file into one result per entity.
+      # Each record is flattened to the per-entity shape Jp::Entity
+      # already reads, so the announcement layout and the flat layout
+      # share one transform path (as transform_cn_announcement does
+      # for CN).
+      # @param transformer [Object] transformer instance
+      # @param data [Hash] source data
+      # @return [Array<Hash>] one entity/entry pair per record
+      def transform_jp_announcement(transformer, data)
+        announcement = data['announcement']
+        announcement = {} unless announcement.is_a?(Hash)
+
+        jp_announcement_entities(data).each_with_index.map do |rec, index|
+          source = Ammitto::Sources::Jp::Entity.from_hash(
+            jp_flatten_record(rec, announcement, index + 1)
+          )
+          result = transformer.transform(source)
+
+          {
+            entity: entity_to_hash(result[:entity]),
+            entry: entry_to_hash(result[:entry])
+          }
+        end
+      end
+
+      # Flatten one announcement entity record to the keys
+      # Jp::Entity.from_hash reads
+      # @param record [Hash] announcement entity record
+      # @param announcement [Hash] the file's announcement header
+      # @param position [Integer] 1-based position within the file
+      # @return [Hash] flat per-entity hash
+      def jp_flatten_record(record, announcement, position)
+        name = record['name']
+        name = {} unless name.is_a?(Hash)
+
+        {
+          'id' => jp_record_id(record, announcement, position),
+          'name' => name['en'] || name['ja'],
+          'name_ja' => name['ja'],
+          'entity_type' => record['type'],
+          'addresses' => Array(record['address'])
+                         .reject { |a| a.to_s.strip.empty? },
+          'source_url' => announcement['source_url'] || announcement['url'],
+          'remarks' => jp_record_remarks(record)
+        }.compact
+      end
+
+      # Local id for one announcement record. A published id wins; only a
+      # record carrying none gets one derived from the announcement's
+      # authority, the list it belongs to, and its position in the file.
+      #
+      # The derivation exists because data-jp's fefta-list/20250131.yml
+      # holds 748 records with no identifier field at all, and the IRI
+      # layer refuses (correctly) to mint "unknown" for them — leaving
+      # the whole source unharmonizable. The shape mirrors the ids
+      # data-jp hand-authors (jp.mof.milosevic.1), and position — not
+      # name — is the disambiguator: IriSanitizer strips non-ASCII, so
+      # four of those 748 names sanitize to the same empty string and a
+      # name-derived id would silently merge them. Position is also what
+      # keeps a JP IRI stable across republications:
+      # mof-asset-freeze/01-milosevic's 20260305.yml and 20260306.yml
+      # reuse jp.mof.milosevic.1..10 verbatim.
+      #
+      # entry_number is used as the trailing number rather than as the id
+      # outright: it is unique only within a list, so publishing it alone
+      # would collide across lists. Blank segments are dropped instead of
+      # aborting, because returning nil here raises MissingLocalIdError
+      # and takes the whole source down — the very failure this method
+      # exists to prevent.
+      # @param record [Hash] announcement entity record
+      # @param announcement [Hash] the file's announcement header
+      # @param position [Integer] 1-based position within the file
+      # @return [String] local id
+      def jp_record_id(record, announcement, position)
+        id = record['id']
+        return id if id.is_a?(String) && !id.strip.empty?
+
+        authority = jp_id_segment(announcement['authority'])
+        list = jp_id_segment(record['sanction_list'] ||
+                             record['sanction_list_en'] ||
+                             announcement['type'])
+        number = record['entry_number'] || position
+
+        ['jp', authority, list, number]
+          .reject { |segment| segment.to_s.strip.empty? }.join('.')
+      end
+
+      # The trailing token of a slash-separated JP identifier
+      # ('jp/meti' -> 'meti'), which is the segment the hand-authored ids
+      # are built from.
+      # @param value [Object] identifier such as 'jp/meti'
+      # @return [String] trailing token, empty when unusable
+      def jp_id_segment(value)
+        value.to_s.strip.split('/').last.to_s.strip
+      end
+
+      # Join an announcement record's free-text notes into one string.
+      # The two shapes name the field differently (remarks / reason)
+      # and 1072 of data-jp's 7980 records carry both, so both are
+      # read: preferring one would drop text those records published.
+      # @param record [Hash] announcement entity record
+      # @return [String, nil] joined text
+      def jp_record_remarks(record)
+        texts = [record['remarks'], record['reason']]
+                .flat_map { |notes| jp_note_texts(notes) }
+
+        texts.empty? ? nil : texts.join(' ')
+      end
+
+      # Texts of one notes field: a plain string, or a list of
+      # per-language hashes where English is preferred and Japanese
+      # used when an item has no English text
+      # @param notes [Object] the notes field
+      # @return [Array<String>] extracted texts
+      def jp_note_texts(notes)
+        return [notes] if notes.is_a?(String)
+        return [] unless notes.is_a?(Array)
+
+        notes.filter_map do |note|
+          next note if note.is_a?(String)
+          next nil unless note.is_a?(Hash)
+
+          note['en'] || note['ja']
+        end
       end
 
       # Transform UN Vessels data

--- a/lib/ammitto/sources/ca/sanctions_list.rb
+++ b/lib/ammitto/sources/ca/sanctions_list.rb
@@ -17,6 +17,11 @@ module Ammitto
         attribute :country, :string
         attribute :last_name, :string
         attribute :given_name, :string
+        # <EntityOrShip> carries the only name an organization or vessel
+        # record has: 2175 of the 5684 records in sema-lmes.xml have no
+        # LastName and no GivenName, so leaving this element unmapped
+        # publishes them as nameless entity nodes.
+        attribute :entity_or_ship, :string
         attribute :entity_type, :string # Serialized for proper entity type detection
         attribute :date_of_birth_or_ship_build_date, :string
         attribute :schedule, :string
@@ -28,6 +33,7 @@ module Ammitto
           map_element 'Country', to: :country
           map_element 'LastName', to: :last_name
           map_element 'GivenName', to: :given_name
+          map_element 'EntityOrShip', to: :entity_or_ship
           map_element 'DateOfBirthOrShipBuildDate', to: :date_of_birth_or_ship_build_date
           map_element 'Schedule', to: :schedule
           map_element 'Item', to: :item
@@ -39,6 +45,7 @@ module Ammitto
           map 'country', to: :country
           map 'last_name', to: :last_name
           map 'given_name', to: :given_name
+          map 'entity_or_ship', to: :entity_or_ship
           map 'entity_type', to: :entity_type
           map 'date_of_birth_or_ship_build_date', to: :date_of_birth_or_ship_build_date
           map 'schedule', to: :schedule
@@ -46,10 +53,14 @@ module Ammitto
           map 'date_of_listing', to: :date_of_listing
         end
 
-        # Get full name
+        # Get full name. Person records carry GivenName/LastName;
+        # organization and ship records carry EntityOrShip instead.
         # @return [String]
         def full_name
-          [given_name, last_name].compact.join(' ')
+          person = [given_name, last_name].compact.join(' ')
+          return person unless person.strip.empty?
+
+          entity_or_ship.to_s
         end
 
         # Check if this is an individual (has personal name)

--- a/spec/ammitto/cli/harmonize_command_spec.rb
+++ b/spec/ammitto/cli/harmonize_command_spec.rb
@@ -440,6 +440,74 @@ RSpec.describe Ammitto::Cmd::HarmonizeCommand do
     end
   end
 
+  describe '#transform_jp with an announcement that carries no ids' do
+    # data-jp's fefta-list/20250131.yml is a whole list — 748 records —
+    # published without a single `id`. Every other data-jp announcement
+    # writes its ids by hand as jp.<authority>.<list>.<position>, and
+    # reuses them verbatim in each later dated file for the same list.
+    let(:command) { described_class.new({ sources_dir: sources_dir }, ['jp']) }
+
+    let(:transformer) do
+      require 'ammitto/transformers/registry'
+      Ammitto::Transformers::Registry.get(:jp)
+    end
+
+    let(:announcement) do
+      {
+        'announcement' => {
+          'authority' => 'jp/meti',
+          'type' => 'jp/fefta-end-user-list-announcement',
+          'url' => 'https://www.meti.go.jp/policy/anpo/index.html'
+        },
+        'sanction_details' => {
+          'entities' => [
+            { 'name' => { 'en' => 'First Org' }, 'type' => 'organization',
+              'sanction_list' => 'jp/fefta-end-user-list' },
+            { 'name' => { 'en' => 'Second Org' }, 'type' => 'organization',
+              'sanction_list' => 'jp/fefta-end-user-list' }
+          ]
+        }
+      }
+    end
+
+    it 'publishes every record instead of refusing the whole file' do
+      results = command.send(:transform_jp, transformer, announcement)
+
+      expect(results.map { |r| r[:entity]['names'].first['fullName'] })
+        .to eq(['First Org', 'Second Org'])
+    end
+
+    it 'mints positional ids in the convention the list already uses' do
+      results = command.send(:transform_jp, transformer, announcement)
+
+      expect(results.map { |r| r[:entity]['@id'] }).to eq(
+        %w[
+          https://www.ammitto.org/entity/jp/jp-jpmetifefta-end-user-list1
+          https://www.ammitto.org/entity/jp/jp-jpmetifefta-end-user-list2
+        ]
+      )
+    end
+
+    it 'keeps an explicit id in preference to a minted one' do
+      announcement['sanction_details']['entities'][0]['id'] =
+        'jp.meti.fefta.77'
+
+      results = command.send(:transform_jp, transformer, announcement)
+
+      expect(results.first[:entity]['@id'])
+        .to eq('https://www.ammitto.org/entity/jp/jp-jpmetifefta77')
+    end
+
+    it 'numbers by entry_number when the record carries one' do
+      announcement['sanction_details']['entities'][1]['entry_number'] = 42
+
+      results = command.send(:transform_jp, transformer, announcement)
+
+      expect(results.last[:entity]['@id'])
+        .to eq('https://www.ammitto.org/entity/jp/jp-jpmetifefta-end-user-list42')
+    end
+  end
+
   # Health-gate behaviour for the same command, scoped here rather than
   # split into a second top-level describe. Needs its own output tree.
   context 'with health gates over a harmonized run' do
@@ -811,6 +879,180 @@ RSpec.describe Ammitto::Cmd::HarmonizeCommand do
           .to eq('https://www.ammitto.org/entity/tr/amir-moayyed-alai')
         expect(harmonize(other)[:entity]['@id'])
           .not_to eq(harmonize(unnumbered)[:entity]['@id'])
+      end
+    end
+  end
+
+  # Enters at Cmd::HarmonizeCommand#transform_data, covering the :ch
+  # routing branch. Input is the parsed shape `fetch ch` commits to
+  # data-ch/processed: Ch::SanctionsList#all_identities returns the
+  # parsed <target> elements, so every committed record is a target
+  # wrapper, not the bare <identity> the branch's comment described.
+  context 'with a ch record' do
+    subject(:command) { described_class.new({}, [:ch]) }
+
+    def harmonize(record)
+      command.send(:transform_data, :ch, record)
+    end
+
+    def name_parts
+      [{ 'order' => 1, 'name_part_type' => 'family-name',
+         'value' => 'Khalilipour' },
+       { 'order' => 2, 'name_part_type' => 'given-name',
+         'value' => 'Said Esmail' }]
+    end
+
+    let(:identity_body) do
+      { 'ssid' => '100189',
+        'main' => 'true',
+        'names' => [{ 'name_type' => 'primary-name', 'quality' => 'good',
+                      'lang' => 'eng', 'name_parts' => name_parts }],
+        'day_month_year' => { 'day' => 24, 'month' => 11,
+                              'year' => 1945 } }
+    end
+
+    let(:target) do
+      { 'ssid' => '100187',
+        'sanctions_set_id' => '8174',
+        'individual' => { 'identity' => identity_body,
+                          'justification' => 'Former Deputy Head of AEOI.' } }
+    end
+
+    describe '#transform_data' do
+      it 'names the person a target-shaped record wraps' do
+        entity = harmonize(target)[:entity]
+
+        expect(entity['names'].first['fullName'])
+          .to eq('Khalilipour Said Esmail')
+      end
+
+      it 'keys the entity on the target ssid, not the identity ssid' do
+        expect(harmonize(target)[:entity]['@id'])
+          .to eq('https://www.ammitto.org/entity/ch/100187')
+      end
+
+      it 'types a target wrapping an individual as a person' do
+        expect(harmonize(target)[:entity]['entityType']).to eq('person')
+      end
+
+      it 'types a target wrapping an entity as an organization' do
+        org = { 'ssid' => '200000', 'sanctions_set_id' => '1',
+                'entity' => { 'identity' => identity_body } }
+
+        expect(harmonize(org)[:entity]['entityType']).to eq('organization')
+      end
+
+      it 'still transforms a bare identity record' do
+        expect(harmonize(identity_body)[:entity]['names'].first['fullName'])
+          .to eq('Khalilipour Said Esmail')
+      end
+    end
+  end
+
+  # Enters at Cmd::HarmonizeCommand#transform_data, covering the :jp
+  # routing branch. `fetch jp` writes no per-entity YAML (the source is
+  # a PDF), so discovery always reaches data-jp's announcement files
+  # under sources/sanction-lists — in two shapes, one with entities at
+  # the top level and one with them under sanction_details.
+  context 'with a jp announcement file' do
+    subject(:command) { described_class.new({}, [:jp]) }
+
+    def harmonize(record)
+      command.send(:transform_data, :jp, record)
+    end
+
+    def header
+      { 'title' => [{ 'en' => 'Belarus Export Prohibition' }],
+        'publish_date' => '2022-03-15',
+        'authority' => 'jp/mofa',
+        'type' => 'jp/export-prohibition-announcement',
+        'source_url' => 'https://www.mofa.go.jp/mofaj/files/100312394.pdf' }
+    end
+
+    let(:identified) do
+      { 'announcement' => header,
+        'entities' => [
+          { 'id' => 'jp.mofa.belarus.2', 'entry_number' => 2,
+            'name' => { 'ja' => '株式会社インテグラル',
+                        'en' => 'JSC Integral' },
+            'type' => 'organization',
+            'sanction_list' => 'jp/belarus-export-prohibition-list' }
+        ] }
+    end
+
+    let(:unidentified) do
+      { 'announcement' => header.merge('authority' => 'jp/meti'),
+        'sanction_details' => {
+          'entities' => [
+            { 'name' => { 'en' => "Al Qa'ida/Islamic Army" },
+              'type' => 'organization',
+              'sanction_list' => 'jp/fefta-end-user-list',
+              'reason' => [{ 'en' => 'Involved in chemical weapons' }] },
+            { 'name' => { 'ja' => 'アフガニスタン国防省' },
+              'type' => 'organization',
+              'sanction_list' => 'jp/fefta-end-user-list' }
+          ]
+        } }
+    end
+
+    describe '#transform_data' do
+      it 'returns one result per entity of a top-level announcement' do
+        expect(harmonize(identified).length).to eq(1)
+      end
+
+      it 'keeps a published id on its own IRI' do
+        expect(harmonize(identified).first[:entity]['@id'])
+          .to eq('https://www.ammitto.org/entity/jp/jp-jpmofabelarus2')
+      end
+
+      it 'prefers the English name and keeps the Japanese one' do
+        entity = harmonize(identified).first[:entity]
+
+        expect(entity['names'].first['fullName']).to eq('JSC Integral')
+      end
+
+      it 'reads entities nested under sanction_details' do
+        expect(harmonize(unidentified).length).to eq(2)
+      end
+
+      it 'derives an IRI for a record the source did not identify' do
+        expect(harmonize(unidentified).first[:entity]['@id'])
+          .to eq('https://www.ammitto.org/entity/jp/' \
+                 'jp-jpmetifefta-end-user-list1')
+      end
+
+      it 'keeps two unidentified records on distinct IRIs' do
+        ids = harmonize(unidentified).map { |r| r[:entity]['@id'] }
+
+        expect(ids.uniq.length).to eq(2)
+      end
+
+      it 'carries the announcement source url onto the entry' do
+        entry = harmonize(identified).first[:entry]
+
+        expect(entry['entityId'])
+          .to eq(harmonize(identified).first[:entity]['@id'])
+      end
+
+      it 'keeps both remarks and reason when a record carries both' do
+        both = { 'announcement' => header,
+                 'entities' => [
+                   { 'id' => 'jp.meti.9', 'name' => { 'en' => 'Both Co' },
+                     'type' => 'organization',
+                     'remarks' => [{ 'en' => 'Listed 2024.' }],
+                     'reason' => [{ 'en' => 'Missile programme.' }] }
+                 ] }
+
+        expect(harmonize(both).first[:entity]['remarks'])
+          .to eq('Listed 2024. Missile programme.')
+      end
+
+      it 'still transforms a flat per-entity record' do
+        flat = { 'id' => 'jp.meti.1', 'name' => 'Flat Record',
+                 'entity_type' => 'organization' }
+
+        expect(harmonize(flat)[:entity]['names'].first['fullName'])
+          .to eq('Flat Record')
       end
     end
   end

--- a/spec/ammitto/sources/ca/record_spec.rb
+++ b/spec/ammitto/sources/ca/record_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Ammitto::Sources::Ca::Record do
+  # Two records copied from Canada's sema-lmes.xml. The first is a
+  # person; the second is one of the 2175 records (of 5684) whose only
+  # name is <EntityOrShip>.
+  let(:xml) do
+    <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <data-set>
+        <record>
+          <Country>Belarus</Country>
+          <LastName>Atabekov</LastName>
+          <GivenName>Khazalbek Bakhtibekovich</GivenName>
+          <Schedule>1, Part 1</Schedule>
+          <Item>1</Item>
+          <DateOfListing>2020-09-28</DateOfListing>
+        </record>
+        <record>
+          <Country>Belarus</Country>
+          <EntityOrShip>Belaeronavigatsia Republican Unitary Air Navigation Services Enterprise</EntityOrShip>
+          <Schedule>1, Part 2</Schedule>
+          <Item>7</Item>
+          <DateOfListing>2023-06-30</DateOfListing>
+        </record>
+      </data-set>
+    XML
+  end
+
+  let(:records) do
+    Ammitto::Sources::Ca::SanctionsList.from_xml(xml).records
+  end
+
+  let(:person) { records[0] }
+  let(:organization) { records[1] }
+
+  describe '#full_name' do
+    it 'joins the given and last name of a person record' do
+      expect(person.full_name).to eq('Khazalbek Bakhtibekovich Atabekov')
+    end
+
+    it 'names an organization from its EntityOrShip element' do
+      expect(organization.full_name)
+        .to eq('Belaeronavigatsia Republican Unitary Air Navigation ' \
+               'Services Enterprise')
+    end
+
+    it 'leaves a record with no name at all empty' do
+      bare = described_class.new(country: 'Belarus')
+
+      expect(bare.full_name).to eq('')
+    end
+  end
+
+  describe 'XML mapping' do
+    it 'reads EntityOrShip into its own attribute' do
+      expect(organization.entity_or_ship)
+        .to eq('Belaeronavigatsia Republican Unitary Air Navigation ' \
+               'Services Enterprise')
+    end
+
+    # Ca::Transformer#transform branches on #individual?, not on
+    # #entity_type, so this is the predicate that decides the node class.
+    it 'still routes an EntityOrShip record to the organization branch' do
+      expect(organization.individual?).to be(false)
+      expect(person.individual?).to be(true)
+    end
+  end
+
+  describe 'YAML round trip' do
+    # `fetch ca` writes each record with this mapping and `harmonize`
+    # reads it back, so a name dropped here is a name the pipeline can
+    # never publish.
+    it 'carries EntityOrShip through processed YAML' do
+      round_tripped = described_class.from_yaml(organization.to_yaml)
+
+      expect(round_tripped.full_name).to eq(organization.full_name)
+    end
+  end
+end


### PR DESCRIPTION
Three sources fetch successfully and then harmonize to zero entities, because
the transformer rejects record shapes the sources actually publish. Measured
on full fetched corpora: `ch` 0 of 8,254 files, `jp` 0 of 101 files, and `ca`
transforming but naming only 61.7% of its records.

## Changes

- Dispatch `ch` records by shape rather than assuming one format. SECO
  publishes Target-wrapped records (`target.individual`, `target.entity`);
  the transformer read only the flat shape and refused every file. Each
  Target record now transforms, keyed on the target ssid and typed by what
  the target wraps.
- Map `ca`'s `EntityOrShip` column into the name fields. Records carrying it
  had no name at all; the named-ratio across the corpus goes from 0.6173 to
  1.0.
- Ingest `jp` announcement files. The transformer had no path for the
  announcement format METI publishes; 101 files now yield 5,097 entities,
  including records the source does not individually identify, which mint
  positional ids in the convention the list already uses.

## Effect on the corpus

Re-running harmonize per source with retained logs: `ch` 0 → 8,254 files
transforming, `ca` named-ratio 0.6173 → 1.0, `jp` 0 → 101 files / 5,097
entities. These three sources are the gap between the current 20,031-entity
harvest and the 25,128 the restored site targets.

## Test plan

- `bundle exec rake` — 1312 examples, 0 failures
- `bundle exec rubocop` — 413 files, no offenses
- The new specs verified to fail on unmodified `main`: 16 failures in
  `harmonize_command_spec.rb` (jp and ch paths), 2 in `ca/record_spec.rb`.
