### PR TITLE
Refuse the blocked ru fetch loudly and stop swallowing scraper failures

### DIFF
--- a/docs/sources/index.adoc
+++ b/docs/sources/index.adoc
@@ -259,11 +259,11 @@ announcement-based reference documents; there is no automated fetch.
 
 Russia maintains the "Unfriendly Countries" list and related sanctions.
 
-[source,bash]
-----
-# Fetch Russia data
-ammitto fetch ru
-----
+Automated fetching is currently blocked: mid.ru answers every request with a
+JavaScript anti-bot challenge the scraper cannot pass (verified 2026-08-06).
+`ammitto fetch ru` reports this and exits nonzero, and `--all` skips RU, so a
+blocked scrape can never be mistaken for an empty list. The committed corpus
+in `data-ru` remains the data of record until a working path exists.
 
 === Turkey (`tr`)
 

--- a/docs/sources/index.adoc
+++ b/docs/sources/index.adoc
@@ -259,11 +259,16 @@ announcement-based reference documents; there is no automated fetch.
 
 Russia maintains the "Unfriendly Countries" list and related sanctions.
 
-Automated fetching is currently blocked: mid.ru answers every request with a
-JavaScript anti-bot challenge the scraper cannot pass (verified 2026-08-06).
-`ammitto fetch ru` reports this and exits nonzero, and `--all` skips RU, so a
-blocked scrape can never be mistaken for an empty list. The committed corpus
-in `data-ru` remains the data of record until a working path exists.
+Automated fetching is currently blocked. mid.ru answers every request --
+the announcement index and the article pages alike -- with a JavaScript
+anti-bot challenge that the HTML scraper cannot execute (verified
+2026-08-06). `ammitto fetch ru` reports the wall and exits nonzero rather
+than saving an empty result, and `ammitto fetch --all` skips RU, so a
+blocked scrape can never be mistaken for an empty sanctions list.
+
+Until a working fetch path exists, the committed corpus in the `data-ru`
+repository is the data of record; harmonization reads it directly and does
+not depend on the fetch.
 
 === Turkey (`tr`)
 

--- a/lib/ammitto/cli/fetch_command.rb
+++ b/lib/ammitto/cli/fetch_command.rb
@@ -108,7 +108,13 @@ module Ammitto
         # content links), so the Mechanize scraper structurally cannot see
         # the announcements. Refusing here beats a scrape that "succeeds"
         # with zero entities. Verified against the live site on 2026-08-06.
-        return error_result(source, 'RU data is manually managed in data-ru; mid.ru serves a JavaScript anti-bot challenge, so automated fetch is not supported') if source == :ru
+        if source == :ru
+          return error_result(source,
+                              'RU fetching is blocked: mid.ru serves a JavaScript ' \
+                              'anti-bot challenge the scraper cannot pass, so automated ' \
+                              'fetch does not work; refusing rather than reporting an ' \
+                              'empty scrape as success')
+        end
 
         extractor_class = extractor_class_for(source)
         return error_result(source, 'No extractor available') unless extractor_class

--- a/lib/ammitto/cli/fetch_command.rb
+++ b/lib/ammitto/cli/fetch_command.rb
@@ -103,6 +103,13 @@ module Ammitto
         # the extractor path returning success without writing anything.
         return error_result(source, 'CN data is manually managed in data-cn; automated fetch is not supported') if source == :cn
 
+        # RU has no automated fetch either: mid.ru answers every request with
+        # an F5/TSPD JavaScript anti-bot challenge shell (HTTP 200, zero
+        # content links), so the Mechanize scraper structurally cannot see
+        # the announcements. Refusing here beats a scrape that "succeeds"
+        # with zero entities. Verified against the live site on 2026-08-06.
+        return error_result(source, 'RU data is manually managed in data-ru; mid.ru serves a JavaScript anti-bot challenge, so automated fetch is not supported') if source == :ru
+
         extractor_class = extractor_class_for(source)
         return error_result(source, 'No extractor available') unless extractor_class
 

