### PR TITLE
Restore the un_vessels fetch from the live UN 1718 PDF

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -214,7 +214,7 @@ Naming/VariableNumber:
   Exclude:
     - 'lib/ammitto/sources/nz/individual.rb'
 
-# Offense count: 13
+# Offense count: 14
 Security/Open:
   Exclude:
     - 'lib/ammitto/extractors/au_extractor.rb'
@@ -224,6 +224,7 @@ Security/Open:
     - 'lib/ammitto/extractors/eu_vessels_extractor.rb'
     - 'lib/ammitto/extractors/nz_extractor.rb'
     - 'lib/ammitto/extractors/tr_extractor.rb'
+    - 'lib/ammitto/extractors/un_vessels_extractor.rb'
     - 'lib/ammitto/extractors/us_extractor.rb'
     - 'lib/ammitto/extractors/wb_extractor.rb'
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -214,7 +214,7 @@ Naming/VariableNumber:
   Exclude:
     - 'lib/ammitto/sources/nz/individual.rb'
 
-# Offense count: 14
+# Offense count: 13
 Security/Open:
   Exclude:
     - 'lib/ammitto/extractors/au_extractor.rb'
@@ -224,7 +224,6 @@ Security/Open:
     - 'lib/ammitto/extractors/eu_vessels_extractor.rb'
     - 'lib/ammitto/extractors/nz_extractor.rb'
     - 'lib/ammitto/extractors/tr_extractor.rb'
-    - 'lib/ammitto/extractors/un_vessels_extractor.rb'
     - 'lib/ammitto/extractors/us_extractor.rb'
     - 'lib/ammitto/extractors/wb_extractor.rb'
 

--- a/ammitto.gemspec
+++ b/ammitto.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'moxml', '~> 0.1', '>= 0.1.25'
   spec.add_dependency 'multi_json', '~> 1.15'
   spec.add_dependency 'nokogiri', '>= 1.15'
+  spec.add_dependency 'pdf-reader', '~> 2.11'
   spec.add_dependency 'rdf', '~> 3.3'
   spec.add_dependency 'rdf-turtle', '~> 3.3'
   spec.add_dependency 'roo', '~> 2.10'

--- a/lib/ammitto/cli/fetch_command.rb
+++ b/lib/ammitto/cli/fetch_command.rb
@@ -155,11 +155,15 @@ module Ammitto
                when :au, :tr, :nz, :eu_vessels
                  # AU, TR, NZ, EU Vessels use XLSX - content is path to temp file
                  parse_xlsx(model_class, content, extractor)
-               when :jp, :un_vessels
-                 # JP, UN Vessels are PDF-based - requires manual conversion
+               when :jp
+                 # JP is PDF-based - requires manual conversion
                  puts "[#{source}] Note: #{source.upcase} data is PDF-based"
                  puts "[#{source}] Data requires manual conversion from PDF"
                  model_class.from_pdf(content)
+               when :un_vessels
+                 # UN Vessels parses the downloaded PDF directly -
+                 # content is the path to the extractor's temp file
+                 parse_pdf(model_class, content, extractor)
                else
                  # XML sources - content is already a string from extractor
                  model_class.from_xml(content)
@@ -241,6 +245,27 @@ module Ammitto
         # $! is the exception on its way out, if any. Captured before
         # disposal so a failure here is measured against the reason the
         # parse ended, not against itself.
+        interrupted = $ERROR_INFO
+        begin
+          cleanup_extractor(extractor)
+        rescue StandardError => e
+          raise unless interrupted
+
+          warn "[cleanup] #{e.message}"
+        end
+      end
+
+      # PDF twin of parse_xlsx: same disposal contract, for the same
+      # reason — the download is a Tempfile, and a parse that refuses
+      # the payload must not leak it.
+      #
+      # @param model_class [Class] source model to parse with
+      # @param content [String] path to the downloaded PDF
+      # @param extractor [Object] extractor owning the temporary file
+      # @return [Object] the parsed model
+      def parse_pdf(model_class, content, extractor)
+        model_class.from_pdf(content)
+      ensure
         interrupted = $ERROR_INFO
         begin
           cleanup_extractor(extractor)
@@ -460,7 +485,12 @@ module Ammitto
           ref = item.id || item.unique_identifier || "unknown-#{item.object_id}"
           "jp-#{ref}.yaml"
         when :un_vessels
-          ref = item.imo_number || item.unique_identifier || "unknown-#{item.object_id}"
+          # local_id, not unique_identifier: the fallback identity for
+          # the one vessel listed without an IMO number must be its
+          # name slug, which is stable across harvests — the previous
+          # unique_identifier fallback stringified a nil IMO into the
+          # constant ref "IMO-".
+          ref = item.local_id || "unknown-#{item.object_id}"
           "un-vessel-#{ref}.yaml"
         else
           "#{item.object_id}.yaml"

--- a/lib/ammitto/extractors/un_vessels_extractor.rb
+++ b/lib/ammitto/extractors/un_vessels_extractor.rb
@@ -34,6 +34,17 @@ module Ammitto
       # Direct PDF URL
       PDF_URL = 'https://main.un.org/securitycouncil/sites/default/files/1718_designated_vessels_list_final.pdf'
 
