### PR TITLE
Keep source-stated birth years and stop inventing January dates

### DIFF
--- a/lib/ammitto/sources/au/transformer.rb
+++ b/lib/ammitto/sources/au/transformer.rb
@@ -247,14 +247,30 @@ module Ammitto
 
           dates.map.with_index do |dob, idx|
             pob = places[idx] || places.first
-            # dob is a FlexibleDate object, use to_date method
-            date = dob.respond_to?(:to_date) ? dob.to_date : parse_date(dob)
-            create_birth_info(
-              date: date,
-              city: pob&.city,
-              country: pob&.country
-            )
+            if dob.respond_to?(:to_date)
+              # A FlexibleDate keeps its stated precision: the date is
+              # used only when day, month and year all resolved; a bare
+              # year rides in BirthInfo#year instead of vanishing
+              create_birth_info(
+                date: complete_date_of(dob),
+                circa: dob.circa || false,
+                year: dob.year,
+                city: pob&.city,
+                country: pob&.country
+              )
+            else
+              create_birth_info(date: dob, city: pob&.city, country: pob&.country)
+            end
           end
+        end
+
+        # @param dob [Ammitto::Sources::Au::FlexibleDate]
+        # @return [Date, nil] the date only when the source stated all of
+        #   day, month and year
+        def complete_date_of(dob)
+          return nil unless dob.day && dob.month && dob.year
+
+          dob.to_date
         end
 
         def transform_regime(committees)

--- a/lib/ammitto/sources/ch/transformer.rb
+++ b/lib/ammitto/sources/ch/transformer.rb
@@ -124,10 +124,9 @@ module Ammitto
           dmy = identity.day_month_year
           return [] unless dmy.year
 
-          # Year-only Swiss records keep their year even when no full date
-          # can be parsed
-          date_str = dmy.to_iso_date
-          [create_birth_info(date: parse_date(date_str), year: dmy.year&.to_i)]
+          # Year-only and year-month Swiss records keep their year; only
+          # a fully stated day-month-year becomes a date
+          [create_birth_info(date: dmy.to_iso_date, year: dmy.year&.to_i)]
         end
 
         def create_entry(target, entity_id)

--- a/lib/ammitto/sources/eu/transformer.rb
+++ b/lib/ammitto/sources/eu/transformer.rb
@@ -189,11 +189,12 @@ module Ammitto
           return [] if birthdates.nil?
 
           birthdates.map do |bd|