--- a/lib/ammitto/config/defaults.rb
+++ b/lib/ammitto/config/defaults.rb
@@ -34,11 +34,14 @@ module Ammitto
       # All available sources
       ALL_SOURCES = %i[eu un us wb uk au ca ch cn ru tr nz jp eu_vessels un_vessels].freeze
 
-      # Sources with an automated fetch path. CN is excluded: its YAML is
-      # manually managed in data-cn, so `fetch --all` must not fail on a
-      # source that cannot be fetched automatically (an explicit
-      # `fetch cn` still reports the manual-management error).
-      FETCHABLE_SOURCES = (ALL_SOURCES - %i[cn]).freeze
+      # Sources with an automated fetch path. CN and RU are excluded:
+      # their YAML is manually managed (data-cn, data-ru), so `fetch
+      # --all` must not fail on a source that cannot be fetched
+      # automatically (an explicit `fetch cn` / `fetch ru` still reports
+      # the manual-management error). RU cannot be scraped: mid.ru
+      # serves an F5/TSPD JavaScript anti-bot challenge to non-browser
+      # clients, so Mechanize never sees the announcement links.
+      FETCHABLE_SOURCES = (ALL_SOURCES - %i[cn ru]).freeze
 
       # Default output format
       DEFAULT_OUTPUT_FORMAT = 'jsonld'

--- a/lib/ammitto/extractors/ru_extractor.rb
+++ b/lib/ammitto/extractors/ru_extractor.rb
@@ -35,7 +35,16 @@ module Ammitto
 
       # Fetch raw data from Russia sources
       # Uses web scraping to fetch HTML announcements
+      #
+      # Scrape failures and zero-entity yields raise instead of being
+      # reported as success: the scraper collects errors into an array the
+      # pipeline never read, and the stop-list is never legitimately
+      # empty, so a blocked or restructured site used to produce a green
+      # run with zero entities. BaseExtractor#run turns the raise into
+      # status :error, which fails the fetch CLI's exit status.
+      #
       # @return [Hash] { announcements: [...], entities: [...], errors: [...] }
+      # @raise [RuntimeError] when the scrape errored or yielded nothing
       def fetch
         puts "[#{code}] Fetching Russia sanctions data via web scraping..." if verbose?
 
@@ -47,6 +56,17 @@ module Ammitto
         )
 
         @fetched_data = scraper.fetch_all
+
+        errors = @fetched_data[:errors] || []
+        unless errors.empty?
+          details = errors.map { |e| "#{e[:source]}: #{e[:error]}" }
+          raise "ru scrape failed: #{details.join('; ')}"
+        end
+
+        if (@fetched_data[:entities] || []).empty?
+          raise 'ru scrape yielded zero entities: the site is blocked or ' \
+                'its structure changed; refusing to report success'
+        end
 
         puts "[#{code}] Fetched #{@fetched_data[:entities].length} entities" if verbose?
 

--- a/lib/ammitto/scrapers/ru/mid_page.rb
+++ b/lib/ammitto/scrapers/ru/mid_page.rb
@@ -62,7 +62,7 @@ module Ammitto
             announcement = fetch_and_parse_announcement(link_info[:url])
             announcements << announcement if announcement
           rescue StandardError => e
-            warn "[MidPage] Error parsing #{link_info[:url]}: #{e.message}"
+            puts "[MidPage] Error parsing #{link_info[:url]}: #{e.message}" if verbose?
             @detail_errors << { url: link_info[:url], error: e.message }
           end
 
@@ -72,16 +72,18 @@ module Ammitto
         # Fetch and parse all announcements
         #
         # A failed fetch raises instead of degrading to an empty array:
