### PR TITLE
Mark jp manually managed so fetch refuses instead of saving zero files

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -337,7 +337,7 @@ ammitto fetch uk --format yaml --output-dir ./processed --verbose
 # Fetch multiple sources
 ammitto fetch uk eu un --format yaml --output-dir ./processed
 
-# Fetch all automatable sources (skips cn, which is manually managed)
+# Fetch all automatable sources (skips cn and jp, which are manually managed)
 ammitto fetch --all --format yaml --output-dir ./processed
 
 # Dry run (show what would be fetched)

--- a/docs/getting-started/quick-start.adoc
+++ b/docs/getting-started/quick-start.adoc
@@ -80,7 +80,7 @@ ammitto get un/KPi.066 --format json
 # Fetch from a specific source
 ammitto fetch eu --output-dir ./data
 
-# Fetch from all automatable sources (skips manually managed cn)
+# Fetch from all automatable sources (skips manually managed cn and jp)
 ammitto fetch --all
 ----
 

--- a/docs/interfaces/cli/index.adoc
+++ b/docs/interfaces/cli/index.adoc
@@ -102,7 +102,7 @@ ammitto fetch eu
 # Fetch multiple sources
 ammitto fetch eu un us
 
-# Fetch all automatable sources (skips manually managed cn)
+# Fetch all automatable sources (skips manually managed cn and jp)
 ammitto fetch --all
 
 # Dry run (show what would be fetched)
@@ -124,7 +124,7 @@ ammitto fetch eu --format yaml
 | Show what would be done without making changes
 
 | `--all`
-| Fetch all automatable sources (skips manually managed cn)
+| Fetch all automatable sources (skips manually managed cn and jp)
 
 | `--format FORMAT`
 | Output format: yaml (default), jsonld

--- a/docs/sources/index.adoc
+++ b/docs/sources/index.adoc
@@ -279,17 +279,19 @@ ammitto fetch tr
 
 === Japan (`jp`)
 
-*Provider:* Ministry of Economy, Trade and Industry (METI)
+*Provider:* Ministry of Economy, Trade and Industry (METI), Ministry of Foreign Affairs (MOFA), Ministry of Finance (MOF)
 *URL:* https://www.meti.go.jp/policy/anpo/index.html
-*Format:* HTML, XLSX
+*Format:* PDF, XLSX
 
 Japan maintains the End User List and implements UN sanctions.
 
-[source,bash]
-----
-# Fetch Japan data
-ammitto fetch jp
-----
+Japan data is manually managed in the `data-jp` repository as
+announcement-based reference documents covering six sanction lists:
+the METI Foreign User List and FEFTA End-User List, the MOFA export
+prohibitions (Belarus, Russia, and third-country), and the MOF
+asset-freeze lists, all converted with `data-jp`'s own scripts; there
+is no automated fetch. `ammitto fetch jp` reports this and exits
+nonzero, and `--all` skips JP.
 
 === New Zealand (`nz`)
 

--- a/lib/ammitto/cli.rb
+++ b/lib/ammitto/cli.rb
@@ -144,7 +144,7 @@ module Ammitto
     DESC
     option :dry_run, type: :boolean, default: false, desc: 'Show what would be done'
     option :all, type: :boolean, default: false,
-                 desc: 'Fetch all automatable sources (skips cn)'
+                 desc: 'Fetch all automatable sources (skips cn and jp)'
     option :format, type: :string, default: 'yaml', desc: 'Output format (yaml, jsonld)'
     option :output_dir, type: :string, desc: 'Output directory for YAML files'
     def fetch(*sources)

--- a/lib/ammitto/cli.rb
+++ b/lib/ammitto/cli.rb
@@ -133,7 +133,8 @@ module Ammitto
       Download raw sanction data from specified sources and save as YAML.
 
       Pass source codes to fetch specific sources, or use --all to fetch
-      every automatable source (cn is skipped: it is manually managed).
+      every automatable source (cn and jp are skipped: they are
+      manually managed).
 
       Examples:
         ammitto fetch uk --format yaml          # Fetch UK data as YAML

--- a/lib/ammitto/cli/fetch_command.rb
+++ b/lib/ammitto/cli/fetch_command.rb
@@ -13,10 +13,29 @@ module Ammitto
     # @example Fetch UK data as YAML
     #   ammitto fetch uk --format yaml --output-dir ./processed
     #
-    # @example Fetch all automatable sources (skips manually managed cn)
+    # @example Fetch all automatable sources (skips manually managed cn, jp)
     #   ammitto fetch --all
     #
     class FetchCommand