-            date = parse_eu_date(bd.birthdate) || parse_year(bd.year)
-
+            # A year without a full birthdate stays a year — it is not
+            # padded into an invented January 1 date
             create_birth_info(
-              date: date,
+              date: bd.birthdate,
               circa: bd.circa,
+              year: bd.year,
               city: [bd.city, bd.place].compact.first,
               region: bd.region,
               country: bd.country_description,
@@ -253,29 +254,6 @@ module Ammitto
           [
             create_effect(effect_type: 'asset_freeze', scope: 'full')
           ]
-        end
-
-        # Parse EU date format (YYYY-MM-DD)
-        # @param date_str [String, nil]
-        # @return [Date, nil]
-        def parse_eu_date(date_str)
-          return nil if date_str.nil? || date_str.empty?
-
-          parse_date(date_str)
-        end
-
-        # Parse year-only value
-        # @param year [Integer, String, nil]
-        # @return [Date, nil]
-        def parse_year(year)
-          return nil if year.nil?
-
-          year_int = year.is_a?(Integer) ? year : year.to_i
-          return nil if year_int.zero?
-
-          Date.new(year_int, 1, 1)
-        rescue Date::Error
-          nil
         end
 
         # Normalize identification type code

--- a/lib/ammitto/sources/ru/transformer.rb
+++ b/lib/ammitto/sources/ru/transformer.rb
@@ -70,8 +70,10 @@ module Ammitto
             id: generate_entity_id(create_reference(source_entity)),
             entity_type: 'person',
             names: transform_names(source_entity),
+            # A year-only DOB string keeps its year; only a complete
+            # day-month-year becomes BirthInfo#date
             birth_info: [create_birth_info(
-              date: parse_date(source_entity.date_of_birth),
+              date: source_entity.date_of_birth,
               country: source_entity.nationality
             )].compact,
             nationalities: [source_entity.nationality].compact,

--- a/lib/ammitto/sources/uk/transformer.rb
+++ b/lib/ammitto/sources/uk/transformer.rb
@@ -303,8 +303,11 @@ module Ammitto
 
             birth_location = details.birth_details&.primary_location
 
+            # A partial DOB ("00/00/1975", "1975-00-00") keeps its year;
+            # only a fully stated day-month-year becomes a date
             birth_infos << create_birth_info(
               date: parse_uk_date(dob_str),
+              year: extract_birth_year(dob_str),
               city: birth_location&.town_of_birth,
               country: birth_location&.country_of_birth
             )
@@ -373,7 +376,8 @@ module Ammitto
           end
         end
 
-        # Parse UK date format (DD/MM/YYYY)
+        # Parse UK date format (DD/MM/YYYY), yielding a Date only for a
+        # complete day-month-year
         # @param date_str [String]
         # @return [Date, nil]
         def parse_uk_date(date_str)
@@ -384,10 +388,10 @@ module Ammitto
             begin
               Date.strptime(date_str, '%d/%m/%Y')
             rescue Date::Error
-              parse_date(date_str) # Fall back to standard parsing
+              parse_complete_date(date_str) # Fall back to standard parsing
             end
           else
-            parse_date(date_str)
+            parse_complete_date(date_str)
           end
         end
 

--- a/lib/ammitto/sources/un/transformer.rb
+++ b/lib/ammitto/sources/un/transformer.rb
@@ -285,10 +285,12 @@ module Ammitto
           pob = individual.place_of_birth
 
           if dob
-            date = parse_un_date(dob)
+            # A year-only record keeps its year — it is not padded into
+            # an invented January 1 date
             birth_infos << create_birth_info(
-              date: date,
+              date: dob.date,
               circa: dob.type_of_date&.include?('APPROXIMATELY'),
+              year: dob.year,
               city: pob&.city,
               region: pob&.state_province,
               country: pob&.country
@@ -343,23 +345,6 @@ module Ammitto
             create_effect(effect_type: 'asset_freeze', scope: 'full'),
             create_effect(effect_type: 'travel_ban', scope: 'full')
           ]
-        end
-
-        # Parse UN date format
-        # @param dob [Ammitto::Sources::Un::IndividualDateOfBirth]
-        # @return [Date, nil]
-        def parse_un_date(dob)
-          return nil unless dob
-
-          if dob.date && !dob.date.empty?
-            parse_date(dob.date)
-          elsif dob.year
-            begin
-              Date.new(dob.year, 1, 1)
-            rescue Date::Error
-              nil
-            end
-          end
         end
 
         # Extract title from designations

--- a/lib/ammitto/sources/us/transformer.rb
+++ b/lib/ammitto/sources/us/transformer.rb
@@ -260,8 +260,13 @@ module Ammitto
           dobs.each_with_index do |dob, idx|
             pob = pobs[idx]
 
+            # OFAC DOBs mix complete dates ("03 Oct 1988") with partial
+            # ones ("1988", "Oct 1988", "circa 1960"): only a complete
+            # date becomes BirthInfo#date, a stated year always survives
+            # in BirthInfo#year
             birth_infos << create_birth_info(
-              date: parse_date(dob.date_of_birth),
+              date: dob.date_of_birth,
+              circa: circa_string?(dob.date_of_birth),
               city: pob&.place_of_birth
             )
           end

--- a/lib/ammitto/transformers/base_transformer.rb
+++ b/lib/ammitto/transformers/base_transformer.rb
@@ -206,17 +206,22 @@ module Ammitto
         )
       end
 
-      # Create a BirthInfo from birth data
+      # Create a BirthInfo from birth data.
+      #
+      # Invariant: BirthInfo#date is set only when the source states a
+      # complete day-month-year; a bare or partial year rides in
+      # BirthInfo#year and is never padded into an invented date.
       # @param date [String, Date, nil] birth date
       # @param circa [Boolean] whether the date is approximate
       # @param city [String, nil] birth city
       # @param region [String, nil] birth region/state
       # @param country [String, nil] birth country
       # @param country_iso_code [String, nil] ISO country code
+      # @param year [Integer, String, nil] source-stated birth year
       # @return [BirthInfo] the birth info
       def create_birth_info(date: nil, circa: false, city: nil, region: nil, country: nil,
                             country_iso_code: nil, year: nil)