-        # BasePage#fetch swallows network errors into a nil page, and an
-        # empty return here is indistinguishable from "the site listed no
-        # announcements", so the pipeline used to report success on a
-        # dead or blocked site.
+        # BasePage#fetch swallows network errors into a nil return, and
+        # an empty return here is indistinguishable from "the site
+        # listed no announcements", so the pipeline used to report
+        # success on a dead or blocked site. The check keys on the
+        # fetch return value, not @page: fetch does not clear @page on
+        # failure, so a page left by an earlier successful fetch must
+        # not mask a failed refetch with stale content.
         #
         # @return [Array<Hash>]
         # @raise [RuntimeError] when the index page could not be fetched
         def fetch_all_announcements
-          fetch
-          unless @page
+          unless fetch
             raise "MidPage: failed to fetch #{url} " \
                   '(network error or non-success response)'
           end

--- a/lib/ammitto/scrapers/ru/mid_page.rb
+++ b/lib/ammitto/scrapers/ru/mid_page.rb
@@ -49,16 +49,31 @@ module Ammitto
             announcement = fetch_and_parse_announcement(link_info[:url])
             announcements << announcement if announcement
           rescue StandardError => e
-            puts "[MidPage] Error parsing #{link_info[:url]}: #{e.message}" if verbose?
+            # Per-announcement failures tolerate a partially broken site,
+            # but must always be visible, not only under --verbose.
+            warn "[MidPage] Error parsing #{link_info[:url]}: #{e.message}"
           end
 
           announcements
         end
 
         # Fetch and parse all announcements
+        #
+        # A failed fetch raises instead of degrading to an empty array:
+        # BasePage#fetch swallows network errors into a nil page, and an
+        # empty return here is indistinguishable from "the site listed no
+        # announcements", so the pipeline used to report success on a
+        # dead or blocked site.
+        #
         # @return [Array<Hash>]
+        # @raise [RuntimeError] when the index page could not be fetched
         def fetch_all_announcements
           fetch
+          unless @page
+            raise "MidPage: failed to fetch #{url} " \
+                  '(network error or non-success response)'
+          end
+
           parse
         end
 

--- a/lib/ammitto/scrapers/ru/mid_page.rb
+++ b/lib/ammitto/scrapers/ru/mid_page.rb
@@ -24,10 +24,15 @@ module Ammitto
         # List type identifier
         LIST_TYPE = 'stop_list'
 
+        # @return [Array<Hash>] detail-page failures collected by the
+        #   last #parse, as { url:, error: } hashes
+        attr_reader :detail_errors
+
         # Initialize with options
         # @param options [Hash] scraper options
         def initialize(options = {})
           super
+          @detail_errors = []
         end
 
         # The URL to scrape
@@ -37,8 +42,16 @@ module Ammitto
         end
 
         # Parse the MID page
+        #
+        # Per-announcement failures keep the scrape going, but are
+        # recorded in #detail_errors instead of only warned: one
+        # successful detail page alongside failures used to report
+        # success with partial data. RuSanctionsScraper propagates
+        # these into its errors so the extractor errors out.
+        #
         # @return [Array<Hash>] array of announcement data
         def parse
+          @detail_errors = []
           return [] unless @page
 
           # Find and parse announcement links
@@ -49,9 +62,8 @@ module Ammitto
             announcement = fetch_and_parse_announcement(link_info[:url])
             announcements << announcement if announcement
           rescue StandardError => e
-            # Per-announcement failures tolerate a partially broken site,
-            # but must always be visible, not only under --verbose.
             warn "[MidPage] Error parsing #{link_info[:url]}: #{e.message}"
+            @detail_errors << { url: link_info[:url], error: e.message }
           end
 
           announcements
@@ -166,18 +178,17 @@ module Ammitto
         end
 
         # Fetch and parse an individual announcement
+        #
+        # Fetch errors propagate to #parse, which records them in
+        # #detail_errors instead of silently dropping the announcement.
+        #
         # @param url [String]
         # @return [Hash, nil]