+      # Sources whose YAML is manually curated in their data-* repository,
+      # keyed to the error an explicit fetch reports. Reporting this beats
+      # a fetch path that succeeds without writing anything.
+      #
+      # cn: announcement-based reference docs, hand-managed in data-cn.
+      # jp: announcement YAML under data-jp/sources/sanction-lists, curated
+      #     with data-jp's own scripts from METI/MOF publications (the METI
+      #     End User List URL is revision-stamped and discovered from a
+      #     Japanese index page). The gem's from_pdf was a placeholder that
+      #     saved zero files, and harmonize prefers processed/ over the
+      #     curated announcements, so partial automated output would shadow
+      #     the curated data.
+      MANUALLY_MANAGED = {
+        cn: 'CN data is manually managed in data-cn; automated fetch ' \
+            'is not supported',
+        jp: 'JP data is manually managed in data-jp; automated fetch ' \
+            'is not supported'
+      }.freeze
+
       # @return [Hash] command options
       attr_reader :options
 
@@ -98,10 +117,8 @@ module Ammitto
       def fetch_source(source)
         puts "[#{source}] Fetching..." if options[:verbose]
 
-        # CN has no automated fetch: its YAML is manually managed in data-cn
-        # (announcement-based reference docs). Reporting this explicitly beats
-        # the extractor path returning success without writing anything.
-        return error_result(source, 'CN data is manually managed in data-cn; automated fetch is not supported') if source == :cn
+        manual_reason = MANUALLY_MANAGED[source]
+        return error_result(source, manual_reason) if manual_reason
 
         extractor_class = extractor_class_for(source)
         return error_result(source, 'No extractor available') unless extractor_class
@@ -155,8 +172,9 @@ module Ammitto
                when :au, :tr, :nz, :eu_vessels
                  # AU, TR, NZ, EU Vessels use XLSX - content is path to temp file
                  parse_xlsx(model_class, content, extractor)
-               when :jp, :un_vessels
-                 # JP, UN Vessels are PDF-based - requires manual conversion
+               when :un_vessels
+                 # UN Vessels is PDF-based - requires manual conversion
+                 # (jp never reaches here: it is manually managed)
                  puts "[#{source}] Note: #{source.upcase} data is PDF-based"
                  puts "[#{source}] Data requires manual conversion from PDF"
                  model_class.from_pdf(content)

--- a/lib/ammitto/config/defaults.rb
+++ b/lib/ammitto/config/defaults.rb
@@ -34,11 +34,12 @@ module Ammitto
       # All available sources
       ALL_SOURCES = %i[eu un us wb uk au ca ch cn ru tr nz jp eu_vessels un_vessels].freeze
 
-      # Sources with an automated fetch path. CN is excluded: its YAML is
-      # manually managed in data-cn, so `fetch --all` must not fail on a
-      # source that cannot be fetched automatically (an explicit
-      # `fetch cn` still reports the manual-management error).
-      FETCHABLE_SOURCES = (ALL_SOURCES - %i[cn]).freeze
+      # Sources with an automated fetch path. CN and JP are excluded: their
+      # YAML is manually managed in data-cn and data-jp (announcement-based
+      # reference docs), so `fetch --all` must not fail on a source that
+      # cannot be fetched automatically (an explicit `fetch cn` or
+      # `fetch jp` still reports the manual-management error).
+      FETCHABLE_SOURCES = (ALL_SOURCES - %i[cn jp]).freeze
 
       # Default output format
       DEFAULT_OUTPUT_FORMAT = 'jsonld'

--- a/lib/ammitto/sources/jp/sanctions_list.rb
+++ b/lib/ammitto/sources/jp/sanctions_list.rb
@@ -7,9 +7,10 @@ module Ammitto
     module Jp
       # SanctionsList represents the Japan End-User List
       #
-      # Note: The Japan End-User List is published as a PDF document.
-      # This class provides methods for parsing the data after manual conversion
-      # from PDF to structured format.
+      # Note: JP data is manually curated in data-jp (announcement YAML
+      # under sources/sanction-lists, converted with data-jp's own
+      # scripts). This class only builds a list from already-converted
+      # structured data; it cannot parse a METI publication itself.
       #
       class SanctionsList < Lutaml::Model::Serializable
         attribute :entities, Entity, collection: true
@@ -29,18 +30,18 @@ module Ammitto
           list
         end
 
-        # Create SanctionsList from PDF (placeholder - requires manual conversion)
+        # Refuse to parse a PDF. This used to be a placeholder that
+        # printed a note and returned an empty list, so `fetch jp`
+        # reported success while saving zero files. There is no PDF
+        # ingestion: raising keeps any caller from mistaking an empty
+        # list for a harvest.
         # @param _pdf_path [String] path to PDF file