-        parsed_date = date.is_a?(Date) ? date : parse_date(date)
+        parsed_date = parse_complete_date(date)
 
         Ammitto::BirthInfo.new(
           date: parsed_date,
@@ -225,8 +230,61 @@ module Ammitto
           region: region,
           country: country,
           country_iso_code: country_iso_code,
-          year: year || parsed_date&.year
+          year: normalize_year(year) || parsed_date&.year || extract_birth_year(date)
         )
+      end
+
+      # Parse a value into a Date only when it states day, month and year.
+      # Partial expressions ("1975", "Oct 1988", "00/00/1963") yield nil
+      # instead of a date padded with invented components. Date instances
+      # pass through: the caller already resolved them.
+      # @param value [Date, String, nil]
+      # @return [Date, nil]
+      def parse_complete_date(value)
+        return value if value.is_a?(Date)
+
+        str = value.to_s.strip
+        return nil if str.empty?
+
+        parts = Date._parse(str)
+        return nil unless parts[:year] && parts[:mon] && parts[:mday]
+
+        Date.new(parts[:year], parts[:mon], parts[:mday])
+      rescue Date::Error
+        nil
+      end
+
+      # Year stated by a partial date string ("1975", "circa 1975",
+      # "Oct 1988", "00/00/1963"). A range such as "1962 to 1964" names
+      # no single year and yields nil — range handling is a separate,
+      # dedicated concern.
+      # @param value [Object] candidate date string
+      # @return [Integer, nil]
+      def extract_birth_year(value)
+        return nil unless value.is_a?(String)
+
+        str = value.strip.sub(/\A(?:circa|approximately|c\.?)\s*/i, '')
+        return str.to_i if /\A\d{4}\z/.match?(str)
+
+        year = Date._parse(str)[:year]
+        year&.positive? ? year : nil
+      end
+
+      # Whether a source date string marks itself approximate
+      # ("circa 1960", "c. 1955", "approximately 1965")
+      # @param value [Object] candidate date string
+      # @return [Boolean]
+      def circa_string?(value)
+        value.is_a?(String) &&
+          value.strip.match?(/\A(?:circa|approximately|c\.)\s/i)
+      end
+
+      # Coerce a source-stated year to a positive Integer
+      # @param value [Integer, String, nil]
+      # @return [Integer, nil]
+      def normalize_year(value)
+        year = value.is_a?(Integer) ? value : value.to_s[/\A\d{4}\z/]&.to_i
+        year&.positive? ? year : nil
       end
 
       # Create a SanctionRegime

--- a/lib/ammitto/transformers/base_transformer.rb
+++ b/lib/ammitto/transformers/base_transformer.rb
@@ -257,26 +257,42 @@ module Ammitto
       # Year stated by a partial date string ("1975", "circa 1975",
       # "Oct 1988", "00/00/1963"). A range such as "1962 to 1964" names
       # no single year and yields nil — range handling is a separate,
-      # dedicated concern.
+      # dedicated concern. That rejection is stated here rather than
+      # left to Date._parse, which returns no year for today's range
+      # spellings only incidentally.
       # @param value [Object] candidate date string
       # @return [Integer, nil]
       def extract_birth_year(value)
         return nil unless value.is_a?(String)
 
         str = value.strip.sub(/\A(?:circa|approximately|c\.?)\s*/i, '')
+        return nil if multiple_years?(str)
         return str.to_i if /\A\d{4}\z/.match?(str)
 
         year = Date._parse(str)[:year]
         year&.positive? ? year : nil
       end
 
+      # Whether a date string names more than one year — "1962 to 1964",
+      # "between 1962 and 1964", "1962-1964". Such a string states a
+      # range, not a birth year. Years are matched on word boundaries so
+      # a run of digits ("19620101") is not read as two of them.
+      # @param value [String] date string, circa marker already stripped
+      # @return [Boolean]
+      def multiple_years?(value)
+        value.scan(/\b\d{4}\b/).uniq.size > 1
+      end
+
       # Whether a source date string marks itself approximate
-      # ("circa 1960", "c. 1955", "approximately 1965")
+      # ("circa 1960", "c. 1955", "c 1955", "approximately 1965").
+      # The bare "c" form is recognized because extract_birth_year
+      # strips it and au's FlexibleDate parser reads it as circa; without
+      # it "c 1955" yielded a year with circa left false.
       # @param value [Object] candidate date string
       # @return [Boolean]
       def circa_string?(value)
         value.is_a?(String) &&