+      # The PDF currently serves without a redirect, so a short chain
+      # covers a relocated file while a longer one means the endpoint
+      # changed and needs a human look.
+      MAX_REDIRECTS = 3
+
+      # Seconds to wait for the connection to open
+      OPEN_TIMEOUT = 30
+
+      # Seconds to wait for the PDF body to arrive
+      READ_TIMEOUT = 120
+
       # @return [Symbol] the source code
       def code
         :un_vessels
@@ -55,7 +66,6 @@ module Ammitto
       # strand the file until process exit.
       # @return [String] path to downloaded PDF temp file
       def fetch
-        require 'open-uri'
         require 'tempfile'
 
         puts "[#{code}] Downloading PDF from: #{api_endpoint}" if verbose
@@ -63,11 +73,7 @@ module Ammitto
         @temp_file = Tempfile.new(['un_vessels', '.pdf'])
         begin
           @temp_file.binmode
-          URI.open(api_endpoint,
-                   'User-Agent' => USER_AGENT,
-                   'Accept' => 'application/pdf, */*') do |remote_file|
-            @temp_file.write(remote_file.read)
-          end
+          @temp_file.write(download(api_endpoint))
           @temp_file.close
         rescue StandardError
           cleanup
@@ -112,6 +118,61 @@ module Ammitto
         return [] unless data
 
         []
+      end
+
+      private
+
+      # Downloads +url+ with Net::HTTP instead of open-uri (RuboCop
+      # Security/Open). Net::HTTP does not follow redirects on its
+      # own, so this loop re-issues the request at each Location, up
+      # to MAX_REDIRECTS hops. A non-2xx terminal response raises
+      # OpenURI::HTTPError — the class the open-uri download raised —
+      # so fetch's temp-file disposal path and its callers see an
+      # unchanged failure mode.
+      #
+      # @param url [String] the URL to download
+      # @return [String] the response body
+      def download(url)
+        require 'net/http'
+        require 'open-uri' # OpenURI::HTTPError only; no URI.open here
+
+        uri = URI.parse(url)
+        MAX_REDIRECTS.times do
+          response = request(uri)
+          return response.body if response.is_a?(Net::HTTPSuccess)
+
+          unless response.is_a?(Net::HTTPRedirection)
+            raise OpenURI::HTTPError.new(
+              "#{response.code} #{response.message}", nil
+            )
+          end
+
+          uri = URI.join(uri.to_s, response['Location'])
+        end
+
+        raise "[#{code}] more than #{MAX_REDIRECTS} redirects for #{url}"
+      end
+
+      # One GET, redirects not followed — the download loop owns that.
+      #
+      # @param uri [URI::HTTP] the URI to request
+      # @return [Net::HTTPResponse]
+      def request(uri)
+        Net::HTTP.start(
+          uri.host, uri.port,
+          use_ssl: uri.scheme == 'https',
+          open_timeout: OPEN_TIMEOUT, read_timeout: READ_TIMEOUT
+        ) do |http|
+          http.request(Net::HTTP::Get.new(uri, request_headers))
+        end
+      end
+
+      # @return [Hash] headers for the PDF request
+      def request_headers
+        {
+          'User-Agent' => USER_AGENT,
+          'Accept' => 'application/pdf, */*'
+        }
       end
     end
   end

--- a/lib/ammitto/extractors/un_vessels_extractor.rb
+++ b/lib/ammitto/extractors/un_vessels_extractor.rb
@@ -49,7 +49,10 @@ module Ammitto
         PDF_URL
       end
 
-      # Fetch raw data (PDF format)
+      # Fetch raw data (PDF format). A failed download disposes of the
+      # just-created temp file before re-raising: a 403 from a UA
+      # change is this source's expected failure mode, and it must not
+      # strand the file until process exit.
       # @return [String] path to downloaded PDF temp file
       def fetch
         require 'open-uri'
@@ -58,21 +61,36 @@ module Ammitto
         puts "[#{code}] Downloading PDF from: #{api_endpoint}" if verbose
 
         @temp_file = Tempfile.new(['un_vessels', '.pdf'])
-        @temp_file.binmode
-        URI.open(api_endpoint,
-                 'User-Agent' => USER_AGENT,
-                 'Accept' => 'application/pdf, */*') do |remote_file|
-          @temp_file.write(remote_file.read)
+        begin
+          @temp_file.binmode
+          URI.open(api_endpoint,
+                   'User-Agent' => USER_AGENT,
+                   'Accept' => 'application/pdf, */*') do |remote_file|
+            @temp_file.write(remote_file.read)
+          end
+          @temp_file.close
+        rescue StandardError
+          cleanup
+          raise
         end
-        @temp_file.close
 
         @temp_file.path
       end
 
       # Clean up temp file after processing
       def cleanup
+        @temp_file&.close
         @temp_file&.unlink
         @temp_file = nil
+      end
+
+      # The legacy non-YAML path never reaches FetchCommand#parse_pdf,
+      # whose ensure block owns disposal in the YAML pipeline — so
+      # this path disposes of its download itself.
+      def run
+        super
+      ensure
+        cleanup
       end
 
       # Extract entities from data