+        # @raise [StandardError] when the detail page could not be fetched
         def fetch_and_parse_announcement(url)
           puts "[MidPage] Fetching announcement: #{url}" if verbose?
 
-          begin
-            detail_page = @agent.get(url)
-          rescue StandardError => e
-            puts "[MidPage] Error fetching #{url}: #{e.message}" if verbose?
-            return nil
-          end
-
+          detail_page = @agent.get(url)
           parse_announcement_detail(detail_page, url)
         end
 

--- a/lib/ammitto/scrapers/ru/ru_sanctions_scraper.rb
+++ b/lib/ammitto/scrapers/ru/ru_sanctions_scraper.rb
@@ -49,6 +49,11 @@ module Ammitto
         end
 
         # Fetch only MID data
+        #
+        # Detail-page failures collected by MidPage#detail_errors are
+        # propagated into the returned errors so partial data is never
+        # reported as success (RuExtractor raises on non-empty errors).
+        #
         # @return [Hash]
         def fetch_mid_data
           puts '[RuSanctionsScraper] Fetching MID data...' if verbose?
@@ -68,6 +73,13 @@ module Ammitto
               (announcement[:entities] || []).each do |entity_data|
                 entities << build_entity(entity_data, announcement)
               end
+            end
+
+            scraper.detail_errors.each do |detail_error|
+              errors << {
+                source: 'mid',
+                error: "#{detail_error[:url]}: #{detail_error[:error]}"
+              }
             end
           rescue StandardError => e
             errors << { source: 'mid', error: e.message }

--- a/spec/ammitto/cli/fetch_command_spec.rb
+++ b/spec/ammitto/cli/fetch_command_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Ammitto::Cmd::FetchCommand do
     expect(result[:error]).to match(/manually managed in data-cn/)
   end
 
-  it 'reports RU as manually managed instead of a silent zero-entity scrape' do
+  it 'reports RU as blocked by the anti-bot wall instead of a silent zero-entity scrape' do
     # mid.ru serves a JavaScript anti-bot challenge to non-browser
     # clients; the scraper structurally yields zero entities, which used
     # to count as success. The command must refuse before scraping.
@@ -27,7 +27,7 @@ RSpec.describe Ammitto::Cmd::FetchCommand do
       result = cmd.send(:fetch_source, :ru)
 
       expect(result[:status]).to eq(:error)
-      expect(result[:error]).to match(/manually managed in data-ru/)
+      expect(result[:error]).to match(/blocked.*anti-bot challenge/)
       expect(Dir.children(dir)).to be_empty
     end
   end

--- a/spec/ammitto/cli/fetch_command_spec.rb
+++ b/spec/ammitto/cli/fetch_command_spec.rb
@@ -18,17 +18,32 @@ RSpec.describe Ammitto::Cmd::FetchCommand do
     expect(result[:error]).to match(/manually managed in data-cn/)
   end
 
+  it 'reports RU as manually managed instead of a silent zero-entity scrape' do
+    # mid.ru serves a JavaScript anti-bot challenge to non-browser
+    # clients; the scraper structurally yields zero entities, which used
+    # to count as success. The command must refuse before scraping.
+    Dir.mktmpdir('ammitto-fetch-ru') do |dir|
+      cmd = described_class.new({ output_dir: dir }, ['ru'])
+      result = cmd.send(:fetch_source, :ru)
+
+      expect(result[:status]).to eq(:error)
+      expect(result[:error]).to match(/manually managed in data-ru/)
+      expect(Dir.children(dir)).to be_empty
+    end
+  end
+
   it 'requires sources or --all' do
     expect { described_class.new({}, []) }
       .to raise_error(Thor::Error, /No sources specified/)
   end
 
-  it 'excludes cn from --all so full runs can succeed' do
+  it 'excludes cn and ru from --all so full runs can succeed' do
     cmd = described_class.new({ all: true }, [])
 
     expect(cmd.sources).not_to include(:cn)