-          value.strip.match?(/\A(?:circa|approximately|c\.)\s/i)
+          value.strip.match?(/\A(?:circa|approximately|c\.?)\s/i)
       end
 
       # Coerce a source-stated year to a positive Integer

--- a/spec/ammitto/sources/au/transformer_spec.rb
+++ b/spec/ammitto/sources/au/transformer_spec.rb
@@ -78,6 +78,53 @@ RSpec.describe Ammitto::Sources::Au::Transformer do
         effect_types = result[:entry].effects.map(&:effect_type)
         expect(effect_types).to contain_exactly('asset_freeze', 'travel_ban')
       end
+
+      it 'carries the complete birth date with its year' do
+        birth = result[:entity].birth_info.first
+        expect(birth.date).to eq(Date.new(1957, 5, 5))
+        expect(birth.year).to eq(1957)
+      end
+    end
+
+    # The birth-precision invariant: a source-provided year is
+    # BirthInfo#year; BirthInfo#date is set only when the source states a
+    # complete day-month-year.
+    context 'when transforming partial birth dates' do
+      def birth_infos_for(*raw_dates)
+        individual = Ammitto::Sources::Au::Individual.new(
+          reference: '9001',
+          dates_of_birth: raw_dates.map do |raw|
+            Ammitto::Sources::Au::FlexibleDate.parse(raw)
+          end,
+          places_of_birth: []
+        )
+        transformer.send(:transform_birth_info, individual)
+      end
+
+      it 'keeps a year-only date as year, without a date' do
+        birth = birth_infos_for('1957').first
+        expect(birth.year).to eq(1957)
+        expect(birth.date).to be_nil
+      end
+
+      it 'keeps a month-year date as year, without inventing a day' do
+        birth = birth_infos_for('May 1957').first
+        expect(birth.year).to eq(1957)
+        expect(birth.date).to be_nil
+      end
+
+      it 'keeps a circa year as a circa-flagged year, without a date' do
+        birth = birth_infos_for('circa 1957').first
+        expect(birth.year).to eq(1957)
+        expect(birth.date).to be_nil
+        expect(birth.circa).to be true
+      end
+
+      it 'resolves a fully stated date to a date plus year' do
+        birth = birth_infos_for('5 May 1957').first
+        expect(birth.date).to eq(Date.new(1957, 5, 5))
+        expect(birth.year).to eq(1957)
+      end
     end
 
     context 'when transforming a vessel' do

--- a/spec/ammitto/sources/ch/transformer_spec.rb
+++ b/spec/ammitto/sources/ch/transformer_spec.rb
@@ -18,4 +18,37 @@ RSpec.describe Ammitto::Sources::Ch::Transformer do
       expect(auth.name).to eq('Switzerland (SECO)')
     end
   end
+
+  # The birth-precision invariant: a source-provided year is
+  # BirthInfo#year; BirthInfo#date is set only when the source states a
+  # complete day-month-year.
+  describe '#transform_birth_info' do
+    def birth_for(day: nil, month: nil, year: nil)
+      identity = Ammitto::Sources::Ch::Identity.new(
+        ssid: '100',
+        day_month_year: Ammitto::Sources::Ch::DayMonthYear.new(
+          day: day, month: month, year: year
+        )
+      )
+      transformer.send(:transform_birth_info, identity).first
+    end
+
+    it 'keeps a year-only record as year, without a date' do
+      birth = birth_for(year: 1975)
+      expect(birth.year).to eq(1975)
+      expect(birth.date).to be_nil
+    end
+
+    it 'keeps a year-month record as year, without inventing a day' do
+      birth = birth_for(year: 1975, month: 3)
+      expect(birth.year).to eq(1975)
+      expect(birth.date).to be_nil
+    end
+
+    it 'resolves a fully stated record to a date plus year' do
+      birth = birth_for(year: 1975, month: 3, day: 5)
+      expect(birth.date).to eq(Date.new(1975, 3, 5))
+      expect(birth.year).to eq(1975)
+    end
+  end
 end