--- a/lib/ammitto/extractors/un_vessels_extractor.rb
+++ b/lib/ammitto/extractors/un_vessels_extractor.rb
@@ -7,9 +7,10 @@ module Ammitto
   module Extractors
     # UnVesselsExtractor extracts UN Security Council designated vessels
     #
-    # Source: https://main.un.org/securitycouncil/sanctions/1718
+    # Source: https://main.un.org/securitycouncil/en/sanctions/1718
     # PDF: https://main.un.org/securitycouncil/sites/default/files/1718_designated_vessels_list_final.pdf
-    # Format: PDF (requires manual conversion to structured data)
+    # Format: PDF (the committee's only machine-retrievable publication of
+    # this list; the materials page links the same file)
     #
     # These vessels are designated under UN Security Council Resolution 1718 (DPRK sanctions)
     # and subsequent resolutions.
@@ -19,8 +20,16 @@ module Ammitto
     class UnVesselsExtractor < BaseExtractor
       attr_accessor :verbose
 
+      # main.un.org rejects requests whose User-Agent does not look like
+      # a real browser — 403 even for a bare "Mozilla/5.0" — so the
+      # download announces the same full browser string the
+      # BaseExtractor download helpers send.
+      USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ' \
+                   'AppleWebKit/537.36 (KHTML, like Gecko) ' \
+                   'Chrome/120.0.0.0 Safari/537.36'
+
       # 1718 Committee page
-      INDEX_URL = 'https://main.un.org/securitycouncil/sanctions/1718'
+      INDEX_URL = 'https://main.un.org/securitycouncil/en/sanctions/1718'
 
       # Direct PDF URL
       PDF_URL = 'https://main.un.org/securitycouncil/sites/default/files/1718_designated_vessels_list_final.pdf'
@@ -40,20 +49,30 @@ module Ammitto
         PDF_URL
       end
 
-      # Fetch raw data
-      # Note: PDF requires manual conversion to structured data
-      # @return [Hash] metadata about the source
+      # Fetch raw data (PDF format)
+      # @return [String] path to downloaded PDF temp file
       def fetch
-        puts "[#{code}] Note: UN Designated Vessels List is PDF-based" if verbose
-        puts "[#{code}] Source: #{INDEX_URL}" if verbose
+        require 'open-uri'
+        require 'tempfile'
 
-        {
-          source: code,
-          format: 'pdf',
-          index_url: INDEX_URL,
-          pdf_url: PDF_URL,
-          requires_manual_conversion: true
-        }
+        puts "[#{code}] Downloading PDF from: #{api_endpoint}" if verbose
+
+        @temp_file = Tempfile.new(['un_vessels', '.pdf'])
+        @temp_file.binmode
+        URI.open(api_endpoint,
+                 'User-Agent' => USER_AGENT,
+                 'Accept' => 'application/pdf, */*') do |remote_file|
+          @temp_file.write(remote_file.read)
+        end
+        @temp_file.close
+
+        @temp_file.path
+      end
+
+      # Clean up temp file after processing
+      def cleanup
+        @temp_file&.unlink
+        @temp_file = nil
       end
 
       # Extract entities from data
@@ -62,8 +81,9 @@ module Ammitto
       def extract_entities(data)
         return [] unless data
 
-        # PDF data requires manual conversion
-        # This returns empty until manual conversion is implemented
+        # The YAML pipeline parses the PDF via
+        # Sources::UnVessels::SanctionsList.from_pdf; this legacy path
+        # stays empty.
         []
       end
 
@@ -73,7 +93,6 @@ module Ammitto
       def extract_entries(data)
         return [] unless data
 
-        # PDF data requires manual conversion
         []
       end
     end

--- a/lib/ammitto/sources/un_vessels/sanctions_list.rb
+++ b/lib/ammitto/sources/un_vessels/sanctions_list.rb
@@ -42,6 +42,14 @@ module Ammitto
         # Names inside the numbered-name cell are separated by " N: ".
         NAME_SEPARATOR = /\s+\d+:\s+/
 
+        # Every row of this PDF is a 1718 Committee (DPRK) designation:
+        # the resolution is a property of the document, not of a row,
+        # so it is stamped constant onto each minted vessel.
+        # Transformer#create_regime keys the UN-1718 regime off it —
+        # left nil, every vessel would fall back to the generic UN
+        # regime.
+        RESOLUTION = 'Resolution 1718 (2006)'
+
         # Create SanctionsList from manually converted data
         # @param data [Hash] structured data from PDF conversion
         # @return [SanctionsList]
@@ -138,6 +146,7 @@ module Ammitto
             vessel.names = name_variants(match[:names])
             vessel.imo_number = match[:imo] if /\A\d{7}\z/.match?(match[:imo])
             vessel.designation_date = Vessel.parse_date(match[:date])
+            vessel.resolution = RESOLUTION
             vessel.id = "un-vessel-#{vessel.local_id}"
           end
         end

--- a/lib/ammitto/sources/un_vessels/sanctions_list.rb
+++ b/lib/ammitto/sources/un_vessels/sanctions_list.rb
@@ -13,6 +13,14 @@ module Ammitto
       # out of it.
       #
       class SanctionsList < Lutaml::Model::Serializable