+    expect(cmd.sources).not_to include(:ru)
     expect(cmd.sources)
-      .to match_array(Ammitto::Config::Defaults::ALL_SOURCES - %i[cn])
+      .to match_array(Ammitto::Config::Defaults::ALL_SOURCES - %i[cn ru])
   end
 
   describe 'exit honesty' do

--- a/spec/ammitto/config/defaults_spec.rb
+++ b/spec/ammitto/config/defaults_spec.rb
@@ -32,6 +32,17 @@ RSpec.describe Ammitto::Config::Defaults do
     end
   end
 
+  describe '::FETCHABLE_SOURCES' do
+    it 'excludes the manually managed sources cn and ru' do
+      # cn: announcement-based reference docs, manual by policy.
+      # ru: mid.ru is behind an F5/TSPD JavaScript anti-bot challenge,
+      # so the Mechanize scraper structurally cannot fetch it.
+      expect(described_class::FETCHABLE_SOURCES).not_to include(:cn, :ru)
+      expect(described_class::FETCHABLE_SOURCES)
+        .to match_array(described_class::ALL_SOURCES - %i[cn ru])
+    end
+  end
+
   describe '::detect_data_repositories' do
     let(:temp_dir) { Dir.mktmpdir('ammitto_config_test') }
 

--- a/spec/ammitto/extractors/ru_extractor_spec.rb
+++ b/spec/ammitto/extractors/ru_extractor_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ammitto/extractors/ru_extractor'
+require 'ammitto/scrapers/ru/ru_sanctions_scraper'
+
+RSpec.describe Ammitto::Extractors::RuExtractor do
+  subject(:extractor) { described_class.new }
+
+  def stub_scrape(result)
+    scraper = instance_double(Ammitto::Scrapers::Ru::RuSanctionsScraper,
+                              fetch_all: result)
+    allow(Ammitto::Scrapers::Ru::RuSanctionsScraper)
+      .to receive(:new).and_return(scraper)
+  end
+
+  describe '#fetch' do
+    it 'raises on a zero-entity scrape instead of reporting success' do
+      # The stop-list is never legitimately empty: zero entities means
+      # the site is blocked (mid.ru serves a JS anti-bot challenge) or
+      # restructured. This used to flow through as a green run.
+      stub_scrape({ announcements: [], entities: [], errors: [] })
+
+      expect { extractor.fetch }
+        .to raise_error(RuntimeError, /zero entities/)
+    end
+
+    it 'raises when the scraper collected errors instead of dropping them' do
+      # RuSanctionsScraper#fetch_mid_data rescues into an errors array
+      # that no caller ever read; a dead mid.ru was indistinguishable
+      # from an empty list.
+      stub_scrape({ announcements: [], entities: [],
+                    errors: [{ source: 'mid', error: 'connection refused' }] })
+
+      expect { extractor.fetch }
+        .to raise_error(RuntimeError, /mid: connection refused/)
+    end
+
+    it 'returns the scraped data when entities were actually yielded' do
+      data = { announcements: [{ list_type: 'stop_list' }],
+               entities: [{ russian_name: 'Иванов Иван',
+                            english_name: 'Ivanov Ivan',
+                            entity_type: 'person' }],
+               errors: [] }
+      stub_scrape(data)
+
+      expect(extractor.fetch).to eq(data)
+    end
+  end
+
+  describe '#run' do
+    it 'turns a zero-entity scrape into status :error' do
+      # BaseExtractor#run converts the raise into the error result that
+      # fails the fetch CLI's exit status (exit honesty).
+      stub_scrape({ announcements: [], entities: [], errors: [] })
+
+      result = extractor.run
+
+      expect(result[:status]).to eq(:error)
+      expect(result[:error]).to match(/zero entities/)
+    end
+  end
+end