--- a/spec/ammitto/sources/eu/transformer_spec.rb
+++ b/spec/ammitto/sources/eu/transformer_spec.rb
@@ -18,4 +18,38 @@ RSpec.describe Ammitto::Sources::Eu::Transformer do
       expect(auth.name).to eq('European Union')
     end
   end
+
+  # The birth-precision invariant: a source-provided year is
+  # BirthInfo#year; BirthInfo#date is set only when the source states a
+  # complete birthdate.
+  describe '#transform_birthdates' do
+    def birth_for(**attrs)
+      birthdate = Ammitto::Sources::Eu::Birthdate.new(**attrs)
+      transformer.send(:transform_birthdates, [birthdate]).first
+    end
+
+    it 'keeps a year-only record as year, without inventing January 1' do
+      birth = birth_for(year: 1962)
+      expect(birth.year).to eq(1962)
+      expect(birth.date).to be_nil
+    end
+
+    it 'keeps a year-month record as year, without inventing a date' do
+      birth = birth_for(year: 1962, month_of_year: 9)
+      expect(birth.year).to eq(1962)
+      expect(birth.date).to be_nil
+    end
+
+    it 'resolves a complete birthdate to a date plus year' do
+      birth = birth_for(birthdate: '1962-09-03', year: 1962)
+      expect(birth.date).to eq(Date.new(1962, 9, 3))
+      expect(birth.year).to eq(1962)
+    end
+
+    it 'preserves the circa flag' do
+      birth = birth_for(year: 1962, circa: true)
+      expect(birth.circa).to be true
+      expect(birth.date).to be_nil
+    end
+  end
 end

--- a/spec/ammitto/sources/ru/transformer_spec.rb
+++ b/spec/ammitto/sources/ru/transformer_spec.rb
@@ -18,4 +18,30 @@ RSpec.describe Ammitto::Sources::Ru::Transformer do
       expect(auth.name).to eq('Russia (MID/CBR)')
     end
   end
+
+  # The birth-precision invariant: a source-provided year is
+  # BirthInfo#year; BirthInfo#date is set only when the source states a
+  # complete day-month-year.
+  describe '#transform birth info' do
+    def birth_for(dob_string)
+      entity = Ammitto::Sources::Ru::SanctionedEntity.new(
+        english_name: 'Test Person',
+        entity_type: 'person',
+        date_of_birth: dob_string
+      )
+      transformer.transform(entity)[:entity].birth_info.first
+    end
+
+    it 'keeps a year-only DOB as year, without a date' do
+      birth = birth_for('1975')
+      expect(birth.year).to eq(1975)
+      expect(birth.date).to be_nil
+    end
+
+    it 'resolves a complete DOB to a date plus year' do
+      birth = birth_for('1975-02-01')
+      expect(birth.date).to eq(Date.new(1975, 2, 1))
+      expect(birth.year).to eq(1975)
+    end
+  end
 end

--- a/spec/ammitto/sources/uk/transformer_spec.rb
+++ b/spec/ammitto/sources/uk/transformer_spec.rb
@@ -18,4 +18,38 @@ RSpec.describe Ammitto::Sources::Uk::Transformer do
       expect(auth.name).to eq('United Kingdom (OFSI)')
     end
   end
+
+  # The birth-precision invariant: a source-provided year is
+  # BirthInfo#year; BirthInfo#date is set only when the source states a
+  # complete day-month-year. OFSI writes unknown components as zeros
+  # ("00/00/1975"), which the model normalizes to "1975-00-00".
+  describe '#transform_birth_info' do
+    def birth_for(dob)
+      details = Ammitto::Sources::Uk::IndividualDetails.new(dobs: [dob])
+      transformer.send(:transform_birth_info, details).first
+    end
+
+    it 'keeps a zeroed partial DOB as year, without a date' do
+      birth = birth_for('00/00/1975')
+      expect(birth.year).to eq(1975)
+      expect(birth.date).to be_nil
+    end
+
+    it 'keeps a zeroed day-month with known month as year, without a date' do
+      birth = birth_for('00/03/1975')
+      expect(birth.year).to eq(1975)
+      expect(birth.date).to be_nil
+    end
+
+    it 'resolves a complete DD/MM/YYYY DOB to a date plus year' do
+      birth = birth_for('07/05/1963')
+      expect(birth.date).to eq(Date.new(1963, 5, 7))
+      expect(birth.year).to eq(1963)
+    end
+
+    it 'skips dd/mm placeholders entirely' do
+      details = Ammitto::Sources::Uk::IndividualDetails.new(dobs: ['dd/mm/yyyy'])
+      expect(transformer.send(:transform_birth_info, details)).to eq([])
+    end
+  end
 end