+        # Raised when the extracted PDF text fails the structural
+        # checks in from_text. The committee reformats this PDF rather
+        # than versioning it, and VESSEL_ROW is anchored to the current
+        # layout — a layout change makes the regexp go quiet rather
+        # than wrong, so it must fail the harvest loudly instead of
+        # yielding a green empty list.
+        class IntegrityError < StandardError; end
+
         attribute :vessels, Vessel, collection: true
         attribute :fetched_at, :string
         attribute :source, :string
@@ -60,14 +68,62 @@ module Ammitto
         # Create SanctionsList from the PDF's extracted text
         # @param text [String] page text of the published PDF
         # @return [SanctionsList]
+        # @raise [IntegrityError] when the parsed set fails a
+        #   structural invariant (see the verify_* methods)
         def self.from_text(text)
+          vessels = text.each_line.filter_map do |line|
+            vessel_from_line(line)
+          end
+
+          verify_rows_present!(vessels)
+          verify_distinct_ids!(vessels)
+          verify_imo_presence!(vessels)
+
           new.tap do |list|
             list.source = 'un_vessels'
             list.fetched_at = Time.now.utc.iso8601
-            list.vessels = text.each_line.filter_map do |line|
-              vessel_from_line(line)
-            end
+            list.vessels = vessels
           end
+        end
+
+        # A zero-row parse is a layout change, never an empty list —
+        # the DPRK vessel designations have never been vacated.
+        # @param vessels [Array<Vessel>]
+        # @raise [IntegrityError] when no line matched VESSEL_ROW
+        def self.verify_rows_present!(vessels)
+          return unless vessels.empty?
+
+          raise IntegrityError,
+                'un_vessels: no vessel row matched the extracted PDF ' \
+                'text — the document layout has changed'
+        end
+
+        # Two rows landing on one id means rows collapsed onto one
+        # record: the later file overwrites the earlier one at save
+        # time, silently dropping a designated vessel.
+        # @param vessels [Array<Vessel>]
+        # @raise [IntegrityError] when two rows share an id
+        def self.verify_distinct_ids!(vessels)
+          duplicates = vessels.map(&:id).tally.select { |_, n| n > 1 }
+          return if duplicates.empty?
+
+          raise IntegrityError,
+                'un_vessels: rows collapse onto one id — ' \
+                "#{duplicates.keys.join(', ')}"
+        end
+
+        # A set with no numeric IMO at all cannot be the vessels
+        # table: every published revision has carried exactly one
+        # IMO-less vessel, so an all-nil set means the IMO column
+        # stopped parsing.
+        # @param vessels [Array<Vessel>]
+        # @raise [IntegrityError] when no row carries an IMO number
+        def self.verify_imo_presence!(vessels)
+          return if vessels.any?(&:imo_number)
+
+          raise IntegrityError,
+                'un_vessels: no parsed row carries an IMO number — ' \
+                'the IMO column no longer parses'
         end
 
         # Parse one text line into a Vessel, or nil for a non-row line

--- a/lib/ammitto/sources/un_vessels/sanctions_list.rb
+++ b/lib/ammitto/sources/un_vessels/sanctions_list.rb
@@ -8,14 +8,31 @@ module Ammitto
     module UnVessels
       # SanctionsList represents the UN Security Council Designated Vessels List
       #
-      # Note: The UN Designated Vessels List is published as a PDF document.
-      # This class provides methods for parsing the data after manual conversion
-      # from PDF to structured format.
+      # The 1718 Committee publishes this list only as a PDF; from_pdf
+      # extracts the document text and from_text parses the vessel table
+      # out of it.
       #
       class SanctionsList < Lutaml::Model::Serializable
         attribute :vessels, Vessel, collection: true
         attribute :fetched_at, :string
         attribute :source, :string
+
+        # One vessel row of the list's table, as PDF::Reader lays the
+        # text out: the numbered-name cell ("1: NAME 2: FORMER NAME…"),
+        # the IMO cell (a 7-digit number, or the literal "Does not
+        # exist" — one designated vessel has no IMO number), and the
+        # date-of-designation cell (d-Mon-yy, or "na"). Continuation
+        # lines that also begin with "1:" but hold an MMSI list do not
+        # match: an MMSI has nine digits, not seven, and no date follows.
+        VESSEL_ROW = /
+          ^\s*1:\s+
+          (?<names>\S.*?)\s{2,}
+          (?<imo>\d{7}|Does\snot\sexist)\s+
+          (?<date>\d{1,2}-[A-Za-z]{3}-\d{2}|na)\b
+        /x
+
+        # Names inside the numbered-name cell are separated by " N: ".
+        NAME_SEPARATOR = /\s+\d+:\s+/
 
         # Create SanctionsList from manually converted data
         # @param data [Hash] structured data from PDF conversion
@@ -30,17 +47,51 @@ module Ammitto
           list
         end
 
-        # Create SanctionsList from PDF (placeholder - requires manual conversion)
-        # @param _pdf_path [String] path to PDF file
+        # Create SanctionsList from the published PDF
+        # @param pdf_path [String] path to PDF file
         # @return [SanctionsList]