-        # @return [SanctionsList]
+        # @raise [NotImplementedError] always
         def self.from_pdf(_pdf_path)
-          puts 'Note: Japan End-User List is PDF-based and requires manual conversion'
-          puts 'Please convert the PDF to structured data and use from_converted_data'
-
-          new.tap do |list|
-            list.source = 'jp'
-            list.fetched_at = Time.now.utc.iso8601
-            list.entities = []
-          end
+          raise NotImplementedError,
+                'Jp::SanctionsList cannot parse PDFs; JP data is ' \
+                'manually curated in data-jp. Use from_converted_data ' \
+                'with already-converted structured data.'
         end
 
         # Get all entities

--- a/spec/ammitto/cli/fetch_command_spec.rb
+++ b/spec/ammitto/cli/fetch_command_spec.rb
@@ -18,17 +18,26 @@ RSpec.describe Ammitto::Cmd::FetchCommand do
     expect(result[:error]).to match(/manually managed in data-cn/)
   end
 
+  it 'reports JP as manually managed instead of a zero-file success' do
+    cmd = described_class.new({}, ['jp'])
+    result = cmd.send(:fetch_source, :jp)
+
+    expect(result[:status]).to eq(:error)
+    expect(result[:error]).to match(/manually managed in data-jp/)
+  end
+
   it 'requires sources or --all' do
     expect { described_class.new({}, []) }
       .to raise_error(Thor::Error, /No sources specified/)
   end
 
-  it 'excludes cn from --all so full runs can succeed' do
+  it 'excludes cn and jp from --all so full runs can succeed' do
     cmd = described_class.new({ all: true }, [])
 
     expect(cmd.sources).not_to include(:cn)
+    expect(cmd.sources).not_to include(:jp)
     expect(cmd.sources)
-      .to match_array(Ammitto::Config::Defaults::ALL_SOURCES - %i[cn])
+      .to match_array(Ammitto::Config::Defaults::ALL_SOURCES - %i[cn jp])
   end
 
   describe 'exit honesty' do
@@ -37,6 +46,14 @@ RSpec.describe Ammitto::Cmd::FetchCommand do
 
       expect { cmd.run }
         .to raise_error(Thor::Error, /Fetch failed for: cn/)
+        .and output(/0 succeeded, 1 failed/).to_stdout
+    end
+
+    it 'fails an explicit jp fetch loudly' do
+      cmd = described_class.new({}, ['jp'])
+
+      expect { cmd.run }
+        .to raise_error(Thor::Error, /Fetch failed for: jp/)
         .and output(/0 succeeded, 1 failed/).to_stdout
     end
 

--- a/spec/ammitto/sources/jp/sanctions_list_spec.rb
+++ b/spec/ammitto/sources/jp/sanctions_list_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ammitto/sources/jp'
+
+RSpec.describe Ammitto::Sources::Jp::SanctionsList do
+  describe '.from_pdf' do
+    it 'refuses instead of succeeding with zero entities' do
+      expect { described_class.from_pdf('end-user-list.pdf') }
+        .to raise_error(NotImplementedError, /manually curated in data-jp/)
+    end
+  end
+
+  describe '.from_converted_data' do
+    it 'builds a list from already-converted structured data' do
+      list = described_class.from_converted_data(
+        'entities' => [
+          { 'id' => 'meti-1', 'name' => 'Example Institute' }
+        ]
+      )
+
+      expect(list.source).to eq('jp')
+      expect(list.count).to eq(1)
+      expect(list.all_entities.first.name).to eq('Example Institute')
+    end
+
+    it 'builds an empty list when no entities are given' do
+      list = described_class.from_converted_data({})
+
+      expect(list.count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
jp's from_pdf was a placeholder producing zero files while data-jp's committed corpus — six curated lists (METI Foreign User List, FEFTA, MOFA Belarus/Russia/third-country export prohibitions, MOF asset-freeze; 5,097 entities live today) — is hand-maintained with data-jp's own scripts. Wiring the working METI extractor into fetch would cover one list of six, and harmonize prefers processed/ over the curated sources/, so a partial auto-fetch would shadow the complete corpus. jp now refuses fetch loudly like cn, and the docs describe the six lists accurately.

## Test plan
- bundle exec rspec — 1354 examples, 0 failures
- bundle exec rubocop — 416 files, no offenses
- New assertions fail on unmodified main

NOTE for data-jp: its fetch.yml does not mask exit codes, so its daily cron goes red once this ships — a coordinated workflow change is prepared as a ready-to-apply diff.