--- a/spec/ammitto/scrapers/ru/mid_page_spec.rb
+++ b/spec/ammitto/scrapers/ru/mid_page_spec.rb
@@ -22,6 +22,17 @@ RSpec.describe Ammitto::Scrapers::Ru::MidPage do
         .to raise_error(RuntimeError, /failed to fetch/)
     end
 
+    it 'raises on a failed refetch even when an earlier fetch left a page' do
+      # BasePage#fetch keeps @page on failure, so the raise keys on the
+      # fetch return value, not the ivar: a stale page from an earlier
+      # successful fetch must not mask a dead site with stale content.
+      page.instance_variable_set(:@page, instance_double(Mechanize::Page))
+      allow(agent).to receive(:get).and_raise(SocketError, 'unreachable')
+
+      expect { page.fetch_all_announcements }
+        .to raise_error(RuntimeError, /failed to fetch/)
+    end
+
     it 'parses the fetched page instead of raising when the fetch worked' do
       html = <<~HTML
         <html><body>
@@ -37,14 +48,16 @@ RSpec.describe Ammitto::Scrapers::Ru::MidPage do
       allow(agent).to receive(:get)
         .with(described_class::NEWS_URL).and_return(index_page)
       # A failed detail page no longer raises, but it is recorded in
-      # #detail_errors instead of being silently omitted.
+      # #detail_errors instead of being silently omitted. The log line
+      # stays behind verbose?, like the cn scrapers' per-link logs, so
+      # a normal run emits nothing to stderr.
       allow(agent).to receive(:get)
         .with('https://www.mid.ru/ru/foreign_policy/news/1234/')
         .and_raise(SocketError, 'detail unreachable')
 
       announcements = nil
       expect { announcements = page.fetch_all_announcements }
-        .to output(/detail unreachable/).to_stderr
+        .not_to output.to_stderr
 
       expect(announcements).to eq([])
       expect(page.detail_errors.length).to eq(1)
@@ -87,9 +100,7 @@ RSpec.describe Ammitto::Scrapers::Ru::MidPage do
         .with('https://www.mid.ru/ru/foreign_policy/news/2/')
         .and_raise(SocketError, 'boom')
 
-      announcements = nil
-      expect { announcements = page.fetch_all_announcements }
-        .to output(%r{Error parsing .*news/2}).to_stderr
+      announcements = page.fetch_all_announcements
 
       expect(announcements.length).to eq(1)
       expect(announcements.first[:source_url])
@@ -99,6 +110,32 @@ RSpec.describe Ammitto::Scrapers::Ru::MidPage do
         [{ url: 'https://www.mid.ru/ru/foreign_policy/news/2/',
            error: 'boom' }]
       )
+    end
+
+    it 'logs per-detail failures only in verbose mode' do
+      html = <<~HTML
+        <html><body>
+          <a href="/ru/foreign_policy/news/9/">
+            Заявление МИД России о персональных санкциях
+          </a>
+        </body></html>
+      HTML
+      index_page = Mechanize::Page.new(
+        URI('https://www.mid.ru/ru/foreign_policy/news/'),
+        nil, html, 200, Mechanize.new
+      )
+      verbose_page = described_class.new(verbose: true)
+      verbose_page.instance_variable_set(:@agent, agent)
+      allow(agent).to receive(:get)
+        .with(described_class::NEWS_URL).and_return(index_page)
+      allow(agent).to receive(:get)
+        .with('https://www.mid.ru/ru/foreign_policy/news/9/')
+        .and_raise(SocketError, 'boom')
+
+      expect { verbose_page.fetch_all_announcements }
+        .to output(%r{Error parsing .*news/9}).to_stdout
+
+      expect(verbose_page.detail_errors.length).to eq(1)
     end
   end
 end

--- a/spec/ammitto/scrapers/ru/mid_page_spec.rb
+++ b/spec/ammitto/scrapers/ru/mid_page_spec.rb
@@ -36,13 +36,69 @@ RSpec.describe Ammitto::Scrapers::Ru::MidPage do
       )
       allow(agent).to receive(:get)
         .with(described_class::NEWS_URL).and_return(index_page)
