### PR TITLE
Reject redirects that downgrade the un_vessels fetch to http

### DIFF
--- a/lib/ammitto/extractors/un_vessels_extractor.rb
+++ b/lib/ammitto/extractors/un_vessels_extractor.rb
@@ -128,7 +128,12 @@ module Ammitto
       # to MAX_REDIRECTS hops. A non-2xx terminal response raises
       # OpenURI::HTTPError — the class the open-uri download raised —
       # so fetch's temp-file disposal path and its callers see an
-      # unchanged failure mode.
+      # unchanged failure mode. A Location that resolves to anything
+      # but https raises the same class: following it would downgrade
+      # to a cleartext request, which URI.open refused. The host is
+      # deliberately not pinned — open-uri allows cross-host https
+      # redirects, and the request carries no credentials or cookies,
+      # so a relocated PDF on another UN host keeps working.
       #
       # @param url [String] the URL to download
       # @return [String] the response body
@@ -148,6 +153,11 @@ module Ammitto
           end
 
           uri = URI.join(uri.to_s, response['Location'])
+          next if uri.is_a?(URI::HTTPS)
+
+          raise OpenURI::HTTPError.new(
+            "redirection to non-https forbidden: #{uri}", nil
+          )
         end
 
         raise "[#{code}] more than #{MAX_REDIRECTS} redirects for #{url}"

--- a/spec/ammitto/extractors/un_vessels_extractor_spec.rb
+++ b/spec/ammitto/extractors/un_vessels_extractor_spec.rb
@@ -68,6 +68,36 @@ RSpec.describe Ammitto::Extractors::UnVesselsExtractor do
       extractor.cleanup
     end
 
+    it 'refuses a redirect that downgrades https to plain http' do
+      # URI.open refused https->http redirects; the Net::HTTP loop
+      # must not reopen that downgrade (the follow-up request would
+      # run with use_ssl: false and fetch the PDF in cleartext).
+      path = capture_tempfile_path
+      moved = http_response(Net::HTTPFound, '302', 'Found',
+                            location: 'http://main.un.org/moved.pdf')
+      allow(Net::HTTP).to receive(:start).and_return(moved)
+
+      expect { extractor.fetch }
+        .to raise_error(OpenURI::HTTPError, /forbidden/)
+      expect(Net::HTTP).to have_received(:start).once
+      expect(File.exist?(path.call)).to be(false)
+    end
+
+    it 'resolves a relative Location against the https base' do
+      moved = http_response(Net::HTTPFound, '302', 'Found',
+                            location: '/relocated.pdf')
+      found = http_response(Net::HTTPOK, '200', 'OK', body: '%PDF-1.4')
+      allow(Net::HTTP).to receive(:start).and_return(moved, found)
+
+      pdf_path = extractor.fetch
+
+      expect(File.binread(pdf_path)).to eq('%PDF-1.4')
+      expect(Net::HTTP).to have_received(:start)
+        .with('main.un.org', 443, hash_including(use_ssl: true)).twice
+    ensure
+      extractor.cleanup
+    end
+
     it 'gives up after the redirect cap instead of looping' do
       path = capture_tempfile_path
       moved = http_response(Net::HTTPFound, '302', 'Found',


### PR DESCRIPTION
The `un_vessels` download loop followed a redirect to an `http://` Location and
set `use_ssl` false, a downgrade `URI.open` refused before the Net::HTTP
rewrite. On a sanctions PDF that means ingesting an unauthenticated
replacement.

## Changes

- Reject any redirect whose resolved URI is not HTTPS, raising the same
  `OpenURI::HTTPError` family the loop already raises. Relative Locations still
  resolve against the current URI.
- Cross-host HTTPS redirects stay allowed: that preserves the former `open-uri`
  behaviour and the request carries no credentials or cookies.

## Test plan

- `bundle exec rspec` / `bundle exec rubocop` — green
- Regression spec fails without the guard (https→http must raise; https→https
  still followed)
- Live fetch re-proven: 59 vessel files from the real UN PDF