--- a/spec/ammitto/sources/un/transformer_spec.rb
+++ b/spec/ammitto/sources/un/transformer_spec.rb
@@ -18,4 +18,35 @@ RSpec.describe Ammitto::Sources::Un::Transformer do
       expect(auth.name).to eq('United Nations')
     end
   end
+
+  # The birth-precision invariant: a source-provided year is
+  # BirthInfo#year; BirthInfo#date is set only when the source states a
+  # complete date.
+  describe '#transform_birth_info' do
+    def birth_for(**attrs)
+      individual = Ammitto::Sources::Un::Individual.new(
+        date_of_birth: Ammitto::Sources::Un::IndividualDateOfBirth.new(**attrs)
+      )
+      transformer.send(:transform_birth_info, individual).first
+    end
+
+    it 'keeps an EXACT year-only record as year, without inventing January 1' do
+      birth = birth_for(type_of_date: 'EXACT', year: 1971)
+      expect(birth.year).to eq(1971)
+      expect(birth.date).to be_nil
+    end
+
+    it 'keeps an APPROXIMATELY year as a circa-flagged year, without a date' do
+      birth = birth_for(type_of_date: 'APPROXIMATELY', year: 1960)
+      expect(birth.year).to eq(1960)
+      expect(birth.date).to be_nil
+      expect(birth.circa).to be true
+    end
+
+    it 'resolves a complete date to a date plus year' do
+      birth = birth_for(type_of_date: 'EXACT', date: '1978-04-28')
+      expect(birth.date).to eq(Date.new(1978, 4, 28))
+      expect(birth.year).to eq(1978)
+    end
+  end
 end

--- a/spec/ammitto/sources/us/transformer_spec.rb
+++ b/spec/ammitto/sources/us/transformer_spec.rb
@@ -18,4 +18,60 @@ RSpec.describe Ammitto::Sources::Us::Transformer do
       expect(auth.name).to eq('United States (OFAC)')
     end
   end
+
+  # The birth-precision invariant: a source-provided year is
+  # BirthInfo#year; BirthInfo#date is set only when the source states a
+  # complete day-month-year.
+  describe '#transform_birth_info' do
+    def birth_for(dob_string)
+      entry = Ammitto::Sources::Us::SdnEntry.new(
+        uid: '1',
+        date_of_birth_list: Ammitto::Sources::Us::DateOfBirthList.new(
+          items: [
+            Ammitto::Sources::Us::DateOfBirthItem.new(date_of_birth: dob_string)
+          ]
+        )
+      )
+      transformer.send(:transform_birth_info, entry).first
+    end
+
+    it 'keeps a bare year as year, without a date' do
+      birth = birth_for('1988')
+      expect(birth.year).to eq(1988)
+      expect(birth.date).to be_nil
+    end
+
+    it 'keeps a month-year DOB as year, without inventing day 1' do
+      birth = birth_for('Oct 1988')
+      expect(birth.year).to eq(1988)
+      expect(birth.date).to be_nil
+    end
+
+    it 'keeps a circa year as a circa-flagged year, without a date' do
+      birth = birth_for('circa 1960')
+      expect(birth.year).to eq(1960)
+      expect(birth.date).to be_nil
+      expect(birth.circa).to be true
+    end
+
+    it 'resolves a complete DOB to a date plus year' do
+      birth = birth_for('03 Oct 1988')
+      expect(birth.date).to eq(Date.new(1988, 10, 3))
+      expect(birth.year).to eq(1988)
+    end
+
+    # Range handling is deliberately deferred (separate design); these
+    # pin today's behavior so a later range design changes it knowingly.
+    it 'pins year ranges to no date and no year, pending range handling' do
+      birth = birth_for('1962 to 1964')
+      expect(birth.date).to be_nil
+      expect(birth.year).to be_nil
+    end
+
+    it 'pins full-date ranges to their opening date, pending range handling' do
+      birth = birth_for('28 Feb 1962 to 28 Feb 1963')
+      expect(birth.date).to eq(Date.new(1962, 2, 28))
+      expect(birth.year).to eq(1962)
+    end
+  end
 end