-      # The detail-page fetch failing is tolerated per announcement; only
-      # the index-page fetch contract is under test here.
+      # A failed detail page no longer raises, but it is recorded in
+      # #detail_errors instead of being silently omitted.
       allow(agent).to receive(:get)
         .with('https://www.mid.ru/ru/foreign_policy/news/1234/')
         .and_raise(SocketError, 'detail unreachable')
 
-      expect(page.fetch_all_announcements).to eq([])
+      announcements = nil
+      expect { announcements = page.fetch_all_announcements }
+        .to output(/detail unreachable/).to_stderr
+
+      expect(announcements).to eq([])
+      expect(page.detail_errors.length).to eq(1)
+    end
+
+    it 'collects failed detail pages so one success is not full success' do
+      # One successful detail page next to a failing one used to return
+      # only the successful announcement with no trace of the failure,
+      # so the extractor reported success with partial data.
+      index_html = <<~HTML
+        <html><body>
+          <a href="/ru/foreign_policy/news/1/">
+            Заявление МИД России о санкциях против граждан США
+          </a>
+          <a href="/ru/foreign_policy/news/2/">
+            Заявление МИД России о санкциях против политиков
+          </a>
+        </body></html>
+      HTML
+      detail_html = <<~HTML
+        <html><body><article>
+          <h1>Заявление МИД России</h1>
+          1. Иванов Иван Иванович (Ivanov Ivan) – директор института.
+        </article></body></html>
+      HTML
+      index_page = Mechanize::Page.new(
+        URI('https://www.mid.ru/ru/foreign_policy/news/'),
+        nil, index_html, 200, Mechanize.new
+      )
+      detail_page = Mechanize::Page.new(
+        URI('https://www.mid.ru/ru/foreign_policy/news/1/'),
+        nil, detail_html, 200, Mechanize.new
+      )
+      allow(agent).to receive(:get)
+        .with(described_class::NEWS_URL).and_return(index_page)
+      allow(agent).to receive(:get)
+        .with('https://www.mid.ru/ru/foreign_policy/news/1/')
+        .and_return(detail_page)
+      allow(agent).to receive(:get)
+        .with('https://www.mid.ru/ru/foreign_policy/news/2/')
+        .and_raise(SocketError, 'boom')
+
+      announcements = nil
+      expect { announcements = page.fetch_all_announcements }
+        .to output(%r{Error parsing .*news/2}).to_stderr
+
+      expect(announcements.length).to eq(1)
+      expect(announcements.first[:source_url])
+        .to eq('https://www.mid.ru/ru/foreign_policy/news/1/')
+      expect(announcements.first[:entities].length).to eq(1)
+      expect(page.detail_errors).to eq(
+        [{ url: 'https://www.mid.ru/ru/foreign_policy/news/2/',
+           error: 'boom' }]
+      )
     end
   end
 end

--- a/spec/ammitto/scrapers/ru/mid_page_spec.rb
+++ b/spec/ammitto/scrapers/ru/mid_page_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ammitto/scrapers/ru/mid_page'
+
+RSpec.describe Ammitto::Scrapers::Ru::MidPage do
+  subject(:page) { described_class.new }
+
+  let(:agent) { instance_double(Mechanize) }
+
+  before { page.instance_variable_set(:@agent, agent) }
+
+  describe '#fetch_all_announcements' do
+    it 'raises when the index page could not be fetched' do
+      # BasePage#fetch swallows network errors into a nil page, and
+      # #parse degrades nil to []. An unreachable mid.ru was therefore
+      # indistinguishable from a site with no announcements, and the
+      # pipeline reported success on it.
+      allow(agent).to receive(:get).and_raise(SocketError, 'unreachable')
+
+      expect { page.fetch_all_announcements }
+        .to raise_error(RuntimeError, /failed to fetch/)
+    end
+
+    it 'parses the fetched page instead of raising when the fetch worked' do
+      html = <<~HTML
+        <html><body>
+          <a href="/ru/foreign_policy/news/1234/">
+            Заявление МИД России о персональных санкциях
+          </a>
+        </body></html>
+      HTML
+      index_page = Mechanize::Page.new(
+        URI('https://www.mid.ru/ru/foreign_policy/news/'),
+        nil, html, 200, Mechanize.new
+      )
+      allow(agent).to receive(:get)
+        .with(described_class::NEWS_URL).and_return(index_page)
+      # The detail-page fetch failing is tolerated per announcement; only
+      # the index-page fetch contract is under test here.
+      allow(agent).to receive(:get)
+        .with('https://www.mid.ru/ru/foreign_policy/news/1234/')
+        .and_raise(SocketError, 'detail unreachable')
+
+      expect(page.fetch_all_announcements).to eq([])
+    end
+  end
+end