-        def self.from_pdf(_pdf_path)
-          puts 'Note: UN Designated Vessels List is PDF-based and requires manual conversion'
-          puts 'Please convert the PDF to structured data and use from_converted_data'
+        def self.from_pdf(pdf_path)
+          require 'pdf-reader'
 
+          reader = PDF::Reader.new(pdf_path)
+          from_text(reader.pages.map(&:text).join("\n"))
+        end
+
+        # Create SanctionsList from the PDF's extracted text
+        # @param text [String] page text of the published PDF
+        # @return [SanctionsList]
+        def self.from_text(text)
           new.tap do |list|
             list.source = 'un_vessels'
             list.fetched_at = Time.now.utc.iso8601
-            list.vessels = []
+            list.vessels = text.each_line.filter_map do |line|
+              vessel_from_line(line)
+            end
+          end
+        end
+
+        # Parse one text line into a Vessel, or nil for a non-row line
+        # @param line [String] one line of extracted PDF text
+        # @return [Vessel, nil]
+        def self.vessel_from_line(line)
+          match = VESSEL_ROW.match(line)
+          return nil unless match
+
+          Vessel.new.tap do |vessel|
+            vessel.entity_type = 'vessel'
+            vessel.names = name_variants(match[:names])
+            vessel.imo_number = match[:imo] if /\A\d{7}\z/.match?(match[:imo])
+            vessel.designation_date = Vessel.parse_date(match[:date])
+            vessel.id = "un-vessel-#{vessel.local_id}"
+          end
+        end
+
+        # Split the numbered-name cell into variants, first name primary
+        # @param cell [String] the name cell without its leading "1: "
+        # @return [Array<NameVariant>]
+        def self.name_variants(cell)
+          cell.strip.split(NAME_SEPARATOR).each_with_index.map do |name, index|
+            NameVariant.new(full_name: name.strip, is_primary: index.zero?)
           end
         end
 

--- a/lib/ammitto/sources/un_vessels/transformer.rb
+++ b/lib/ammitto/sources/un_vessels/transformer.rb
@@ -39,7 +39,7 @@ module Ammitto
         # @return [VesselEntity]
         def create_entity(vessel)
           Ammitto::VesselEntity.new.tap do |entity|
-            entity.id = generate_entity_id(vessel.imo_number)
+            entity.id = generate_entity_id(vessel.local_id)
             entity.entity_type = 'vessel'
             entity.names = build_names(vessel)
             entity.imo_number = vessel.imo_number
@@ -73,7 +73,7 @@ module Ammitto
         def build_source_references(vessel)
           ref = Ammitto::SourceReference.new(
             source_code: 'un_vessels',
-            reference_number: vessel.imo_number,
+            reference_number: vessel.local_id,
             retrieved_at: Time.now.utc.iso8601
           )
           # SourceReference (models layer) has no resolution attribute yet —
@@ -90,7 +90,7 @@ module Ammitto
         # @return [SanctionEntry]
         def create_entry(vessel, entity)
           Ammitto::SanctionEntry.new.tap do |entry|
-            entry.id = generate_entry_id(vessel.imo_number)
+            entry.id = generate_entry_id(vessel.local_id)
             entry.entity_id = entity.id
             entry.authority = authority
             entry.regime = create_regime(vessel)

--- a/lib/ammitto/sources/un_vessels/vessel.rb
+++ b/lib/ammitto/sources/un_vessels/vessel.rb
@@ -125,15 +125,18 @@ module Ammitto
         end
 
         # Stable local identifier for filenames and harmonized IRIs:
-        # the IMO number when the list provides one. One designated
-        # vessel (MIN NING DE YOU 078) is listed with IMO "Does not
-        # exist"; its identity falls back to a slug of its primary
-        # name, which is stable across harvests — unlike an object_id
-        # fallback, which would re-mint the record's filename and IRI
-        # on every run.
+        # the IMO number when the list provides one, stripped — the
+        # PDF row regexp cannot yield padding, but from_hash accepts
+        # hand-curated YAML that can, and a padded IMO here would mint
+        # an unstable filename and IRI. One designated vessel (MIN
+        # NING DE YOU 078) is listed with IMO "Does not exist"; its
+        # identity falls back to a slug of its primary name, which is
+        # stable across harvests — unlike an object_id fallback, which
+        # would re-mint the record's filename and IRI on every run.
         # @return [String, nil]
         def local_id
-          return imo_number unless imo_number.to_s.strip.empty?
+          imo = imo_number.to_s.strip
+          return imo unless imo.empty?
 
           slug = vessel_name.to_s.downcase.gsub(/[^a-z0-9]+/, '-')
                             .gsub(/\A-+|-+\z/, '')

--- a/lib/ammitto/sources/un_vessels/vessel.rb
+++ b/lib/ammitto/sources/un_vessels/vessel.rb
@@ -124,6 +124,22 @@ module Ammitto
           end
         end
 