--- a/spec/ammitto/transformers/base_transformer_spec.rb
+++ b/spec/ammitto/transformers/base_transformer_spec.rb
@@ -121,9 +121,40 @@ RSpec.describe Ammitto::Transformers::BaseTransformer do
       expect(transformer.send(:extract_birth_year, '1962 to 1964')).to be_nil
     end
 
+    it 'yields nil for every spelling of a year range' do
+      ['1962 to 1964', 'between 1962 and 1964', '1962-1964',
+       '1962–1964', 'circa 1962 to 1964'].each do |range|
+        expect(transformer.send(:extract_birth_year, range))
+          .to(be_nil, "expected #{range.inspect} to name no single year")
+      end
+    end
+
     it 'yields nil for non-strings' do
       expect(transformer.send(:extract_birth_year, nil)).to be_nil
       expect(transformer.send(:extract_birth_year, Date.new(1970, 1, 1))).to be_nil
+    end
+  end
+
+  describe '#multiple_years?' do
+    it 'is true only when two different years are named' do
+      expect(transformer.send(:multiple_years?, '1962 to 1964')).to be true
+      expect(transformer.send(:multiple_years?, '1962-1964')).to be true
+      expect(transformer.send(:multiple_years?, 'between 1962 and 1964'))
+        .to be true
+    end
+
+    it 'is false for one year, however it is written' do
+      ['1975', '00/00/1963', '03 Oct 1988', '1963 (1963)']
+        .each do |str|
+          expect(transformer.send(:multiple_years?, str))
+            .to(be(false), "expected #{str.inspect} to name one year")
+        end
+    end
+
+    # A guard reading "19620101" as 1962 and 0101 would reject a date
+    # the parser handles today.
+    it 'does not split a run of digits into two years' do
+      expect(transformer.send(:multiple_years?, '19620101')).to be false
     end
   end
 
@@ -134,9 +165,29 @@ RSpec.describe Ammitto::Transformers::BaseTransformer do
       expect(transformer.send(:circa_string?, 'approximately 1965')).to be true
     end
 
+    it 'recognizes the bare "c" marker extract_birth_year strips' do
+      expect(transformer.send(:circa_string?, 'c 1955')).to be true
+      expect(transformer.send(:circa_string?, 'C 1955')).to be true
+    end
+
+    # The year and the circa flag are read from the same string by two
+    # different methods; when they disagree the entity claims an exact
+    # birth year the source only approximated.
+    it 'agrees with extract_birth_year on both "c" spellings' do
+      ['c 1955', 'c. 1955'].each do |str|
+        expect(transformer.send(:extract_birth_year, str)).to eq(1955)
+        expect(transformer.send(:circa_string?, str)).to be true
+      end
+    end
+
     it 'rejects plain dates and non-strings' do
       expect(transformer.send(:circa_string?, '03 Oct 1988')).to be false
       expect(transformer.send(:circa_string?, nil)).to be false
+    end
+
+    it 'does not read a word starting with c as a circa marker' do
+      expect(transformer.send(:circa_string?, 'China 1955')).to be false
+      expect(transformer.send(:circa_string?, 'c1955')).to be false
     end
   end
 end

--- a/spec/ammitto/transformers/base_transformer_spec.rb
+++ b/spec/ammitto/transformers/base_transformer_spec.rb
@@ -45,4 +45,98 @@ RSpec.describe Ammitto::Transformers::BaseTransformer do
       expect(auth).to be_nil # :test is not a registered authority
     end
   end