--- a/spec/ammitto/scrapers/ru/ru_sanctions_scraper_spec.rb
+++ b/spec/ammitto/scrapers/ru/ru_sanctions_scraper_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ammitto/scrapers/ru/ru_sanctions_scraper'
+
+RSpec.describe Ammitto::Scrapers::Ru::RuSanctionsScraper do
+  subject(:scraper) { described_class.new }
+
+  describe '#fetch_all' do
+    it 'propagates detail-page failures into the returned errors' do
+      # One successful announcement next to a failed detail page used
+      # to come back with empty errors, so RuExtractor (which raises on
+      # non-empty errors) reported success on partial data.
+      announcement = {
+        list_type: 'stop_list',
+        source_url: 'https://www.mid.ru/ru/foreign_policy/news/1/',
+        entities: [{ russian_name: 'Иванов Иван',
+                     english_name: 'Ivanov Ivan',
+                     entity_type: 'person' }]
+      }
+      mid_page = instance_double(
+        Ammitto::Scrapers::Ru::MidPage,
+        fetch_all_announcements: [announcement],
+        detail_errors: [{ url: 'https://www.mid.ru/ru/foreign_policy/news/2/',
+                          error: 'boom' }]
+      )
+      allow(Ammitto::Scrapers::Ru::MidPage)
+        .to receive(:new).and_return(mid_page)
+
+      result = scraper.fetch_all
+
+      expect(result[:announcements].length).to eq(1)
+      expect(result[:entities].length).to eq(1)
+      expect(result[:errors]).to eq(
+        [{ source: 'mid',
+           error: 'https://www.mid.ru/ru/foreign_policy/news/2/: boom' }]
+      )
+    end
+
+    it 'returns empty errors when every detail page parsed' do
+      mid_page = instance_double(
+        Ammitto::Scrapers::Ru::MidPage,
+        fetch_all_announcements: [],
+        detail_errors: []
+      )
+      allow(Ammitto::Scrapers::Ru::MidPage)
+        .to receive(:new).and_return(mid_page)
+
+      expect(scraper.fetch_all[:errors]).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
mid.ru answers every request with an F5 JavaScript anti-bot challenge —
reproduced with the gem's own Mechanize stack site-wide, so the scraper
structurally cannot see content. `ammitto fetch ru` now reports that wall and
exits nonzero, `--all` skips RU, and the error-swallowing chain is removed end
to end: index failures raise, detail-page failures propagate into scraper
errors, zero entities raise, and the CLI exits nonzero. Previously a failed
scrape reported success with zero files.

This states the blocked fetch as a verified fact; whether RU should revive via
the reference-docs pipeline recorded in #15 is a separate maintainer decision
this PR deliberately does not make.

## Test plan

- `bundle exec rspec` — 1362 examples, 0 failures
- `bundle exec rubocop` — 418 files, no offenses
- New specs fail on unmodified main
- data-ru's workflow masks fetch exit codes, so its cron stays green