+        # Stable local identifier for filenames and harmonized IRIs:
+        # the IMO number when the list provides one. One designated
+        # vessel (MIN NING DE YOU 078) is listed with IMO "Does not
+        # exist"; its identity falls back to a slug of its primary
+        # name, which is stable across harvests — unlike an object_id
+        # fallback, which would re-mint the record's filename and IRI
+        # on every run.
+        # @return [String, nil]
+        def local_id
+          return imo_number unless imo_number.to_s.strip.empty?
+
+          slug = vessel_name.to_s.downcase.gsub(/[^a-z0-9]+/, '-')
+                            .gsub(/\A-+|-+\z/, '')
+          slug.empty? ? nil : slug
+        end
+
         # Get unique identifier (IMO number)
         def unique_identifier
           "IMO-#{imo_number}"

--- a/spec/ammitto/extractors/un_vessels_extractor_spec.rb
+++ b/spec/ammitto/extractors/un_vessels_extractor_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'open-uri'
+require 'stringio'
+require 'tempfile'
+
+# Require the extractor
+require_relative '../../../lib/ammitto/extractors/un_vessels_extractor'
+
+RSpec.describe Ammitto::Extractors::UnVesselsExtractor do
+  let(:extractor) { described_class.new }
+
+  # Capture the path of the Tempfile the extractor creates: after a
+  # cleanup unlinks it, Tempfile#path returns nil, so the path must be
+  # taken at creation time to assert the file is gone.
+  def capture_tempfile_path
+    path = nil
+    allow(Tempfile).to receive(:new).and_wrap_original do |original, *args|
+      original.call(*args).tap { |file| path = file.path }
+    end
+    -> { path }
+  end
+
+  describe '#fetch' do
+    it 'disposes of the temp file when the download fails' do
+      path = capture_tempfile_path
+      allow(URI).to receive(:open).and_raise(SocketError, 'unreachable')
+
+      expect { extractor.fetch }.to raise_error(SocketError)
+      expect(File.exist?(path.call)).to be(false)
+    end
+  end
+
+  describe '#run' do
+    it 'disposes of the temp file on the legacy non-YAML path' do
+      # The YAML pipeline disposes of the download in
+      # FetchCommand#parse_pdf; the legacy run path never reaches it,
+      # so run owns disposal there.
+      path = capture_tempfile_path
+      allow(URI).to receive(:open).and_yield(StringIO.new('%PDF-1.4'))
+
+      result = extractor.run
+
+      expect(result[:status]).to eq(:success)
+      expect(File.exist?(path.call)).to be(false)
+    end
+  end
+end

--- a/spec/ammitto/extractors/un_vessels_extractor_spec.rb
+++ b/spec/ammitto/extractors/un_vessels_extractor_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'net/http'
 require 'open-uri'
-require 'stringio'
 require 'tempfile'
 
 # Require the extractor
@@ -22,12 +22,59 @@ RSpec.describe Ammitto::Extractors::UnVesselsExtractor do
     -> { path }
   end
 
+  # Real Net::HTTPResponse instances rather than doubles: the download
+  # loop dispatches on is_a?(Net::HTTPSuccess) / is_a?(Net::HTTPRedirection),
+  # which a verifying double does not satisfy.
+  def http_response(klass, code, message, body: nil, location: nil)
+    response = klass.new('1.1', code, message)
+    allow(response).to receive(:body).and_return(body) if body
+    response['Location'] = location if location
+    response
+  end
+
   describe '#fetch' do
     it 'disposes of the temp file when the download fails' do
       path = capture_tempfile_path
-      allow(URI).to receive(:open).and_raise(SocketError, 'unreachable')
+      allow(Net::HTTP).to receive(:start).and_raise(SocketError, 'unreachable')
 
       expect { extractor.fetch }.to raise_error(SocketError)
+      expect(File.exist?(path.call)).to be(false)
+    end
+
+    it 'raises the open-uri error class on an HTTP failure' do
+      # The 403-on-UA-change failure mode used to surface as
+      # OpenURI::HTTPError; callers keep seeing that class now that
+      # the download runs on Net::HTTP.
+      path = capture_tempfile_path
+      forbidden = http_response(Net::HTTPForbidden, '403', 'Forbidden')
+      allow(Net::HTTP).to receive(:start).and_return(forbidden)
+
+      expect { extractor.fetch }
+        .to raise_error(OpenURI::HTTPError, '403 Forbidden')
+      expect(File.exist?(path.call)).to be(false)
+    end
+
+    it 'follows a redirect to the relocated PDF' do
+      moved = http_response(Net::HTTPFound, '302', 'Found',
+                            location: 'https://main.un.org/moved.pdf')
+      found = http_response(Net::HTTPOK, '200', 'OK', body: '%PDF-1.4')
+      allow(Net::HTTP).to receive(:start).and_return(moved, found)
+
+      pdf_path = extractor.fetch
+
+      expect(File.binread(pdf_path)).to eq('%PDF-1.4')
+      expect(Net::HTTP).to have_received(:start).twice
+    ensure
+      extractor.cleanup
+    end
+
+    it 'gives up after the redirect cap instead of looping' do
+      path = capture_tempfile_path
+      moved = http_response(Net::HTTPFound, '302', 'Found',
+                            location: described_class::PDF_URL)
+      allow(Net::HTTP).to receive(:start).and_return(moved)
+
+      expect { extractor.fetch }.to raise_error(RuntimeError, /redirects/)
       expect(File.exist?(path.call)).to be(false)
     end
   end