+
+  # The birth-precision invariant: a source-provided year is BirthInfo#year;
+  # BirthInfo#date is set only when the source states a complete
+  # day-month-year, never padded from a partial expression.
+  describe '#create_birth_info' do
+    it 'sets date and year for a complete date string' do
+      info = transformer.send(:create_birth_info, date: '03 Oct 1988')
+      expect(info.date).to eq(Date.new(1988, 10, 3))
+      expect(info.year).to eq(1988)
+    end
+
+    it 'keeps a bare year as year only, without inventing a date' do
+      info = transformer.send(:create_birth_info, date: '1988')
+      expect(info.date).to be_nil
+      expect(info.year).to eq(1988)
+    end
+
+    it 'keeps a month-year string as year only, without inventing a day' do
+      info = transformer.send(:create_birth_info, date: 'Oct 1988')
+      expect(info.date).to be_nil
+      expect(info.year).to eq(1988)
+    end
+
+    it 'prefers an explicitly passed year over string extraction' do
+      info = transformer.send(:create_birth_info, date: nil, year: 1971)
+      expect(info.date).to be_nil
+      expect(info.year).to eq(1971)
+    end
+
+    it 'passes a caller-resolved Date through unchanged' do
+      info = transformer.send(:create_birth_info, date: Date.new(1957, 5, 5))
+      expect(info.date).to eq(Date.new(1957, 5, 5))
+      expect(info.year).to eq(1957)
+    end
+  end
+
+  describe '#parse_complete_date' do
+    it 'parses a complete ISO date' do
+      expect(transformer.send(:parse_complete_date, '1957-05-05'))
+        .to eq(Date.new(1957, 5, 5))
+    end
+
+    it 'returns nil for a bare year' do
+      expect(transformer.send(:parse_complete_date, '1975')).to be_nil
+    end
+
+    it 'returns nil for a zero-padded partial date' do
+      expect(transformer.send(:parse_complete_date, '1963-00-00')).to be_nil
+    end
+
+    it 'returns nil for a month-year string' do
+      expect(transformer.send(:parse_complete_date, 'Oct 1988')).to be_nil
+    end
+
+    it 'returns nil for an impossible date' do
+      expect(transformer.send(:parse_complete_date, '31/02/1990')).to be_nil
+    end
+  end
+
+  describe '#extract_birth_year' do
+    it 'extracts a bare year' do
+      expect(transformer.send(:extract_birth_year, '1975')).to eq(1975)
+    end
+
+    it 'extracts the year from a circa expression' do
+      expect(transformer.send(:extract_birth_year, 'circa 1960')).to eq(1960)
+    end
+
+    it 'extracts the year from a zeroed partial date' do
+      expect(transformer.send(:extract_birth_year, '00/00/1963')).to eq(1963)
+    end
+
+    it 'yields nil for a year range — range handling is a separate concern' do
+      expect(transformer.send(:extract_birth_year, '1962 to 1964')).to be_nil
+    end
+
+    it 'yields nil for non-strings' do
+      expect(transformer.send(:extract_birth_year, nil)).to be_nil
+      expect(transformer.send(:extract_birth_year, Date.new(1970, 1, 1))).to be_nil
+    end
+  end
+
+  describe '#circa_string?' do
+    it 'recognizes circa markers' do
+      expect(transformer.send(:circa_string?, 'circa 1960')).to be true
+      expect(transformer.send(:circa_string?, 'c. 1955')).to be true
+      expect(transformer.send(:circa_string?, 'approximately 1965')).to be true
+    end
+
+    it 'rejects plain dates and non-strings' do
+      expect(transformer.send(:circa_string?, '03 Oct 1988')).to be false
+      expect(transformer.send(:circa_string?, nil)).to be false
+    end
+  end
 end


### PR DESCRIPTION
A source-stated birth year could not reach the published data. `FlexibleDate`
year-precision values return `nil` from `to_date`, and AU passed only
`to_date` into `BirthInfo` — so correctly parsed years vanished. EU and UN went
the other way and invented January 1 dates from bare years; UK, US and RU let
`Date.parse` decide. Five different behaviours for one question.

## Changes

- `BaseTransformer#create_birth_info` becomes the single choke point: a new
  `parse_complete_date` sets `date` only when the source states day, month and
  year (checked via `Date._parse` components), and `year` is filled
  independently.
- Per-source adaptations so no transformer hands an already-invented `Date` to
  the choke point.

The invariant, stated once: **a source-provided year is `BirthInfo.year`;
`BirthInfo.date` exists only when the source provided a complete date.**

## Effect on the corpus

Measured over real harmonize output for au, ch, eu, uk, un and us — 23,826
entities carrying birth information:

- **3,143 entities gain a year** they were silently losing
- **zero source-stated complete dates are lost**
- the non-birth graph is byte-identical

RU has no corpus run available; its behaviour is pinned by transformer specs
instead.

Date *ranges* are deliberately out of scope — that needs first-class range
fields, designed separately.

## Test plan

- `bundle exec rspec` / `bundle exec rubocop` — green
- Per-source specs proving the invariant, red without the change