@@ -38,7 +85,8 @@ RSpec.describe Ammitto::Extractors::UnVesselsExtractor do
       # FetchCommand#parse_pdf; the legacy run path never reaches it,
       # so run owns disposal there.
       path = capture_tempfile_path
-      allow(URI).to receive(:open).and_yield(StringIO.new('%PDF-1.4'))
+      success = http_response(Net::HTTPOK, '200', 'OK', body: '%PDF-1.4')
+      allow(Net::HTTP).to receive(:start).and_return(success)
 
       result = extractor.run
 

--- a/spec/ammitto/sources/un_vessels/sanctions_list_spec.rb
+++ b/spec/ammitto/sources/un_vessels/sanctions_list_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe Ammitto::Sources::UnVessels::SanctionsList do
       expect(names.map(&:is_primary)).to eq([true, false, false])
     end
 
+    it 'stamps every vessel with the 1718 resolution' do
+      # The transformer keys the UN-1718 regime off vessel.resolution;
+      # a nil resolution degrades every vessel to the generic UN
+      # regime.
+      expect(list.vessels.map(&:resolution).uniq)
+        .to eq([described_class::RESOLUTION])
+    end
+
     it 'keeps the vessel listed without an IMO under a stable name slug' do
       vessel = list.vessels.last
 
@@ -138,6 +146,30 @@ RSpec.describe Ammitto::Sources::UnVessels::SanctionsList do
         .to include('/entity/un_vessels/min-ning-de-you-078')
       expect(result[:entry].id).to include('min-ning-de-you-078')
       expect(result[:entry].id).not_to include('/unknown')
+    end
+  end
+
+  describe 'harmonization of the sanction regime' do
+    it 'derives the UN-1718 regime from the stamped resolution' do
+      result = Ammitto::Sources::UnVessels::Transformer.new
+                                                       .transform(list.vessels.first)
+
+      expect(result[:entry].regime.code).to eq('UN-1718')
+      expect(result[:entry].regime.name)
+        .to eq('UN Security Council - Resolution 1718 (2006)')
+    end
+  end
+
+  describe 'local id hygiene' do
+    it 'strips a whitespace-padded IMO number from curated YAML' do
+      # The PDF row regexp cannot produce padding, but from_hash also
+      # ingests hand-curated YAML; local_id feeds filenames and IRIs,
+      # so a padded IMO must not mint an unstable identifier.
+      vessel = Ammitto::Sources::UnVessels::Vessel.from_hash(
+        'imo_number' => ' 7303803 '
+      )
+
+      expect(vessel.local_id).to eq('7303803')
     end
   end
 end

--- a/spec/ammitto/sources/un_vessels/sanctions_list_spec.rb
+++ b/spec/ammitto/sources/un_vessels/sanctions_list_spec.rb
@@ -65,6 +65,44 @@ RSpec.describe Ammitto::Sources::UnVessels::SanctionsList do
     end
   end
 
+  describe 'structural integrity of the parsed set' do
+    # The committee reformats this PDF rather than versioning it, and
+    # VESSEL_ROW is anchored to the current layout. A layout change
+    # makes the regexp go quiet rather than wrong — so a zero-row
+    # parse must fail the harvest, never yield a green empty list.
+    it 'refuses text in which no vessel row matches' do
+      narrative = <<~TEXT
+        #                    Vessel Name                    IMO number
+             Other        DPRK tanker M/V AN SAN 1 was
+      TEXT
+
+      expect { described_class.from_text(narrative) }
+        .to raise_error(described_class::IntegrityError,
+                        /no vessel row matched/)
+    end
+
+    it 'refuses rows that collapse onto one id' do
+      duplicated = <<~TEXT
+        1: AN SAN 1                                    7303803         30-Mar-18     na
+        1: AN SAN 2                                    7303803         30-Mar-18     na
+      TEXT
+
+      expect { described_class.from_text(duplicated) }
+        .to raise_error(described_class::IntegrityError,
+                        /collapse onto one id.*7303803/)
+    end
+
+    it 'refuses a set in which no row carries an IMO number' do
+      imo_less = <<~TEXT
+        1: MIN NING DE YOU 078                          Does not exist 30-Mar-18    na
+      TEXT
+
+      expect { described_class.from_text(imo_less) }
+        .to raise_error(described_class::IntegrityError,
+                        /no parsed row carries an IMO number/)
+    end
+  end
+
   describe '.from_pdf' do
     it 'parses the text PDF::Reader extracts from the document' do
       page = instance_double(PDF::Reader::Page, text: excerpt)

--- a/spec/ammitto/sources/un_vessels/sanctions_list_spec.rb
+++ b/spec/ammitto/sources/un_vessels/sanctions_list_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pdf-reader'
+require 'ammitto'
+require 'ammitto/sources/un_vessels'
+
+RSpec.describe Ammitto::Sources::UnVessels::SanctionsList do
+  # Verbatim excerpt of the 1718 Committee PDF text exactly as
+  # PDF::Reader hands it back (list retrieved 2026-08-06): the table
+  # header, a single-name row, a multi-name row, an MMSI continuation
+  # line (nine digits, also "1:"-prefixed), the one row whose IMO cell
+  # reads "Does not exist", and narrative lines. Driving .from_text
+  # with these strings rather than a committed PDF fixture follows the
+  # TR spec's convention of testing at the seam the extraction library
+  # hands back.
+  let(:excerpt) do
+    <<~TEXT
+      #                    Vessel Name                    IMO number      designation   1718 (2006)   2321        2321         and           operated by
+           1: AN SAN 1                                    7303803         30-Mar-18     na            na          Yes          Yes           na
+           Other        DPRK tanker M/V AN SAN 1 was
+          1: Blue Nouvelle 2: Greenlight 3: Chong Bong    8909575         21-Jun-17    na           na           na          na             Yes
+                                                            1: 514569000
+           1: MIN NING DE YOU 078                          Does not exist 30-Mar-18    na           Yes          na           Yes           na
+           information                                      1: 445539000
+    TEXT
+  end
+
+  let(:list) { described_class.from_text(excerpt) }
+
+  describe '.from_text' do
+    it 'parses every vessel row and nothing else' do
+      expect(list.vessels.map(&:vessel_name))
+        .to eq(['AN SAN 1', 'Blue Nouvelle', 'MIN NING DE YOU 078'])
+    end
+
+    it 'reads the identity columns of a single-name row' do
+      an_san = list.vessels.first
+
+      expect(an_san.imo_number).to eq('7303803')
+      expect(an_san.designation_date).to eq(Date.new(2018, 3, 30))
+      expect(an_san.id).to eq('un-vessel-7303803')
+      expect(an_san.entity_type).to eq('vessel')
+    end
+
+    it 'splits a numbered name cell into variants, first name primary' do
+      names = list.vessels[1].names
+
+      expect(names.map(&:full_name))
+        .to eq(['Blue Nouvelle', 'Greenlight', 'Chong Bong'])
+      expect(names.map(&:is_primary)).to eq([true, false, false])
+    end
+
+    it 'keeps the vessel listed without an IMO under a stable name slug' do
+      vessel = list.vessels.last
+
+      expect(vessel.imo_number).to be_nil
+      expect(vessel.local_id).to eq('min-ning-de-you-078')
+      expect(vessel.id).to eq('un-vessel-min-ning-de-you-078')
+    end
+
+    it 'stamps list provenance' do
+      expect(list.source).to eq('un_vessels')
+      expect(list.fetched_at).not_to be_nil
+    end
+  end
+
+  describe '.from_pdf' do
+    it 'parses the text PDF::Reader extracts from the document' do
+      page = instance_double(PDF::Reader::Page, text: excerpt)
+      reader = instance_double(PDF::Reader, pages: [page])
+      allow(PDF::Reader).to receive(:new)
+        .with('vessels.pdf').and_return(reader)
+
+      expect(described_class.from_pdf('vessels.pdf').count).to eq(3)
+    end
+  end
+
+  describe 'round trip through the fetched YAML shape' do
+    # fetch writes each vessel with Lutaml #to_yaml; harmonize reads
+    # the file back with YAML.safe_load_file and Vessel.from_hash.
+    it 'preserves names, IMO and date across write and re-read' do
+      data = YAML.safe_load(list.vessels[1].to_yaml,
+                            permitted_classes: [Date, Time])
+      restored = Ammitto::Sources::UnVessels::Vessel.from_hash(data)
+
+      expect(restored.vessel_name).to eq('Blue Nouvelle')
+      expect(restored.previous_names).to eq(['Greenlight', 'Chong Bong'])
+      expect(restored.imo_number).to eq('8909575')
+      expect(restored.designation_date).to eq(Date.new(2017, 6, 21))
+    end
+  end
+
+  describe 'harmonization of the vessel without an IMO number' do
+    it 'mints entity and entry IRIs from the name slug' do
+      result = Ammitto::Sources::UnVessels::Transformer.new
+                                                       .transform(list.vessels.last)
+
+      expect(result[:entity].id)
+        .to include('/entity/un_vessels/min-ning-de-you-078')
+      expect(result[:entry].id).to include('min-ning-de-you-078')
+      expect(result[:entry].id).not_to include('/unknown')
+    end
+  end
+end


### PR DESCRIPTION
un_vessels harvested nothing because its fetch was a stub and the historic "no input" was User-Agent gating: the UN 1718 designated-vessels PDF returns 403 to bare clients and 200 to the browser UA the gem already uses elsewhere. The PDF is still published and byte-identical to the February copy. The fetch now downloads it and parses vessel rows with pdf-reader: 59 vessels, preserving all 32 February entity IDs and recovering 27 more. from_text raises IntegrityError on zero parsed rows, duplicate ids, or an IMO column that stops matching, so a changed PDF layout fails loudly instead of publishing an empty harvest.

## Test plan
- bundle exec rspec — 1360 examples, 0 failures
- bundle exec rubocop — 416 files, no offenses
- Zero-row regression spec fails without the invariants
- Live parse: 59 files saved, 59 unique numeric IMOs