### PR TITLE
Add a fleet health monitor for the data-repo fetch schedules

### DIFF
--- a/.github/workflows/fleet-health.yml
+++ b/.github/workflows/fleet-health.yml
@@ -9,14 +9,18 @@ name: fleet-health
 # Actions API — every fleet repo is public, so the default GITHUB_TOKEN
 # is enough (anonymous reads work too; the token only buys rate limit) —
 # and fails loudly when any schedule is dead, stale (>48h without a
-# schedule-event run) or failing (3+ consecutive failed runs). A run
+# schedule-event run), failing (3+ hard failures since the last success)
+# or unreadable. Only scheduled runs are counted, so a red PR run never
+# pages the fleet and a green push run never clears a real streak. A run
 # that commits nothing is healthy: only run conclusions are read, never
 # commit deltas, so zero-delta days are never flagged.
 #
-# One alert channel: on detection the job appends a per-repo report to
-# the job summary and creates-or-updates a SINGLE tracking issue on this
-# repo (matched by exact title; an open match gets a comment, so there
-# is never a duplicate). Then the job exits non-zero.
+# One alert channel: the job appends a per-repo report to the job summary
+# and keeps a SINGLE tracking issue on this repo (matched by exact
+# title). The issue step runs on every pass, healthy or not, because it
+# is what announces recovery — but it only writes when the set of paging
+# repos actually CHANGES, so an unhealthy fleet does not generate a
+# comment a day until someone mutes the whole channel.
 #
 # This monitor runs on a schedule, so IT can die the same death.
 # Mitigations: workflow_dispatch allows a manual heartbeat at any time;
@@ -61,24 +65,33 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Self-test the monitor
-        # Offline fixture proof (dead / stale / failing / healthy-quiet
-        # / unreadable, plus issue-upsert idempotency with a stubbed
-        # gh). A monitor whose parser silently broke would report
-        # "healthy" forever — the exact failure mode this workflow
-        # exists to kill — so the live check only runs after the logic
-        # proves itself. Costs <1s and no API calls.
+        # Offline fixture proof (dead / stale / failing / cancelled-
+        # forever / healthy-quiet / unreadable documents / acknowledged
+        # / expired acknowledgement, the scheduled-runs-only query, plus
+        # the issue state machine against a stubbed gh). A monitor whose
+        # parser silently broke would report "healthy" forever — the
+        # exact failure mode this workflow exists to kill — so the live
+        # check only runs after the logic proves itself. Costs <1s and
+        # no API calls.
         run: scripts/fleet_health_test.sh
 
       - name: Check fleet health
         id: fleet
         env:
           GH_TOKEN: ${{ github.token }}
-        # Exit 0 = healthy, 1 = unhealthy (report tells which repos and
-        # why), anything else = the script itself broke and the job must
-        # fail as a monitor outage, not masquerade as a health verdict.
+        # Exit 0 = nothing paging, 1 = at least one repo pages (report
+        # tells which and why), 69 = every repo was unreadable so the
+        # monitor's own view is down, anything else = the script broke.
+        # All of those fail the job here and skip the issue step, so an
+        # auth or rate-limit outage never masquerades as a health
+        # verdict or manufactures an incident about fifteen repos.
         run: |
           rc=0
           scripts/fleet_health.sh --report fleet-report.md || rc=$?
+          if [ "$rc" -eq 69 ]; then
+            echo "::error::fleet health could not read ANY repo — auth, rate limit or API outage"
+            exit "$rc"
+          fi
           if [ "$rc" -gt 1 ]; then
             echo "::error::fleet_health.sh crashed with exit $rc"
             exit "$rc"
@@ -89,12 +102,18 @@ jobs:
             echo "healthy=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Create or update the single tracking issue
-        if: steps.fleet.outputs.healthy == 'false'
+      # Runs on healthy passes too: recovery is a state change and has to
+      # be announced, and a healthy pass with no open issue writes
+      # nothing at all. The script decides; the default `if: success()`
+      # keeps it from running when the check above crashed.
+      - name: Announce fleet-health state changes
         env:
           GH_TOKEN: ${{ github.token }}
         run: scripts/fleet_health_issue.sh fleet-report.md
 
+      # Always fails while anything pages, even on the days the issue
+      # step stayed quiet because nothing changed: the red run is the
+      # standing signal, the issue comment is only the change notice.
       - name: Fail loudly
         if: steps.fleet.outputs.healthy == 'false'
         run: |

--- a/.github/workflows/fleet-health.yml
+++ b/.github/workflows/fleet-health.yml
@@ -1,0 +1,102 @@
+name: fleet-health
+
+# Watches the fifteen ammitto/data-* fetch schedules from ONE place.
+#
+# Why: GitHub silently disables a cron workflow after 60 days without
+# repository activity. Six data-repo schedules died exactly that way and
+# nobody noticed for ~3 months (the run gap from 2026-05-11 to 2026-08-07
+# on data-ca/data-cn is the fossil record). This job reads each repo's
+# Actions API — every fleet repo is public, so the default GITHUB_TOKEN
+# is enough (anonymous reads work too; the token only buys rate limit) —
+# and fails loudly when any schedule is dead, stale (>48h without a
+# schedule-event run) or failing (3+ consecutive failed runs). A run
+# that commits nothing is healthy: only run conclusions are read, never
+# commit deltas, so zero-delta days are never flagged.
+#
+# One alert channel: on detection the job appends a per-repo report to
+# the job summary and creates-or-updates a SINGLE tracking issue on this
+# repo (matched by exact title; an open match gets a comment, so there
+# is never a duplicate). Then the job exits non-zero.
+#
+# This monitor runs on a schedule, so IT can die the same death.
+# Mitigations: workflow_dispatch allows a manual heartbeat at any time;
+# the push trigger below re-runs (and, per GitHub's rules, re-enables)
+# the workflow whenever its own files change, and any commit to the repo
+# resets the 60-day inactivity clock — this hub repo has regular commit
+# traffic, unlike the data repos; GitHub also emails a deactivation
+# warning before disabling. RESIDUAL RISK, stated honestly: if this hub
+# repo itself goes quiet for 60+ days, the watchdog dies silently with
+# everything it watches. No in-repo trigger can prevent that; closing it
+# needs a watcher outside GitHub (e.g. a dead-man's-switch pinger such
+# as healthchecks.io alerting when the daily run STOPS reporting). That
+# is deliberately not added here to stay dependency-free.
+
+on:
+  schedule:
+    - cron: '30 12 * * *'  # Daily, after the fleet's fetch window (~06-10 UTC)
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/fleet-health.yml'
+      - 'scripts/fleet_health.sh'
+      - 'scripts/fleet_health_issue.sh'
+      - 'scripts/fleet_health_test.sh'
+      - 'scripts/fleet_repos.txt'
+
+permissions:
+  contents: read
+  issues: write
+
+# A slow API day must not let two runs race each other into the
+# tracking issue.
+concurrency:
+  group: fleet-health
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Self-test the monitor
+        # Offline fixture proof (dead / stale / failing / healthy-quiet
+        # / unreadable, plus issue-upsert idempotency with a stubbed
+        # gh). A monitor whose parser silently broke would report
+        # "healthy" forever — the exact failure mode this workflow
+        # exists to kill — so the live check only runs after the logic
+        # proves itself. Costs <1s and no API calls.
+        run: scripts/fleet_health_test.sh
+
+      - name: Check fleet health
+        id: fleet
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # Exit 0 = healthy, 1 = unhealthy (report tells which repos and
+        # why), anything else = the script itself broke and the job must
+        # fail as a monitor outage, not masquerade as a health verdict.
+        run: |
+          rc=0
+          scripts/fleet_health.sh --report fleet-report.md || rc=$?
+          if [ "$rc" -gt 1 ]; then
+            echo "::error::fleet_health.sh crashed with exit $rc"
+            exit "$rc"
+          fi
+          if [ "$rc" -eq 0 ]; then
+            echo "healthy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "healthy=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update the single tracking issue
+        if: steps.fleet.outputs.healthy == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/fleet_health_issue.sh fleet-report.md
+
+      - name: Fail loudly
+        if: steps.fleet.outputs.healthy == 'false'
+        run: |
+          echo "::error::Fleet unhealthy — per-repo report in the job summary and the tracking issue"
+          exit 1

--- a/scripts/fleet_health.sh
+++ b/scripts/fleet_health.sh
@@ -12,28 +12,78 @@
 #           FLEET_HEALTH_MAX_AGE_HOURS hours (default 48 — one missed
 #           daily run plus cron jitter). Catches deaths the state field
 #           misses: cron typo, renamed workflow file, archived repo.
-#   FAILING FLEET_HEALTH_STREAK (default 3) or more consecutive failed
-#           completed runs with no intervening success. failure,
-#           timed_out and startup_failure count as failures; cancelled,
-#           skipped and neutral neither extend nor break a streak.
-#   UNREADABLE fetch.yml missing or the API unreachable. Deliberately
-#           unhealthy: an unwatchable repo is not a healthy repo.
+#   FAILING FLEET_HEALTH_STREAK (default 3) or more hard failures since
+#           the last success — see "The streak model" below.
+#   UNREADABLE any of the three API documents missing, empty, or not
+#           shaped like the API contract. Deliberately unhealthy: a repo
+#           we cannot read is not a repo we can call healthy.
 #
 # A run that commits nothing is HEALTHY: only run conclusions are read,
 # never commit deltas, so zero-delta days (data-au has them legitimately)
 # are never flagged.
 #
+# Scheduled runs only
+# -------------------
+# Every run query filters event=schedule. The monitor watches the cron,
+# not the repo: a failing PR or a broken push run says nothing about
+# whether the daily fetch still works, and letting those into the streak
+# both raises false alarms (red PR run pages the fleet) and hides real
+# ones (a green push run would reset a streak of dead cron runs).
+#
+# The streak model
+# ----------------
+# Conclusions are read newest-first and mapped to one letter each:
+#   S  success
+#   F  hard failure — failure, timed_out, startup_failure
+#   C  inconclusive — cancelled, skipped, neutral, action_required,
+#      stale, or a null/unknown conclusion
+# The window under judgement is everything before the most recent S (the
+# whole sequence when there is no S at all). Within that window:
+#   * FLEET_HEALTH_STREAK or more F  -> failing.
+#   * FLEET_HEALTH_STREAK or more C  -> flagged too. Inconclusive runs
+#     used to be dropped outright, which let a repo whose cron fires
+#     daily and is cancelled every time look perfectly healthy: recent
+#     run, no failures, no page. A schedule that never finishes is not a
+#     working schedule, so repeated cancellations are surfaced, not
+#     swallowed.
+#   * Neither count reaching the limit but no S anywhere in the window
+#     and at least FLEET_HEALTH_STREAK runs in it -> flagged as well.
+#     This is the mixed-outcome catch-all (2 failures + 2 cancellations
+#     is four scheduled runs since the last success, and no single
+#     counter would notice).
+#
+# Acknowledgements
+# ----------------
+# A line in the repos file may carry an acknowledgement:
+#
+#   data-ru ack:parked for maintainer ruling on ru revival:2026-09-07
+#
+# meaning "this one is known-broken, do not page me about it until
+# 2026-09-07". Acknowledged repos report ACKNOWLEDGED, are excluded from
+# the unhealthy count and never reach the tracking issue. The date is a
+# deadline, not a mute button: from the day AFTER review-by the repo
+# reports EXPIRED-ACK and pages like any other failure — including when
+# it has since recovered, because an expired acknowledgement is an
+# unmade decision and the point of the date is to force the ruling. A
+# malformed acknowledgement pages immediately rather than suppressing
+# anything, so a typo in the date can never mute a repo forever.
+#
 # Usage: scripts/fleet_health.sh [--report FILE]
 #   Prints a Markdown report (also appended to GITHUB_STEP_SUMMARY when
-#   set, and written to FILE with --report).
-#   Exit 0: every repo healthy. Exit 1: at least one repo flagged.
+#   set, and written to FILE with --report). The report ends with an
+#   HTML-comment state marker that fleet_health_issue.sh diffs to decide
+#   whether anything actually changed.
+#   Exit 0: nothing paging. Exit 1: at least one repo pages.
+#   Exit 69: every repo was unreadable — the monitor's own view is down
+#   (auth, rate limit, network), which is an outage to fix, not fifteen
+#   dead repositories to page about.
 #   Any other exit code is a bug in this script, not a health verdict.
 #
 # Environment:
 #   FLEET_HEALTH_ORG            owner org (default ammitto)
 #   FLEET_HEALTH_WORKFLOW       workflow file name (default fetch.yml)
 #   FLEET_HEALTH_MAX_AGE_HOURS  staleness limit (default 48)
-#   FLEET_HEALTH_STREAK         failure-streak limit (default 3)
+#   FLEET_HEALTH_STREAK         failure/inconclusive limit (default 3)
 #   FLEET_HEALTH_REPOS_FILE     repo list (default scripts/fleet_repos.txt)
 #   FLEET_HEALTH_FIXTURES       dir of fixture JSON; no network at all
 #   FLEET_HEALTH_NOW_EPOCH      freeze "now" for tests
@@ -71,28 +121,40 @@ done
 [ -f "$REPOS_FILE" ] || { echo "repos file not found: $REPOS_FILE" >&2; exit 66; }
 
 # Fetch one API document. kind: workflow | schedule_runs | completed_runs.
-# Prints the JSON body, or nothing on any failure — the caller treats an
-# empty/invalid body as UNREADABLE rather than crashing, so one repo's
-# outage cannot hide the state of the other fourteen.
+# Prints the JSON body, or nothing on any failure — the caller validates
+# the body and treats anything unexpected as UNREADABLE rather than
+# crashing, so one repo's outage cannot hide the other fourteen.
 api_get() {
-  local kind="$1" repo="$2" path
+  local kind="$1" repo="$2" path base
   if [ -n "$FIXTURES" ]; then
     cat "$FIXTURES/${repo}__${kind}.json" 2>/dev/null || true
     return 0
   fi
+  base="repos/$ORG/$repo/actions/workflows/$WORKFLOW_FILE"
   case "$kind" in
     workflow)
-      path="repos/$ORG/$repo/actions/workflows/$WORKFLOW_FILE" ;;
+      path="$base" ;;
+    # Recency: newest scheduled run of any status, so a run still in
+    # progress still counts as the cron having fired.
     schedule_runs)
-      path="repos/$ORG/$repo/actions/workflows/$WORKFLOW_FILE/runs?event=schedule&per_page=1" ;;
+      path="$base/runs?event=schedule&per_page=1" ;;
+    # Streak: scheduled runs only. A red PR run must never page the
+    # fleet, and a green push run must never clear a real streak.
     completed_runs)
-      path="repos/$ORG/$repo/actions/workflows/$WORKFLOW_FILE/runs?status=completed&per_page=10" ;;
+      path="$base/runs?event=schedule&status=completed&per_page=10" ;;
     *)
       return 1 ;;
   esac
+  # `gh auth token` only exists from gh 2.6; probing with it alone made
+  # gh 2.4 look logged-out and silently dropped the whole run onto the
+  # anonymous curl path, whose 60/hour budget one 45-call pass nearly
+  # exhausts. The second pass then returned nothing for every repo and
+  # the monitor reported fifteen dead repositories. `gh auth status` has
+  # been there far longer, so try both.
   if command -v gh >/dev/null 2>&1 &&
      { [ -n "${GH_TOKEN:-}" ] || [ -n "${GITHUB_TOKEN:-}" ] ||
-       gh auth token >/dev/null 2>&1; }; then
+       gh auth token >/dev/null 2>&1 ||
+       gh auth status >/dev/null 2>&1; }; then
     gh api "$path" 2>/dev/null || true
   else
     curl -sS --max-time 30 -H 'Accept: application/vnd.github+json' \
@@ -100,109 +162,271 @@ api_get() {
   fi
 }
 
+# Every document is validated on its own. Before this existed only the
+# workflow document was checked, so a 404 or a truncated body on the
+# runs endpoints produced an empty sequence, a zero streak and a
+# confident "OK" — the monitor's own version of the silence it exists to
+# detect.
+#
+# An empty body must be rejected before jq sees it: `jq -e` exits 0 on
+# empty input (verified with jq 1.6), so an unchecked empty response
+# would validate.
+doc_valid() { # kind json
+  local kind="$1" json="$2"
+  [ -n "${json//[[:space:]]/}" ] || return 1
+  case "$kind" in
+    workflow)
+      jq -e 'type == "object" and (.state | type == "string")
+             and (.state | length > 0)' >/dev/null 2>&1 <<<"$json" ;;
+    *)
+      jq -e 'type == "object" and (.workflow_runs | type == "array")' \
+        >/dev/null 2>&1 <<<"$json" ;;
+  esac
+}
+
 table_rows=""
 detail_lines=""
-unhealthy=0
+state_pairs=""
+paging=0
+acknowledged=0
+unreadable_total=0
 total=0
 
 # The loop reads the repos file on FD 3 so gh/curl inside the loop can
 # never swallow the remaining lines from stdin.
-while IFS= read -r repo <&3; do
-  repo="${repo%%#*}"
-  repo="$(printf '%s' "$repo" | tr -d '[:space:]')"
+while IFS= read -r line <&3; do
+  line="${line%%#*}"
+  # First field is the repo, the rest (if any) is the acknowledgement.
+  read -r repo ack_spec <<<"$line" || true
+  repo="${repo:-}"
+  ack_spec="${ack_spec:-}"
   [ -n "$repo" ] || continue
   total=$((total + 1))
 
+  # --- acknowledgement --------------------------------------------------
+  # "ack:<reason>:<review-by YYYY-MM-DD>". The reason may itself contain
+  # colons, so the date is taken from the last colon and the reason is
+  # everything before it.
+  ack_reason=""
+  ack_until=""
+  ack_bad=""
+  ack_epoch=0
+  if [ -n "$ack_spec" ]; then
+    case "$ack_spec" in
+      ack:*)
+        ack_body="${ack_spec#ack:}"
+        ack_until="${ack_body##*:}"
+        ack_reason="${ack_body%:*}"
+        if [ -z "$ack_reason" ] || [ "$ack_reason" = "$ack_until" ]; then
+          ack_bad="acknowledgement needs 'ack:<reason>:<YYYY-MM-DD>'"
+        elif ! [[ "$ack_until" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+          ack_bad="acknowledgement review-by '$ack_until' is not YYYY-MM-DD"
+        elif ! ack_epoch="$(date -ud "$ack_until" +%s 2>/dev/null)"; then
+          ack_bad="acknowledgement review-by '$ack_until' is not a real date"
+        fi
+        ;;
+      *)
+        ack_bad="unknown entry '$ack_spec' (expected 'ack:<reason>:<YYYY-MM-DD>')"
+        ;;
+    esac
+  fi
+
+  # --- read and validate the three documents ---------------------------
   workflow_json="$(api_get workflow "$repo")"
   schedule_json="$(api_get schedule_runs "$repo")"
   completed_json="$(api_get completed_runs "$repo")"
 
-  state="$(jq -r '.state // empty' <<<"$workflow_json" 2>/dev/null || true)"
-  last_sched="$(jq -r '.workflow_runs[0].created_at // empty' \
-    <<<"$schedule_json" 2>/dev/null || true)"
-  last_sched_conclusion="$(jq -r '.workflow_runs[0].conclusion // empty' \
-    <<<"$schedule_json" 2>/dev/null || true)"
-  # Newest-first S/F sequence of decided runs, e.g. "FFFS": F extends a
-  # streak, S ends it, everything else (cancelled/skipped/neutral) is
-  # dropped so it can neither hide nor fake a failure streak.
-  seq="$(jq -r '[.workflow_runs[]? | .conclusion
-        | select(. == "success" or . == "failure"
-                 or . == "timed_out" or . == "startup_failure")
-        | if . == "success" then "S" else "F" end] | join("")' \
-    <<<"$completed_json" 2>/dev/null || true)"
-
   reasons=()
+  unreadable=0
+  doc_valid workflow "$workflow_json" || {
+    reasons+=("workflow document unreadable — $WORKFLOW_FILE missing, or the API returned no usable body")
+    unreadable=1
+  }
+  doc_valid schedule_runs "$schedule_json" || {
+    reasons+=("schedule-runs document unreadable — no usable workflow_runs array")
+    unreadable=1
+  }
+  doc_valid completed_runs "$completed_json" || {
+    reasons+=("completed-runs document unreadable — no usable workflow_runs array, so the failure streak is unknown")
+    unreadable=1
+  }
 
-  if [ -z "$state" ]; then
-    reasons+=("$WORKFLOW_FILE missing or API unreadable — treat as down until proven otherwise")
-    state="(unreadable)"
-  elif [ "$state" != "active" ]; then
-    reasons+=("workflow state is '$state' — the schedule is not running")
-  fi
-
+  state="(unreadable)"
+  last_sched=""
+  last_sched_conclusion=""
   age_display="-"
-  if [ -n "$last_sched" ]; then
-    run_epoch="$(date -ud "$last_sched" +%s 2>/dev/null || echo 0)"
-    if [ "$run_epoch" -gt 0 ]; then
-      age_hours=$(( (NOW_EPOCH - run_epoch) / 3600 ))
-      age_display="${age_hours}h"
-      if [ "$age_hours" -gt "$MAX_AGE_HOURS" ]; then
-        reasons+=("last schedule run was ${age_hours}h ago (limit ${MAX_AGE_HOURS}h)")
+  seq=""
+  hard=0
+  inconc=0
+
+  if [ "$unreadable" -eq 0 ]; then
+    state="$(jq -r '.state' <<<"$workflow_json")"
+    last_sched="$(jq -r '.workflow_runs[0].created_at // empty' \
+      <<<"$schedule_json")"
+    last_sched_conclusion="$(jq -r '.workflow_runs[0].conclusion // empty' \
+      <<<"$schedule_json")"
+    seq="$(jq -r '[.workflow_runs[]? | .conclusion
+          | if . == "success" then "S"
+            elif . == "failure" or . == "timed_out"
+                 or . == "startup_failure" then "F"
+            else "C" end] | join("")' <<<"$completed_json")"
+
+    if [ "$state" != "active" ]; then
+      reasons+=("workflow state is '$state' — the schedule is not running")
+    fi
+
+    if [ -n "$last_sched" ]; then
+      if run_epoch="$(date -ud "$last_sched" +%s 2>/dev/null)" &&
+         [ "$run_epoch" -gt 0 ]; then
+        age_hours=$(( (NOW_EPOCH - run_epoch) / 3600 ))
+        age_display="${age_hours}h"
+        if [ "$age_hours" -gt "$MAX_AGE_HOURS" ]; then
+          reasons+=("last schedule run was ${age_hours}h ago (limit ${MAX_AGE_HOURS}h)")
+        fi
+      else
+        reasons+=("unparseable schedule run timestamp: $last_sched")
+        unreadable=1
       fi
     else
-      reasons+=("unparseable schedule run timestamp: $last_sched")
+      reasons+=("no schedule-event run on record")
     fi
-  elif [ "$state" = "active" ] || [ "$state" = "(unreadable)" ]; then
-    reasons+=("no schedule-event run on record")
+
+    # Window = everything newer than the most recent success.
+    window="${seq%%S*}"
+    only_f="${window//[^F]/}"
+    only_c="${window//[^C]/}"
+    hard="${#only_f}"
+    inconc="${#only_c}"
+    if [ "$hard" -ge "$STREAK_LIMIT" ]; then
+      reasons+=("$hard hard failures since the last success (limit $STREAK_LIMIT)")
+    fi
+    if [ "$inconc" -ge "$STREAK_LIMIT" ]; then
+      reasons+=("$inconc inconclusive scheduled runs (cancelled/skipped) since the last success (limit $STREAK_LIMIT) — the cron fires but never finishes, so recency alone looks healthy")
+    elif [ "$hard" -lt "$STREAK_LIMIT" ] &&
+         [ "${#window}" -ge "$STREAK_LIMIT" ]; then
+      reasons+=("no successful scheduled run in the last ${#window} completed runs ($hard failed, $inconc inconclusive)")
+    fi
   fi
 
-  leading="${seq%%S*}"
-  streak="${#leading}"
-  if [ "$streak" -ge "$STREAK_LIMIT" ]; then
-    reasons+=("$streak consecutive failed runs (limit $STREAK_LIMIT)")
-  fi
-
-  if [ "${#reasons[@]}" -eq 0 ]; then
+  # --- verdict ----------------------------------------------------------
+  if [ -n "$ack_bad" ]; then
+    reasons+=("$ack_bad — refusing to suppress anything until it is fixed")
+    status="UNHEALTHY"
+  elif [ -n "$ack_reason" ] && [ "$NOW_EPOCH" -ge "$((ack_epoch + 86400))" ]; then
+    status="EXPIRED-ACK"
+    reasons+=("acknowledgement expired (review-by $ack_until): $ack_reason")
+    if [ "${#reasons[@]}" -eq 1 ]; then
+      reasons+=("no outstanding health problem — either renew the acknowledgement or drop it from the repos file")
+    fi
+  elif [ -n "$ack_reason" ]; then
+    status="ACKNOWLEDGED"
+    reasons+=("acknowledged until $ack_until: $ack_reason")
+  elif [ "$unreadable" -eq 1 ]; then
+    status="UNREADABLE"
+  elif [ "${#reasons[@]}" -eq 0 ]; then
     status="OK"
   else
     status="UNHEALTHY"
-    unhealthy=$((unhealthy + 1))
+  fi
+
+  # Counted from the raw documents, not the verdict: an acknowledged
+  # repo is still one the API could not answer for.
+  if [ "$unreadable" -eq 1 ]; then
+    unreadable_total=$((unreadable_total + 1))
+  fi
+
+  case "$status" in
+    OK) ;;
+    ACKNOWLEDGED)
+      acknowledged=$((acknowledged + 1)) ;;
+    *)
+      paging=$((paging + 1)) ;;
+  esac
+
+  if [ "$status" != "OK" ]; then
     joined=""
     for r in "${reasons[@]}"; do joined="$joined; $r"; done
     detail_lines="$detail_lines
-- **$repo** — ${joined#; }"
+- **$repo** ($status) — ${joined#; }"
+  fi
+  # Only paging statuses enter the signature. An acknowledged repo stays
+  # visible in the report but must not move the signature, or the very
+  # act of acknowledging it would open a tracking issue about it.
+  if [ "$status" != "OK" ] && [ "$status" != "ACKNOWLEDGED" ]; then
+    state_pairs="$state_pairs$repo=$status
+"
   fi
 
   table_rows="$table_rows
-| $repo | $status | $state | ${last_sched:-none} (${last_sched_conclusion:--}) | $age_display | ${seq:-none} | $streak |"
+| $repo | $status | $state | ${last_sched:-none} (${last_sched_conclusion:--}) | $age_display | ${seq:-none} | ${hard}F/${inconc}C |"
 done 3< "$REPOS_FILE"
 
 [ "$total" -gt 0 ] || { echo "repos file lists no repositories" >&2; exit 65; }
 
+# Order-independent one-line signature of everything that is not OK.
+# fleet_health_issue.sh compares it against the signature stored in the
+# tracking issue so the fleet is announced when it CHANGES, not once per
+# scheduled run.
+if [ -n "$state_pairs" ]; then
+  state_marker="$(printf '%s' "$state_pairs" | sort | tr '\n' ' ')"
+  state_marker="${state_marker% }"
+else
+  state_marker="healthy"
+fi
+
 report="## Fleet health — $(date -ud "@$NOW_EPOCH" '+%Y-%m-%d %H:%M UTC')
 
-Watching \`$WORKFLOW_FILE\` in $total repos under \`$ORG\`. Limits: schedule
-gap > ${MAX_AGE_HOURS}h, failure streak >= ${STREAK_LIMIT}. Recent runs are
-newest-first (S success, F failure).
+Watching \`$WORKFLOW_FILE\` in $total repos under \`$ORG\`, scheduled runs
+only. Limits: schedule gap > ${MAX_AGE_HOURS}h, ${STREAK_LIMIT}+ hard
+failures or inconclusive runs since the last success. Recent runs are
+newest-first (S success, F hard failure, C inconclusive); the last column
+counts both within the window since that success.
 
-| Repo | Status | Workflow state | Last schedule run | Age | Recent runs | Streak |
+| Repo | Status | Workflow state | Last schedule run | Age | Recent scheduled runs | Since success |
 |---|---|---|---|---|---|---|$table_rows
 "
-if [ "$unhealthy" -gt 0 ]; then
+if [ -n "$detail_lines" ]; then
+  # "0" is a non-empty string, so ${acknowledged:+...} would print
+  # ", 0 acknowledged" — spell the conditional out instead.
+  ack_note=""
+  if [ "$acknowledged" -gt 0 ]; then
+    ack_note=", $acknowledged acknowledged and deliberately silent"
+  fi
   report="$report
-### $unhealthy of $total repos unhealthy
+### $paging of $total repos paging$ack_note
 $detail_lines
 
 A quiet repo is not a flagged repo: runs that commit nothing count as
-healthy. Every line above is a schedule that is off, silent past the
-limit, or failing repeatedly."
+healthy. ACKNOWLEDGED lines are known-broken and deliberately silent
+until their review-by date; every other line is a schedule that is off,
+silent past the limit, failing, or unreadable."
 else
   report="$report
 All $total repos healthy."
 fi
+report="$report
+
+<!-- fleet-health-state: $state_marker -->"
 
 printf '%s\n' "$report"
-[ -n "$REPORT_FILE" ] && printf '%s\n' "$report" > "$REPORT_FILE"
-[ -n "${GITHUB_STEP_SUMMARY:-}" ] && printf '%s\n' "$report" >> "$GITHUB_STEP_SUMMARY"
+if [ -n "$REPORT_FILE" ]; then
+  printf '%s\n' "$report" > "$REPORT_FILE"
+fi
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  printf '%s\n' "$report" >> "$GITHUB_STEP_SUMMARY"
+fi
 
-[ "$unhealthy" -eq 0 ]
+# Every single repo unreadable is an outage of the monitor's own view,
+# not fifteen simultaneous deaths. Observed for real: an auth probe that
+# misfired sent a whole pass down the anonymous curl path, the 60/hour
+# budget ran out and the fleet "died" in one step. Exiting outside the
+# 0/1 health range makes the workflow fail as a monitor outage and skip
+# the tracking issue entirely, so a blackout cannot manufacture fifteen
+# pages and a bogus incident.
+if [ "$total" -gt 1 ] && [ "$unreadable_total" -eq "$total" ]; then
+  echo "monitor outage: all $total repos unreadable — treating as an API/auth" \
+       "failure, not a health verdict" >&2
+  exit 69
+fi
+
+[ "$paging" -eq 0 ]

--- a/scripts/fleet_health.sh
+++ b/scripts/fleet_health.sh
@@ -128,15 +128,47 @@ done
 # refused at startup rather than discovered in a quiet report. 100 is the
 # API's per_page ceiling, so a larger threshold cannot be judged from the
 # single page the streak query fetches.
-case "$STREAK_LIMIT" in
-  ''|*[!0-9]*)
-    echo "FLEET_HEALTH_STREAK must be a whole number: $STREAK_LIMIT" >&2
-    exit 64 ;;
-esac
-if [ "$STREAK_LIMIT" -lt 1 ] || [ "$STREAK_LIMIT" -gt 100 ]; then
-  echo "FLEET_HEALTH_STREAK must be between 1 and 100: $STREAK_LIMIT" >&2
-  exit 64
-fi
+#
+# The value is re-emitted in base 10 because bash reads a leading zero as
+# octal in $((…)) but not in [ … -lt … ]: FLEET_HEALTH_STREAK=012 would
+# size the query as 10 while every comparison read it as 12, restoring the
+# short page this check exists to prevent. 008 and 09 are not octal at all
+# and abort the script mid-run.
+# Called directly, never in $(…): a subshell's exit would only end the
+# subshell and let the script run on with an unvalidated threshold.
+check_whole_number() {
+  # name value min max
+  local digits
+  case "$2" in
+    ''|*[!0-9]*)
+      echo "$1 must be a whole number: $2" >&2
+      exit 64 ;;
+  esac
+  # Bash arithmetic wraps at 64 bits, so 18446744073709551617 evaluates to
+  # 1 and would pass the range check below as a valid threshold. Measure
+  # the digit count instead — with the leading zeros stripped first, so
+  # 0000012 counts as two digits and not seven — and refuse anything
+  # longer than the ceiling before it is ever evaluated.
+  digits=${2#"${2%%[!0]*}"}
+  [ -n "$digits" ] || digits=0
+  if [ "${#digits}" -gt "${#4}" ]; then
+    echo "$1 must be between $3 and $4: $2" >&2
+    exit 64
+  fi
+  if [ "$digits" -lt "$3" ] || [ "$digits" -gt "$4" ]; then
+    echo "$1 must be between $3 and $4: $2" >&2
+    exit 64
+  fi
+}
+
+# The staleness limit is checked too — not for the octal split (it is only
+# ever compared, never used in arithmetic) but because a non-numeric value
+# aborts the run mid-report instead of at startup. A ceiling of one year
+# keeps it from silently meaning "never stale".
+check_whole_number FLEET_HEALTH_STREAK "$STREAK_LIMIT" 1 100
+check_whole_number FLEET_HEALTH_MAX_AGE_HOURS "$MAX_AGE_HOURS" 1 8760
+STREAK_LIMIT=$((10#$STREAK_LIMIT))
+MAX_AGE_HOURS=$((10#$MAX_AGE_HOURS))
 
 # The streak window is every run before the most recent success, so a
 # page shorter than the threshold can never show a streak that long. Ask

--- a/scripts/fleet_health.sh
+++ b/scripts/fleet_health.sh
@@ -178,8 +178,20 @@ doc_valid() { # kind json
     workflow)
       jq -e 'type == "object" and (.state | type == "string")
              and (.state | length > 0)' >/dev/null 2>&1 <<<"$json" ;;
+    schedule_runs)
+      # Members must be objects with a usable created_at: a runs array
+      # holding null or a scalar would otherwise validate and read as
+      # "no scheduled run" -- which is the silent-death signal itself.
+      jq -e 'type == "object" and (.workflow_runs | type == "array")
+             and (.workflow_runs | all(type == "object"
+                   and (.created_at | type == "string")
+                   and (.created_at | length > 0)
+                   and ((.conclusion == null) or (.conclusion | type == "string"))))' \
+        >/dev/null 2>&1 <<<"$json" ;;
     *)
-      jq -e 'type == "object" and (.workflow_runs | type == "array")' \
+      jq -e 'type == "object" and (.workflow_runs | type == "array")
+             and (.workflow_runs | all(type == "object"
+                   and ((.conclusion == null) or (.conclusion | type == "string"))))' \
         >/dev/null 2>&1 <<<"$json" ;;
   esac
 }

--- a/scripts/fleet_health.sh
+++ b/scripts/fleet_health.sh
@@ -83,12 +83,15 @@
 #   FLEET_HEALTH_ORG            owner org (default ammitto)
 #   FLEET_HEALTH_WORKFLOW       workflow file name (default fetch.yml)
 #   FLEET_HEALTH_MAX_AGE_HOURS  staleness limit (default 48)
-#   FLEET_HEALTH_STREAK         failure/inconclusive limit (default 3)
+#   FLEET_HEALTH_STREAK         failure/inconclusive limit (default 3);
+#                               1-100, and the streak query asks for
+#                               enough runs to reach whatever is set
 #   FLEET_HEALTH_REPOS_FILE     repo list (default scripts/fleet_repos.txt)
 #   FLEET_HEALTH_FIXTURES       dir of fixture JSON; no network at all
 #   FLEET_HEALTH_NOW_EPOCH      freeze "now" for tests
 #   GH_TOKEN / GITHUB_TOKEN     optional; raises the API rate limit from
-#                               60/h to 1000/h. The fleet is public, so
+#                               60/h to 1000/h, on the gh path and the
+#                               curl path alike. The fleet is public, so
 #                               anonymous reads work (verified 2026-08-07)
 #                               but one 15-repo pass costs 45 of the 60.
 #
@@ -120,12 +123,36 @@ done
 
 [ -f "$REPOS_FILE" ] || { echo "repos file not found: $REPOS_FILE" >&2; exit 66; }
 
+# A threshold the streak query cannot reach would report every repo
+# healthy forever — the silent "OK" this monitor exists to kill. It is
+# refused at startup rather than discovered in a quiet report. 100 is the
+# API's per_page ceiling, so a larger threshold cannot be judged from the
+# single page the streak query fetches.
+case "$STREAK_LIMIT" in
+  ''|*[!0-9]*)
+    echo "FLEET_HEALTH_STREAK must be a whole number: $STREAK_LIMIT" >&2
+    exit 64 ;;
+esac
+if [ "$STREAK_LIMIT" -lt 1 ] || [ "$STREAK_LIMIT" -gt 100 ]; then
+  echo "FLEET_HEALTH_STREAK must be between 1 and 100: $STREAK_LIMIT" >&2
+  exit 64
+fi
+
+# The streak window is every run before the most recent success, so a
+# page shorter than the threshold can never show a streak that long. Ask
+# for one more than the threshold — the extra run is the success that
+# closes the window — and never fewer than the 10 this has always used.
+COMPLETED_PER_PAGE=$((STREAK_LIMIT + 1))
+if [ "$COMPLETED_PER_PAGE" -lt 10 ]; then COMPLETED_PER_PAGE=10; fi
+if [ "$COMPLETED_PER_PAGE" -gt 100 ]; then COMPLETED_PER_PAGE=100; fi
+
 # Fetch one API document. kind: workflow | schedule_runs | completed_runs.
 # Prints the JSON body, or nothing on any failure — the caller validates
 # the body and treats anything unexpected as UNREADABLE rather than
 # crashing, so one repo's outage cannot hide the other fourteen.
 api_get() {
-  local kind="$1" repo="$2" path base
+  local kind="$1" repo="$2" path base token
+  local -a auth
   if [ -n "$FIXTURES" ]; then
     cat "$FIXTURES/${repo}__${kind}.json" 2>/dev/null || true
     return 0
@@ -141,7 +168,7 @@ api_get() {
     # Streak: scheduled runs only. A red PR run must never page the
     # fleet, and a green push run must never clear a real streak.
     completed_runs)
-      path="$base/runs?event=schedule&status=completed&per_page=10" ;;
+      path="$base/runs?event=schedule&status=completed&per_page=$COMPLETED_PER_PAGE" ;;
     *)
       return 1 ;;
   esac
@@ -157,7 +184,19 @@ api_get() {
        gh auth status >/dev/null 2>&1; }; then
     gh api "$path" 2>/dev/null || true
   else
+    # Without gh, the token has to be presented by hand or it buys
+    # nothing and the pass runs on the anonymous 60/hour budget that one
+    # 45-call sweep nearly exhausts — which the environment notes above
+    # promise it does not. Built as an argument array so the token is
+    # never interpolated into a logged string, and left empty when no
+    # token is set so an anonymous read stays anonymous.
+    auth=()
+    token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+    if [ -n "$token" ]; then
+      auth=(-H "Authorization: Bearer $token")
+    fi
     curl -sS --max-time 30 -H 'Accept: application/vnd.github+json' \
+      ${auth[@]+"${auth[@]}"} \
       "https://api.github.com/$path" 2>/dev/null || true
   fi
 }

--- a/scripts/fleet_health.sh
+++ b/scripts/fleet_health.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Fleet health monitor for the ammitto/data-* fetch schedules.
+#
+# Six data-repo schedules once died silently (GitHub deactivates a cron
+# workflow after 60 days without repository activity) and nobody noticed
+# for ~3 months. This script reads each fleet repo's Actions state — all
+# reads, no writes — and flags:
+#
+#   DEAD    fetch.yml state is not "active" (disabled_inactively is
+#           exactly the silent death above; disabled_manually counts too).
+#   STALE   no schedule-event run of fetch.yml within the last
+#           FLEET_HEALTH_MAX_AGE_HOURS hours (default 48 — one missed
+#           daily run plus cron jitter). Catches deaths the state field
+#           misses: cron typo, renamed workflow file, archived repo.
+#   FAILING FLEET_HEALTH_STREAK (default 3) or more consecutive failed
+#           completed runs with no intervening success. failure,
+#           timed_out and startup_failure count as failures; cancelled,
+#           skipped and neutral neither extend nor break a streak.
+#   UNREADABLE fetch.yml missing or the API unreachable. Deliberately
+#           unhealthy: an unwatchable repo is not a healthy repo.
+#
+# A run that commits nothing is HEALTHY: only run conclusions are read,
+# never commit deltas, so zero-delta days (data-au has them legitimately)
+# are never flagged.
+#
+# Usage: scripts/fleet_health.sh [--report FILE]
+#   Prints a Markdown report (also appended to GITHUB_STEP_SUMMARY when
+#   set, and written to FILE with --report).
+#   Exit 0: every repo healthy. Exit 1: at least one repo flagged.
+#   Any other exit code is a bug in this script, not a health verdict.
+#
+# Environment:
+#   FLEET_HEALTH_ORG            owner org (default ammitto)
+#   FLEET_HEALTH_WORKFLOW       workflow file name (default fetch.yml)
+#   FLEET_HEALTH_MAX_AGE_HOURS  staleness limit (default 48)
+#   FLEET_HEALTH_STREAK         failure-streak limit (default 3)
+#   FLEET_HEALTH_REPOS_FILE     repo list (default scripts/fleet_repos.txt)
+#   FLEET_HEALTH_FIXTURES       dir of fixture JSON; no network at all
+#   FLEET_HEALTH_NOW_EPOCH      freeze "now" for tests
+#   GH_TOKEN / GITHUB_TOKEN     optional; raises the API rate limit from
+#                               60/h to 1000/h. The fleet is public, so
+#                               anonymous reads work (verified 2026-08-07)
+#                               but one 15-repo pass costs 45 of the 60.
+#
+# Needs bash, jq, GNU date, and gh or curl — all present on ubuntu runners.
+set -euo pipefail
+
+ORG="${FLEET_HEALTH_ORG:-ammitto}"
+WORKFLOW_FILE="${FLEET_HEALTH_WORKFLOW:-fetch.yml}"
+MAX_AGE_HOURS="${FLEET_HEALTH_MAX_AGE_HOURS:-48}"
+STREAK_LIMIT="${FLEET_HEALTH_STREAK:-3}"
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPOS_FILE="${FLEET_HEALTH_REPOS_FILE:-$SCRIPT_DIR/fleet_repos.txt}"
+FIXTURES="${FLEET_HEALTH_FIXTURES:-}"
+NOW_EPOCH="${FLEET_HEALTH_NOW_EPOCH:-$(date -u +%s)}"
+
+REPORT_FILE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --report)
+      REPORT_FILE="${2:?--report needs a file argument}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 64
+      ;;
+  esac
+done
+
+[ -f "$REPOS_FILE" ] || { echo "repos file not found: $REPOS_FILE" >&2; exit 66; }
+
+# Fetch one API document. kind: workflow | schedule_runs | completed_runs.
+# Prints the JSON body, or nothing on any failure — the caller treats an
+# empty/invalid body as UNREADABLE rather than crashing, so one repo's
+# outage cannot hide the state of the other fourteen.
+api_get() {
+  local kind="$1" repo="$2" path
+  if [ -n "$FIXTURES" ]; then
+    cat "$FIXTURES/${repo}__${kind}.json" 2>/dev/null || true
+    return 0
+  fi
+  case "$kind" in
+    workflow)
+      path="repos/$ORG/$repo/actions/workflows/$WORKFLOW_FILE" ;;
+    schedule_runs)
+      path="repos/$ORG/$repo/actions/workflows/$WORKFLOW_FILE/runs?event=schedule&per_page=1" ;;
+    completed_runs)
+      path="repos/$ORG/$repo/actions/workflows/$WORKFLOW_FILE/runs?status=completed&per_page=10" ;;
+    *)
+      return 1 ;;
+  esac
+  if command -v gh >/dev/null 2>&1 &&
+     { [ -n "${GH_TOKEN:-}" ] || [ -n "${GITHUB_TOKEN:-}" ] ||
+       gh auth token >/dev/null 2>&1; }; then
+    gh api "$path" 2>/dev/null || true
+  else
+    curl -sS --max-time 30 -H 'Accept: application/vnd.github+json' \
+      "https://api.github.com/$path" 2>/dev/null || true
+  fi
+}
+
+table_rows=""
+detail_lines=""
+unhealthy=0
+total=0
+
+# The loop reads the repos file on FD 3 so gh/curl inside the loop can
+# never swallow the remaining lines from stdin.
+while IFS= read -r repo <&3; do
+  repo="${repo%%#*}"
+  repo="$(printf '%s' "$repo" | tr -d '[:space:]')"
+  [ -n "$repo" ] || continue
+  total=$((total + 1))
+
+  workflow_json="$(api_get workflow "$repo")"
+  schedule_json="$(api_get schedule_runs "$repo")"
+  completed_json="$(api_get completed_runs "$repo")"
+
+  state="$(jq -r '.state // empty' <<<"$workflow_json" 2>/dev/null || true)"
+  last_sched="$(jq -r '.workflow_runs[0].created_at // empty' \
+    <<<"$schedule_json" 2>/dev/null || true)"
+  last_sched_conclusion="$(jq -r '.workflow_runs[0].conclusion // empty' \
+    <<<"$schedule_json" 2>/dev/null || true)"
+  # Newest-first S/F sequence of decided runs, e.g. "FFFS": F extends a
+  # streak, S ends it, everything else (cancelled/skipped/neutral) is
+  # dropped so it can neither hide nor fake a failure streak.
+  seq="$(jq -r '[.workflow_runs[]? | .conclusion
+        | select(. == "success" or . == "failure"
+                 or . == "timed_out" or . == "startup_failure")
+        | if . == "success" then "S" else "F" end] | join("")' \
+    <<<"$completed_json" 2>/dev/null || true)"
+
+  reasons=()
+
+  if [ -z "$state" ]; then
+    reasons+=("$WORKFLOW_FILE missing or API unreadable — treat as down until proven otherwise")
+    state="(unreadable)"
+  elif [ "$state" != "active" ]; then
+    reasons+=("workflow state is '$state' — the schedule is not running")
+  fi
+
+  age_display="-"
+  if [ -n "$last_sched" ]; then
+    run_epoch="$(date -ud "$last_sched" +%s 2>/dev/null || echo 0)"
+    if [ "$run_epoch" -gt 0 ]; then
+      age_hours=$(( (NOW_EPOCH - run_epoch) / 3600 ))
+      age_display="${age_hours}h"
+      if [ "$age_hours" -gt "$MAX_AGE_HOURS" ]; then
+        reasons+=("last schedule run was ${age_hours}h ago (limit ${MAX_AGE_HOURS}h)")
+      fi
+    else
+      reasons+=("unparseable schedule run timestamp: $last_sched")
+    fi
+  elif [ "$state" = "active" ] || [ "$state" = "(unreadable)" ]; then
+    reasons+=("no schedule-event run on record")
+  fi
+
+  leading="${seq%%S*}"
+  streak="${#leading}"
+  if [ "$streak" -ge "$STREAK_LIMIT" ]; then
+    reasons+=("$streak consecutive failed runs (limit $STREAK_LIMIT)")
+  fi
+
+  if [ "${#reasons[@]}" -eq 0 ]; then
+    status="OK"
+  else
+    status="UNHEALTHY"
+    unhealthy=$((unhealthy + 1))
+    joined=""
+    for r in "${reasons[@]}"; do joined="$joined; $r"; done
+    detail_lines="$detail_lines
+- **$repo** — ${joined#; }"
+  fi
+
+  table_rows="$table_rows
+| $repo | $status | $state | ${last_sched:-none} (${last_sched_conclusion:--}) | $age_display | ${seq:-none} | $streak |"
+done 3< "$REPOS_FILE"
+
+[ "$total" -gt 0 ] || { echo "repos file lists no repositories" >&2; exit 65; }
+
+report="## Fleet health — $(date -ud "@$NOW_EPOCH" '+%Y-%m-%d %H:%M UTC')
+
+Watching \`$WORKFLOW_FILE\` in $total repos under \`$ORG\`. Limits: schedule
+gap > ${MAX_AGE_HOURS}h, failure streak >= ${STREAK_LIMIT}. Recent runs are
+newest-first (S success, F failure).
+
+| Repo | Status | Workflow state | Last schedule run | Age | Recent runs | Streak |
+|---|---|---|---|---|---|---|$table_rows
+"
+if [ "$unhealthy" -gt 0 ]; then
+  report="$report
+### $unhealthy of $total repos unhealthy
+$detail_lines
+
+A quiet repo is not a flagged repo: runs that commit nothing count as
+healthy. Every line above is a schedule that is off, silent past the
+limit, or failing repeatedly."
+else
+  report="$report
+All $total repos healthy."
+fi
+
+printf '%s\n' "$report"
+[ -n "$REPORT_FILE" ] && printf '%s\n' "$report" > "$REPORT_FILE"
+[ -n "${GITHUB_STEP_SUMMARY:-}" ] && printf '%s\n' "$report" >> "$GITHUB_STEP_SUMMARY"
+
+[ "$unhealthy" -eq 0 ]

--- a/scripts/fleet_health_issue.sh
+++ b/scripts/fleet_health_issue.sh
@@ -1,14 +1,37 @@
 #!/usr/bin/env bash
-# Create-or-update the SINGLE fleet-health tracking issue.
+# Announce fleet-health STATE CHANGES on a single tracking issue.
 #
-# Called by .github/workflows/fleet-health.yml only when the fleet is
-# unhealthy. Idempotent by title: if an open issue with the exact title
-# already exists, the fresh report is added as a comment; otherwise one
-# issue is created. One alert channel, never fifteen, never a duplicate
-# per day.
+# Called by .github/workflows/fleet-health.yml on every run, healthy or
+# not. Idempotent by title: at most one open issue with the exact title
+# exists at a time. Pull requests share the issues listing and could
+# share the title, so anything carrying a pull_request key is ignored
+# when matching.
 #
-# Pull requests share the issues listing and could share the title, so
-# anything carrying a pull_request key is ignored when matching.
+# Only changes are announced
+# --------------------------
+# A daily job that comments every time the fleet is unhealthy trains
+# everyone to ignore it, and the thing this monitor exists to prevent is
+# exactly a signal nobody reads. So fleet_health.sh ends its report with
+#
+#   <!-- fleet-health-state: data-eu=UNHEALTHY data-ru=EXPIRED-ACK -->
+#
+# an order-independent signature of every PAGING repo (acknowledged
+# repos are deliberately absent — acknowledging a repo must not open an
+# issue about it). The same signature is stored in the tracking issue's
+# body, so this script can compare today against the last announcement
+# with no database, cache or artifact anywhere:
+#
+#   signature unchanged        -> say nothing, write nothing
+#   new or different problems  -> comment the report, restore the body
+#                                 to carry the new signature
+#   signature now "healthy"    -> comment the recovery and CLOSE the
+#                                 issue, because an open issue titled
+#                                 "schedules unhealthy" over a healthy
+#                                 fleet is the same kind of lie this
+#                                 monitor was built to kill
+#
+# An acknowledgement expiring changes the signature (nothing ->
+# repo=EXPIRED-ACK), so it announces itself through the same path.
 #
 # Guarded: outside GitHub Actions this script refuses to run unless
 # FLEET_HEALTH_ALLOW_ISSUE_WRITE=1, so a local invocation of the monitor
@@ -37,15 +60,64 @@ fi
   exit 64
 }
 
-existing="$(gh api "repos/$REPO/issues?state=open&per_page=100" |
+marker_of() { # file
+  sed -n 's/.*fleet-health-state:[[:space:]]*\(.*\)[[:space:]]*-->.*/\1/p' \
+    "$1" | tail -n 1 | sed 's/[[:space:]]*$//'
+}
+
+new_state="$(marker_of "$REPORT")"
+# No marker means the report did not come from this version of
+# fleet_health.sh. Refusing loudly beats guessing "healthy".
+[ -n "$new_state" ] || {
+  echo "no fleet-health-state marker in $REPORT — is it a fleet_health.sh report?" >&2
+  exit 65
+}
+
+open_json="$(gh api "repos/$REPO/issues?state=open&per_page=100")"
+existing="$(jq -r --arg t "$TITLE" \
+  '[.[] | select(has("pull_request") | not) | select(.title == $t)]
+   | .[0].number // empty' <<<"$open_json")"
+old_state=""
+if [ -n "$existing" ]; then
+  TMP_BODY="$(mktemp)"
+  trap 'rm -f "$TMP_BODY"' EXIT
   jq -r --arg t "$TITLE" \
     '[.[] | select(has("pull_request") | not) | select(.title == $t)]
-     | .[0].number // empty')"
-
-if [ -n "$existing" ]; then
-  gh issue comment "$existing" --repo "$REPO" --body-file "$REPORT"
-  echo "updated existing tracking issue #$existing"
-else
-  gh issue create --repo "$REPO" --title "$TITLE" --body-file "$REPORT"
-  echo "created new tracking issue"
+     | .[0].body // ""' <<<"$open_json" > "$TMP_BODY"
+  old_state="$(marker_of "$TMP_BODY")"
 fi
+
+# The unchanged check comes FIRST, before the healthy/unhealthy split.
+# Ordering it the other way makes a healthy fleet with an open issue
+# comment "recovered" and close it on every single run.
+if [ -z "$existing" ]; then
+  if [ "$new_state" = "healthy" ]; then
+    echo "fleet healthy, no open tracking issue — nothing to announce"
+    exit 0
+  fi
+  gh issue create --repo "$REPO" --title "$TITLE" --body-file "$REPORT"
+  echo "new tracking issue created for state: $new_state"
+  exit 0
+fi
+
+if [ "$old_state" = "$new_state" ]; then
+  echo "no state change since the last announcement ($new_state) — staying quiet"
+  exit 0
+fi
+
+if [ "$new_state" = "healthy" ]; then
+  RECOVERY="$(mktemp)"
+  trap 'rm -f "$TMP_BODY" "$RECOVERY"' EXIT
+  {
+    printf '%s\n\n' "Recovered — every watched schedule is healthy again. Closing; a new incident opens a fresh issue."
+    cat "$REPORT"
+  } > "$RECOVERY"
+  gh issue comment "$existing" --repo "$REPO" --body-file "$RECOVERY"
+  gh issue close "$existing" --repo "$REPO"
+  echo "fleet recovered — commented and closed tracking issue #$existing"
+  exit 0
+fi
+
+gh issue comment "$existing" --repo "$REPO" --body-file "$REPORT"
+gh issue edit "$existing" --repo "$REPO" --body-file "$REPORT"
+echo "state changed on #$existing: '${old_state:-none}' -> '$new_state'"

--- a/scripts/fleet_health_issue.sh
+++ b/scripts/fleet_health_issue.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Create-or-update the SINGLE fleet-health tracking issue.
+#
+# Called by .github/workflows/fleet-health.yml only when the fleet is
+# unhealthy. Idempotent by title: if an open issue with the exact title
+# already exists, the fresh report is added as a comment; otherwise one
+# issue is created. One alert channel, never fifteen, never a duplicate
+# per day.
+#
+# Pull requests share the issues listing and could share the title, so
+# anything carrying a pull_request key is ignored when matching.
+#
+# Guarded: outside GitHub Actions this script refuses to run unless
+# FLEET_HEALTH_ALLOW_ISSUE_WRITE=1, so a local invocation of the monitor
+# can never write to GitHub by accident.
+#
+# Usage: scripts/fleet_health_issue.sh <report.md>
+# Environment:
+#   FLEET_HEALTH_ISSUE_REPO   target repo (default $GITHUB_REPOSITORY)
+#   FLEET_HEALTH_ISSUE_TITLE  match/create title (default below)
+#   GH_TOKEN                  token with issues:write on the target repo
+set -euo pipefail
+
+REPORT="${1:?usage: fleet_health_issue.sh <report.md>}"
+[ -f "$REPORT" ] || { echo "report file not found: $REPORT" >&2; exit 66; }
+REPO="${FLEET_HEALTH_ISSUE_REPO:-${GITHUB_REPOSITORY:-}}"
+TITLE="${FLEET_HEALTH_ISSUE_TITLE:-Fleet health: data-repo fetch schedules unhealthy}"
+
+if [ "${GITHUB_ACTIONS:-}" != "true" ] &&
+   [ "${FLEET_HEALTH_ALLOW_ISSUE_WRITE:-}" != "1" ]; then
+  echo "refusing to write issues outside GitHub Actions" \
+       "(set FLEET_HEALTH_ALLOW_ISSUE_WRITE=1 to override)" >&2
+  exit 78
+fi
+[ -n "$REPO" ] || {
+  echo "no target repo: set GITHUB_REPOSITORY or FLEET_HEALTH_ISSUE_REPO" >&2
+  exit 64
+}
+
+existing="$(gh api "repos/$REPO/issues?state=open&per_page=100" |
+  jq -r --arg t "$TITLE" \
+    '[.[] | select(has("pull_request") | not) | select(.title == $t)]
+     | .[0].number // empty')"
+
+if [ -n "$existing" ]; then
+  gh issue comment "$existing" --repo "$REPO" --body-file "$REPORT"
+  echo "updated existing tracking issue #$existing"
+else
+  gh issue create --repo "$REPO" --title "$TITLE" --body-file "$REPORT"
+  echo "created new tracking issue"
+fi

--- a/scripts/fleet_health_test.sh
+++ b/scripts/fleet_health_test.sh
@@ -407,6 +407,129 @@ env -u GH_TOKEN -u GITHUB_TOKEN PATH="$TMP/bin2:$PATH" \
   && fail "fell through to anonymous curl: $(cat "$TMP/curl.log")" \
   || pass "did not fall through to anonymous curl"
 
+echo "== streak: the page must be large enough to reach the threshold =="
+# per_page was pinned at 10 while FLEET_HEALTH_STREAK is configurable, so
+# any threshold above 10 could never be reached: the streak stayed short
+# of the limit forever and a dead repo read healthy — the silent OK this
+# monitor exists to kill.
+: > "$TMP/paths12.txt"
+rc=0
+PATH="$TMP/bin:$PATH" GH_TOKEN=stub-token GH_PATHS="$TMP/paths12.txt" \
+  SCHED_TS="$(iso '3 hours ago')" FLEET_HEALTH_FIXTURES= \
+  FLEET_HEALTH_STREAK=12 FLEET_HEALTH_REPOS_FILE="$TMP/repos_q.txt" \
+  "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report_12q.md" > /dev/null || rc=$?
+grep -q 'status=completed&per_page=13' "$TMP/paths12.txt" \
+  && pass "threshold 12 asks the API for 13 completed runs" \
+  || fail "streak page ignored the threshold: $(grep -o 'per_page=[0-9]*' "$TMP/paths12.txt" | tr '\n' ' ')"
+grep -q 'status=completed&per_page=10' "$TMP/paths.txt" \
+  && pass "the default threshold still asks for 10" \
+  || fail "default page size changed: $(grep -o 'per_page=[0-9]*' "$TMP/paths.txt" | tr '\n' ' ')"
+
+# The fixture layer bypasses URL building, so this proves the other half:
+# with the runs in hand, a threshold above the old page size does reach a
+# verdict instead of sitting one short of it forever.
+printf 'data-streak12\n' > "$TMP/repos_12.txt"
+workflow_fixture data-streak12 active
+schedule_fixture data-streak12 '5 hours ago' failure
+completed_fixture data-streak12 failure failure failure failure failure \
+  failure failure failure failure failure failure failure
+rc=0
+FLEET_HEALTH_STREAK=12 FLEET_HEALTH_FIXTURES="$FIX" \
+  FLEET_HEALTH_REPOS_FILE="$TMP/repos_12.txt" \
+  "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report_12.md" > /dev/null || rc=$?
+expect_status data-streak12 UNHEALTHY "$TMP/report_12.md"
+expect_reason data-streak12 "12 hard failures since the last success" \
+  "$TMP/report_12.md"
+
+# ...and that it stays a threshold, not a hair trigger: eleven is below it.
+completed_fixture data-streak12 failure failure failure failure failure \
+  failure failure failure failure failure failure
+rc=0
+FLEET_HEALTH_STREAK=12 FLEET_HEALTH_FIXTURES="$FIX" \
+  FLEET_HEALTH_REPOS_FILE="$TMP/repos_12.txt" \
+  "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report_11.md" > /dev/null || rc=$?
+expect_status data-streak12 OK "$TMP/report_11.md"
+
+echo "== streak: a threshold the query cannot honour is refused =="
+# 100 is the API per_page ceiling. A larger threshold, or a non-numeric
+# one, is refused at startup rather than discovered as a quiet "OK".
+for bad in 0 101 abc -1; do
+  rc=0
+  FLEET_HEALTH_STREAK="$bad" FLEET_HEALTH_FIXTURES="$FIX" \
+    FLEET_HEALTH_REPOS_FILE="$TMP/repos_12.txt" \
+    "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report_bad.md" \
+    > /dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 64 ] && pass "refuses FLEET_HEALTH_STREAK=$bad (exit 64)" \
+    || fail "FLEET_HEALTH_STREAK=$bad exited $rc, wanted 64"
+done
+rc=0
+FLEET_HEALTH_STREAK=100 FLEET_HEALTH_FIXTURES="$FIX" \
+  FLEET_HEALTH_REPOS_FILE="$TMP/repos_12.txt" \
+  "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report_100.md" > /dev/null || rc=$?
+[ "$rc" -ne 64 ] && pass "accepts the largest honourable threshold (100)" \
+  || fail "threshold 100 was refused"
+
+echo "== curl fallback presents the token the environment notes promise =="
+# Without gh the token was dropped, so a tokened run quietly spent the
+# anonymous 60/hour budget that one 45-call sweep nearly exhausts. gh is
+# kept off PATH entirely here: with a token set the gh branch would win
+# and the curl path would never be reached.
+mkdir -p "$TMP/bin3"
+for b in bash cat date dirname jq sort tr; do
+  ln -sf "$(command -v "$b")" "$TMP/bin3/$b"
+done
+cat > "$TMP/bin3/curl" <<'STUB'
+#!/usr/bin/env bash
+# One argument per line so an assertion can match a header exactly.
+{ for a in "$@"; do echo "$a"; done; } >> "$CURL_LOG"
+case "$*" in
+  *status=completed*) printf '{"workflow_runs":[{"conclusion":"success"}]}' ;;
+  *event=schedule*) printf '{"workflow_runs":[{"created_at":"%s","conclusion":"success"}]}' "$SCHED_TS" ;;
+  *) printf '{"path":".github/workflows/fetch.yml","state":"active"}' ;;
+esac
+STUB
+chmod +x "$TMP/bin3/curl"
+
+: > "$TMP/curl_tok.log"
+rc=0
+env PATH="$TMP/bin3" GH_TOKEN=stub-token CURL_LOG="$TMP/curl_tok.log" \
+  SCHED_TS="$(iso '3 hours ago')" FLEET_HEALTH_FIXTURES= \
+  FLEET_HEALTH_REPOS_FILE="$TMP/repos_q.txt" \
+  "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report_curl.md" > /dev/null || rc=$?
+[ "$rc" -eq 0 ] && pass "the curl path produces a verdict" \
+  || fail "curl path exit was $rc"
+grep -qx 'Authorization: Bearer stub-token' "$TMP/curl_tok.log" \
+  && pass "curl sends Authorization when a token is set" \
+  || fail "curl sent no Authorization header"
+grep -q 'stub-token' "$TMP/report_curl.md" \
+  && fail "the report leaked the token" \
+  || pass "the token stays out of the report"
+
+# GITHUB_TOKEN is the workflow's spelling; it must work the same.
+: > "$TMP/curl_gt.log"
+rc=0
+env -u GH_TOKEN PATH="$TMP/bin3" GITHUB_TOKEN=stub-gt \
+  CURL_LOG="$TMP/curl_gt.log" SCHED_TS="$(iso '3 hours ago')" \
+  FLEET_HEALTH_FIXTURES= FLEET_HEALTH_REPOS_FILE="$TMP/repos_q.txt" \
+  "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report_curl_gt.md" > /dev/null || rc=$?
+grep -qx 'Authorization: Bearer stub-gt' "$TMP/curl_gt.log" \
+  && pass "GITHUB_TOKEN reaches curl too" \
+  || fail "GITHUB_TOKEN was dropped on the curl path"
+
+# No token must stay anonymous — an empty header would be a 401, which is
+# worse than the anonymous read the fleet's public repos allow.
+: > "$TMP/curl_anon.log"
+rc=0
+env -u GH_TOKEN -u GITHUB_TOKEN PATH="$TMP/bin3" \
+  CURL_LOG="$TMP/curl_anon.log" SCHED_TS="$(iso '3 hours ago')" \
+  FLEET_HEALTH_FIXTURES= FLEET_HEALTH_REPOS_FILE="$TMP/repos_q.txt" \
+  "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report_anon.md" > /dev/null || rc=$?
+[ -s "$TMP/curl_anon.log" ] && pass "an untokened run still reaches curl" \
+  || fail "curl was never called"
+grep -q 'Authorization' "$TMP/curl_anon.log" \
+  && fail "an untokened run sent an Authorization header" \
+  || pass "no token, no Authorization header"
+
 echo "== issue: announces state changes, and only state changes =="
 # gh stub: logs every invocation; "gh api" answers with a canned issue
 # list so the title match runs against realistic JSON.

--- a/scripts/fleet_health_test.sh
+++ b/scripts/fleet_health_test.sh
@@ -469,6 +469,79 @@ FLEET_HEALTH_STREAK=100 FLEET_HEALTH_FIXTURES="$FIX" \
 [ "$rc" -ne 64 ] && pass "accepts the largest honourable threshold (100)" \
   || fail "threshold 100 was refused"
 
+echo "== streak: a leading zero means the same number everywhere =="
+# bash reads a leading zero as octal inside $((…)) but as decimal in
+# [ … -lt … ]. Unnormalised, FLEET_HEALTH_STREAK=012 sized the page as 10
+# while every comparison read 12 — a page one short of the threshold, the
+# exact silent OK the block above exists to kill. 008 and 09 are not octal
+# at all and aborted the run with an arithmetic error instead of exit 64.
+: > "$TMP/paths012.txt"
+rc=0
+PATH="$TMP/bin:$PATH" GH_TOKEN=stub-token GH_PATHS="$TMP/paths012.txt" \
+  SCHED_TS="$(iso '3 hours ago')" FLEET_HEALTH_FIXTURES= \
+  FLEET_HEALTH_STREAK=012 FLEET_HEALTH_REPOS_FILE="$TMP/repos_q.txt" \
+  "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report_012.md" > /dev/null || rc=$?
+grep -q 'status=completed&per_page=13' "$TMP/paths012.txt" \
+  && pass "threshold 012 asks for 13, the same as 12" \
+  || fail "012 was read as octal: $(grep -o 'per_page=[0-9]*' "$TMP/paths012.txt" | tr '\n' ' ')"
+
+# A padded threshold must be indistinguishable from its plain spelling —
+# same exit code, same verdict — not merely "does not crash", since the
+# fleet's own unhealthy exit code is easy to mistake for survival.
+for pair in 008:8 09:9 0100:100; do
+  zeroed=${pair%:*}; plain=${pair#*:}
+  rc_z=0; rc_p=0
+  FLEET_HEALTH_STREAK="$zeroed" FLEET_HEALTH_FIXTURES="$FIX" \
+    FLEET_HEALTH_REPOS_FILE="$TMP/repos_12.txt" \
+    "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report_z.md" \
+    > /dev/null 2>&1 || rc_z=$?
+  FLEET_HEALTH_STREAK="$plain" FLEET_HEALTH_FIXTURES="$FIX" \
+    FLEET_HEALTH_REPOS_FILE="$TMP/repos_12.txt" \
+    "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report_p.md" \
+    > /dev/null 2>&1 || rc_p=$?
+  if [ "$rc_z" = "$rc_p" ] && diff -q "$TMP/report_z.md" "$TMP/report_p.md" \
+       > /dev/null 2>&1; then
+    pass "FLEET_HEALTH_STREAK=$zeroed behaves exactly like $plain (exit $rc_p)"
+  else
+    fail "$zeroed exited $rc_z and $plain exited $rc_p, reports differ"
+  fi
+done
+
+# Bash arithmetic wraps at 64 bits: 2^64+1 evaluates to 1, which is a
+# perfectly valid threshold, so a range check performed after evaluation
+# waves it through and the monitor silently runs at a threshold nobody
+# configured.
+for huge in 18446744073709551617 99999999999999999999999; do
+  rc=0
+  FLEET_HEALTH_STREAK="$huge" FLEET_HEALTH_FIXTURES="$FIX" \
+    FLEET_HEALTH_REPOS_FILE="$TMP/repos_12.txt" \
+    "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report_huge.md" \
+    > /dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 64 ] && pass "refuses FLEET_HEALTH_STREAK=$huge (exit 64)" \
+    || fail "FLEET_HEALTH_STREAK=$huge exited $rc, wanted 64 — it wrapped"
+done
+
+echo "== the staleness limit is validated at startup too =="
+# MAX_AGE_HOURS is only ever compared, never used in arithmetic, so octal
+# cannot bite it — but an unvalidated non-numeric value used to abort the
+# sweep partway through the fleet instead of refusing at startup.
+for bad in abc 0 ''; do
+  rc=0
+  FLEET_HEALTH_MAX_AGE_HOURS="$bad" FLEET_HEALTH_FIXTURES="$FIX" \
+    FLEET_HEALTH_REPOS_FILE="$TMP/repos_12.txt" \
+    "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report_age.md" \
+    > /dev/null 2>&1 || rc=$?
+  if [ -z "$bad" ]; then
+    # An empty value is the shell's own "use the default" spelling, and
+    # the default is the strict end of the range — it must not be refused.
+    [ "$rc" -ne 64 ] && pass "an empty staleness limit falls back to the default" \
+      || fail "empty FLEET_HEALTH_MAX_AGE_HOURS was refused"
+  else
+    [ "$rc" -eq 64 ] && pass "refuses FLEET_HEALTH_MAX_AGE_HOURS=$bad (exit 64)" \
+      || fail "FLEET_HEALTH_MAX_AGE_HOURS=$bad exited $rc, wanted 64"
+  fi
+done
+
 echo "== curl fallback presents the token the environment notes promise =="
 # Without gh the token was dropped, so a tokened run quietly spent the
 # anonymous 60/hour budget that one 45-call sweep nearly exhausts. gh is

--- a/scripts/fleet_health_test.sh
+++ b/scripts/fleet_health_test.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Offline proof of the fleet-health monitor. No network, no writes.
+#
+# Generates synthetic API fixtures for the failure modes the monitor
+# exists to catch, runs the real detection script against them, and
+# asserts the verdicts. Also proves the tracking-issue upsert is
+# idempotent using a stubbed gh. The fleet-health workflow runs this
+# before every live check: a monitor whose own parser silently broke
+# would otherwise report "healthy" forever — the exact failure mode
+# this whole feature exists to kill.
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+FIX="$TMP/fixtures"
+mkdir -p "$FIX" "$TMP/bin"
+
+failures=0
+fail() { echo "FAIL: $*"; failures=$((failures + 1)); }
+pass() { echo "ok: $*"; }
+
+iso() { date -ud "$1" '+%Y-%m-%dT%H:%M:%SZ'; }
+
+workflow_fixture() { # repo state
+  printf '{"path":".github/workflows/fetch.yml","state":"%s"}' "$2" \
+    > "$FIX/$1__workflow.json"
+}
+schedule_fixture() { # repo age conclusion
+  printf '{"workflow_runs":[{"created_at":"%s","conclusion":"%s"}]}' \
+    "$(iso "$2")" "$3" > "$FIX/$1__schedule_runs.json"
+}
+completed_fixture() { # repo conclusion...
+  local repo="$1" runs="" c
+  shift
+  for c in "$@"; do
+    runs="$runs{\"conclusion\":\"$c\"},"
+  done
+  printf '{"workflow_runs":[%s]}' "${runs%,}" \
+    > "$FIX/${repo}__completed_runs.json"
+}
+
+# Case 1 — dead schedule: GitHub deactivated it 60 days after the last
+# repo activity; the state field says so and the last run is ancient.
+# This is the death the six repos died.
+workflow_fixture data-dead disabled_inactively
+schedule_fixture data-dead '70 days ago' success
+completed_fixture data-dead success success success
+
+# Case 1b — dead but lying state: workflow reads "active" yet the cron
+# has not produced a run in 3 days (cron typo, renamed file, actor
+# suspended). The recency check must catch what the state check misses.
+workflow_fixture data-stale active
+schedule_fixture data-stale '72 hours ago' success
+completed_fixture data-stale success success success
+
+# Case 2 — failure streak: schedule alive and recent, but the last three
+# completed runs all failed. A cancelled run in between must not break
+# the streak.
+workflow_fixture data-failing active
+schedule_fixture data-failing '5 hours ago' failure
+completed_fixture data-failing failure failure cancelled failure success success
+
+# Case 3 — healthy but quiet: ran on schedule this morning, succeeded,
+# committed nothing (invisible to run conclusions, which is the point).
+# Must NOT be flagged. data-au has legitimate zero-delta days.
+workflow_fixture data-quiet active
+schedule_fixture data-quiet '6 hours ago' success
+completed_fixture data-quiet success success success
+
+# Boundary — two consecutive failures is below the streak limit and the
+# schedule is alive: not flagged.
+workflow_fixture data-two-fails active
+schedule_fixture data-two-fails '4 hours ago' failure
+completed_fixture data-two-fails failure failure success success
+
+# Unreadable — no fixtures at all for data-ghost: missing workflow or
+# dead API must flag, not pass silently.
+
+repos_all="$TMP/repos_all.txt"
+printf '%s\n' data-dead data-stale data-failing data-quiet \
+  data-two-fails data-ghost > "$repos_all"
+repos_healthy="$TMP/repos_healthy.txt"
+printf '%s\n' data-quiet data-two-fails > "$repos_healthy"
+
+echo "== detection: mixed fleet must exit 1 with exact verdicts =="
+rc=0
+FLEET_HEALTH_FIXTURES="$FIX" FLEET_HEALTH_REPOS_FILE="$repos_all" \
+  "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report.md" \
+  > /dev/null || rc=$?
+[ "$rc" -eq 1 ] && pass "mixed fleet exits 1" || fail "mixed fleet exit was $rc"
+
+expect_unhealthy() {
+  if grep -E "^\| $1 \| UNHEALTHY " "$TMP/report.md" > /dev/null; then
+    pass "$1 flagged"
+  else
+    fail "$1 not flagged"
+  fi
+}
+expect_healthy() {
+  if grep -E "^\| $1 \| OK " "$TMP/report.md" > /dev/null; then
+    pass "$1 healthy"
+  else
+    fail "$1 wrongly flagged"
+  fi
+}
+expect_reason() {
+  if grep -F "**$1**" "$TMP/report.md" | grep -qF "$2"; then
+    pass "$1 reason mentions: $2"
+  else
+    fail "$1 reason missing: $2"
+  fi
+}
+
+expect_unhealthy data-dead
+expect_reason data-dead "disabled_inactively"
+expect_unhealthy data-stale
+expect_reason data-stale "72h ago (limit 48h)"
+expect_unhealthy data-failing
+expect_reason data-failing "3 consecutive failed runs"
+expect_unhealthy data-ghost
+expect_reason data-ghost "missing or API unreadable"
+expect_healthy data-quiet
+expect_healthy data-two-fails
+grep -qE '4 of 6 repos unhealthy' "$TMP/report.md" \
+  && pass "summary counts 4 of 6" || fail "summary count wrong"
+
+echo "== detection: all-healthy fleet must exit 0 =="
+rc=0
+FLEET_HEALTH_FIXTURES="$FIX" FLEET_HEALTH_REPOS_FILE="$repos_healthy" \
+  "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report_ok.md" \
+  > /dev/null || rc=$?
+[ "$rc" -eq 0 ] && pass "healthy fleet exits 0" || fail "healthy exit was $rc"
+grep -q 'All 2 repos healthy' "$TMP/report_ok.md" \
+  && pass "healthy summary present" || fail "healthy summary missing"
+
+echo "== issue upsert: create once, then comment, never duplicate =="
+# gh stub: logs every invocation; "gh api" answers with a canned issue
+# list so the title match runs against realistic JSON.
+cat > "$TMP/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+echo "gh $*" >> "$GH_LOG"
+case "$1" in
+  api) cat "$GH_ISSUES_JSON" ;;
+esac
+STUB
+chmod +x "$TMP/bin/gh"
+
+title='Fleet health: data-repo fetch schedules unhealthy'
+echo '[]' > "$TMP/issues_none.json"
+# The open list holds a PR with the exact title (must be ignored) and
+# the real issue #42 (must be matched).
+printf '[{"number":7,"title":"%s","pull_request":{}},{"number":42,"title":"%s"}]' \
+  "$title" "$title" > "$TMP/issues_open.json"
+
+run_upsert() { # issues-json log-file
+  PATH="$TMP/bin:$PATH" GH_LOG="$2" GH_ISSUES_JSON="$1" \
+    FLEET_HEALTH_ALLOW_ISSUE_WRITE=1 \
+    FLEET_HEALTH_ISSUE_REPO=ammitto/ammitto \
+    "$SCRIPT_DIR/fleet_health_issue.sh" "$TMP/report.md" > /dev/null
+}
+
+: > "$TMP/log1"; run_upsert "$TMP/issues_none.json" "$TMP/log1"
+grep -q '^gh issue create ' "$TMP/log1" \
+  && pass "no open issue -> creates" || fail "create path broken"
+grep -q '^gh issue comment ' "$TMP/log1" \
+  && fail "created AND commented" || pass "create path does not comment"
+
+: > "$TMP/log2"; run_upsert "$TMP/issues_open.json" "$TMP/log2"
+grep -q '^gh issue comment 42 ' "$TMP/log2" \
+  && pass "open issue #42 -> comments (PR with same title ignored)" \
+  || fail "comment path broken"
+grep -q '^gh issue create ' "$TMP/log2" \
+  && fail "duplicate issue created" || pass "comment path does not create"
+
+echo "== issue upsert: refuses to write outside Actions =="
+rc=0
+: > "$TMP/log3"
+PATH="$TMP/bin:$PATH" GH_LOG="$TMP/log3" GH_ISSUES_JSON="$TMP/issues_none.json" \
+  GITHUB_ACTIONS= FLEET_HEALTH_ALLOW_ISSUE_WRITE= \
+  FLEET_HEALTH_ISSUE_REPO=ammitto/ammitto \
+  "$SCRIPT_DIR/fleet_health_issue.sh" "$TMP/report.md" \
+  > /dev/null 2>&1 || rc=$?
+[ "$rc" -eq 78 ] && pass "guard refuses (exit 78)" || fail "guard exit was $rc"
+[ -s "$TMP/log3" ] && fail "guard still called gh" || pass "guard called no gh"
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "fleet_health_test: all checks passed"
+else
+  echo "fleet_health_test: $failures check(s) FAILED"
+  exit 1
+fi

--- a/scripts/fleet_health_test.sh
+++ b/scripts/fleet_health_test.sh
@@ -133,6 +133,19 @@ printf '{"message":"Not Found","documentation_url":"https://docs.github.com"}' \
 healthy_fixture data-truncated
 printf '{"workflow_runs":[{"conclu' > "$FIX/data-truncated__completed_runs.json"
 
+# A runs array whose MEMBERS are unusable: validating only the array type
+# let {"workflow_runs":[null]} read as "no scheduled run" -- indistinguishable
+# from the silent death this monitor exists to catch.
+healthy_fixture data-nullmember
+printf '{"workflow_runs":[null]}' > "$FIX/data-nullmember__schedule_runs.json"
+
+healthy_fixture data-scalarmember
+printf '{"workflow_runs":["oops"]}' > "$FIX/data-scalarmember__completed_runs.json"
+
+healthy_fixture data-blankdate
+printf '{"workflow_runs":[{"created_at":"","conclusion":"success"}]}' \
+  > "$FIX/data-blankdate__schedule_runs.json"
+
 # An empty body is the trap that looks safest: `jq -e` exits 0 on empty
 # input, so an unguarded validator would wave this through as healthy.
 healthy_fixture data-empty
@@ -141,7 +154,8 @@ healthy_fixture data-empty
 repos_all="$TMP/repos_all.txt"
 printf '%s\n' data-dead data-stale data-failing data-quiet data-two-fails \
   data-cancelled data-mixed data-ghost data-badwf data-badsched \
-  data-badcompleted data-truncated data-empty > "$repos_all"
+  data-badcompleted data-truncated data-empty \
+  data-nullmember data-scalarmember data-blankdate > "$repos_all"
 repos_healthy="$TMP/repos_healthy.txt"
 printf '%s\n' data-quiet data-two-fails > "$repos_healthy"
 
@@ -197,6 +211,12 @@ expect_status data-badsched UNREADABLE
 expect_reason data-badsched "schedule-runs document unreadable"
 expect_status data-badcompleted UNREADABLE
 expect_reason data-badcompleted "completed-runs document unreadable"
+expect_status data-nullmember UNREADABLE
+expect_reason data-nullmember "schedule-runs document unreadable"
+expect_status data-scalarmember UNREADABLE
+expect_reason data-scalarmember "completed-runs document unreadable"
+expect_status data-blankdate UNREADABLE
+expect_reason data-blankdate "schedule-runs document unreadable"
 expect_status data-truncated UNREADABLE
 expect_status data-empty UNREADABLE
 for r in data-badwf data-badsched data-badcompleted data-truncated data-empty; do

--- a/scripts/fleet_health_test.sh
+++ b/scripts/fleet_health_test.sh
@@ -3,11 +3,13 @@
 #
 # Generates synthetic API fixtures for the failure modes the monitor
 # exists to catch, runs the real detection script against them, and
-# asserts the verdicts. Also proves the tracking-issue upsert is
-# idempotent using a stubbed gh. The fleet-health workflow runs this
-# before every live check: a monitor whose own parser silently broke
-# would otherwise report "healthy" forever — the exact failure mode
-# this whole feature exists to kill.
+# asserts the verdicts. Also drives the real query builder through a
+# stubbed gh (to prove only scheduled runs are counted) and the real
+# issue script through a stubbed gh (to prove it writes on state changes
+# and stays silent otherwise). The fleet-health workflow runs this before
+# every live check: a monitor whose own parser silently broke would
+# otherwise report "healthy" forever — the exact failure mode this whole
+# feature exists to kill.
 set -euo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
@@ -39,6 +41,27 @@ completed_fixture() { # repo conclusion...
   printf '{"workflow_runs":[%s]}' "${runs%,}" \
     > "$FIX/${repo}__completed_runs.json"
 }
+healthy_fixture() { # repo — alive, recent, three clean runs
+  workflow_fixture "$1" active
+  schedule_fixture "$1" '5 hours ago' success
+  completed_fixture "$1" success success success
+}
+# The acknowledgement tests freeze the clock weeks away from real "now",
+# where a fixture written as "5 hours ago" would read as badly stale.
+# These anchor the last run five hours before the frozen instant instead.
+healthy_fixture_at() { # repo frozen-now-epoch
+  workflow_fixture "$1" active
+  printf '{"workflow_runs":[{"created_at":"%s","conclusion":"success"}]}' \
+    "$(date -ud "@$(( $2 - 18000 ))" '+%Y-%m-%dT%H:%M:%SZ')" \
+    > "$FIX/$1__schedule_runs.json"
+  completed_fixture "$1" success success success
+}
+
+# Frozen instants for the acknowledgement tests, against a review-by of
+# 2026-09-07. Verified with `date -ud <stamp> +%s`.
+NOW_BEFORE=1786536000   # 2026-08-12 12:00 UTC — well before review-by
+NOW_ONDAY=1788782400    # 2026-09-07 12:00 UTC — the review-by day itself
+NOW_AFTER=1788868800    # 2026-09-08 12:00 UTC — the day after
 
 # Case 1 — dead schedule: GitHub deactivated it 60 days after the last
 # repo activity; the state field says so and the last run is ancient.
@@ -54,9 +77,9 @@ workflow_fixture data-stale active
 schedule_fixture data-stale '72 hours ago' success
 completed_fixture data-stale success success success
 
-# Case 2 — failure streak: schedule alive and recent, but the last three
-# completed runs all failed. A cancelled run in between must not break
-# the streak.
+# Case 2 — failure streak: schedule alive and recent, but three hard
+# failures since the last success. A cancelled run in between must not
+# reset the count.
 workflow_fixture data-failing active
 schedule_fixture data-failing '5 hours ago' failure
 completed_fixture data-failing failure failure cancelled failure success success
@@ -68,73 +91,303 @@ workflow_fixture data-quiet active
 schedule_fixture data-quiet '6 hours ago' success
 completed_fixture data-quiet success success success
 
-# Boundary — two consecutive failures is below the streak limit and the
-# schedule is alive: not flagged.
+# Boundary — two hard failures is below the limit and the schedule is
+# alive: not flagged.
 workflow_fixture data-two-fails active
 schedule_fixture data-two-fails '4 hours ago' failure
 completed_fixture data-two-fails failure failure success success
 
+# Case 4 — cancelled forever: the cron fires daily and every run is
+# cancelled. Recency looks perfect and there is not one failure, so the
+# old "drop everything that is not success/failure" model called this
+# healthy. A schedule that never finishes is not a working schedule.
+workflow_fixture data-cancelled active
+schedule_fixture data-cancelled '3 hours ago' cancelled
+completed_fixture data-cancelled cancelled cancelled cancelled success
+
+# Case 4b — mixed outcomes: two failures and two cancellations since the
+# last success. Neither counter alone reaches the limit of 3, but four
+# scheduled runs have gone by without a success.
+workflow_fixture data-mixed active
+schedule_fixture data-mixed '3 hours ago' failure
+completed_fixture data-mixed failure cancelled failure cancelled success
+
 # Unreadable — no fixtures at all for data-ghost: missing workflow or
 # dead API must flag, not pass silently.
 
+# Case 5 — each API document must validate on its own. Every repo below
+# is perfectly healthy except for ONE unusable document. Before the
+# monitor validated all three, an unreadable runs document produced an
+# empty sequence, a zero streak and a confident "OK".
+healthy_fixture data-badwf
+printf '{"message":"Not Found","documentation_url":"https://docs.github.com"}' \
+  > "$FIX/data-badwf__workflow.json"
+
+healthy_fixture data-badsched
+printf '{"message":"Server Error"}' > "$FIX/data-badsched__schedule_runs.json"
+
+healthy_fixture data-badcompleted
+printf '{"message":"Not Found","documentation_url":"https://docs.github.com"}' \
+  > "$FIX/data-badcompleted__completed_runs.json"
+
+healthy_fixture data-truncated
+printf '{"workflow_runs":[{"conclu' > "$FIX/data-truncated__completed_runs.json"
+
+# An empty body is the trap that looks safest: `jq -e` exits 0 on empty
+# input, so an unguarded validator would wave this through as healthy.
+healthy_fixture data-empty
+: > "$FIX/data-empty__completed_runs.json"
+
 repos_all="$TMP/repos_all.txt"
-printf '%s\n' data-dead data-stale data-failing data-quiet \
-  data-two-fails data-ghost > "$repos_all"
+printf '%s\n' data-dead data-stale data-failing data-quiet data-two-fails \
+  data-cancelled data-mixed data-ghost data-badwf data-badsched \
+  data-badcompleted data-truncated data-empty > "$repos_all"
 repos_healthy="$TMP/repos_healthy.txt"
 printf '%s\n' data-quiet data-two-fails > "$repos_healthy"
 
+run_health() { # repos-file report-file [env assignments...]
+  local repos="$1" report="$2"
+  shift 2
+  local rc=0
+  env "$@" FLEET_HEALTH_FIXTURES="$FIX" FLEET_HEALTH_REPOS_FILE="$repos" \
+    "$SCRIPT_DIR/fleet_health.sh" --report "$report" > /dev/null || rc=$?
+  echo "$rc"
+}
+
 echo "== detection: mixed fleet must exit 1 with exact verdicts =="
-rc=0
-FLEET_HEALTH_FIXTURES="$FIX" FLEET_HEALTH_REPOS_FILE="$repos_all" \
-  "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report.md" \
-  > /dev/null || rc=$?
+rc=$(run_health "$repos_all" "$TMP/report.md")
 [ "$rc" -eq 1 ] && pass "mixed fleet exits 1" || fail "mixed fleet exit was $rc"
 
-expect_unhealthy() {
-  if grep -E "^\| $1 \| UNHEALTHY " "$TMP/report.md" > /dev/null; then
-    pass "$1 flagged"
+expect_status() { # repo status [report]
+  local report="${3:-$TMP/report.md}"
+  if grep -E "^\| $1 \| $2 " "$report" > /dev/null; then
+    pass "$1 is $2"
   else
-    fail "$1 not flagged"
+    fail "$1 is not $2: $(grep -E "^\| $1 \|" "$report" || echo 'no row')"
   fi
 }
-expect_healthy() {
-  if grep -E "^\| $1 \| OK " "$TMP/report.md" > /dev/null; then
-    pass "$1 healthy"
-  else
-    fail "$1 wrongly flagged"
-  fi
-}
-expect_reason() {
-  if grep -F "**$1**" "$TMP/report.md" | grep -qF "$2"; then
+expect_reason() { # repo substring [report]
+  if grep -F "**$1**" "${3:-$TMP/report.md}" | grep -qF "$2"; then
     pass "$1 reason mentions: $2"
   else
     fail "$1 reason missing: $2"
   fi
 }
 
-expect_unhealthy data-dead
+expect_status data-dead UNHEALTHY
 expect_reason data-dead "disabled_inactively"
-expect_unhealthy data-stale
+expect_status data-stale UNHEALTHY
 expect_reason data-stale "72h ago (limit 48h)"
-expect_unhealthy data-failing
-expect_reason data-failing "3 consecutive failed runs"
-expect_unhealthy data-ghost
-expect_reason data-ghost "missing or API unreadable"
-expect_healthy data-quiet
-expect_healthy data-two-fails
-grep -qE '4 of 6 repos unhealthy' "$TMP/report.md" \
-  && pass "summary counts 4 of 6" || fail "summary count wrong"
+expect_status data-failing UNHEALTHY
+expect_reason data-failing "3 hard failures since the last success"
+expect_status data-quiet OK
+expect_status data-two-fails OK
+expect_status data-ghost UNREADABLE
+
+echo "== detection: repeated cancellations must not read as healthy =="
+expect_status data-cancelled UNHEALTHY
+expect_reason data-cancelled "3 inconclusive scheduled runs"
+expect_status data-mixed UNHEALTHY
+expect_reason data-mixed "no successful scheduled run in the last 4 completed runs"
+
+echo "== detection: every API document validates independently =="
+expect_status data-badwf UNREADABLE
+expect_reason data-badwf "workflow document unreadable"
+expect_status data-badsched UNREADABLE
+expect_reason data-badsched "schedule-runs document unreadable"
+expect_status data-badcompleted UNREADABLE
+expect_reason data-badcompleted "completed-runs document unreadable"
+expect_status data-truncated UNREADABLE
+expect_status data-empty UNREADABLE
+for r in data-badwf data-badsched data-badcompleted data-truncated data-empty; do
+  if grep -E "^\| $r \| OK " "$TMP/report.md" > /dev/null; then
+    fail "$r reported OK with an unusable document"
+  fi
+done
+pass "no repo with an unusable document reported OK"
+
+echo "== detection: a total blackout is an outage, not fifteen deaths =="
+# Observed live: a misfiring auth probe pushed a whole pass onto the
+# anonymous API, the hourly budget ran out and every repo came back
+# empty. Paging the entire fleet (and opening an incident) for one auth
+# failure is worse than useless, so a full blackout leaves the 0/1
+# health range and the workflow fails it as a monitor outage.
+repos_blackout="$TMP/repos_blackout.txt"
+printf '%s\n' data-ghost data-ghost2 data-ghost3 > "$repos_blackout"
+rc=$(run_health "$repos_blackout" "$TMP/report_blackout.md")
+[ "$rc" -eq 69 ] && pass "total blackout exits 69, outside the health range" \
+  || fail "total blackout exit was $rc"
+# One unreadable repo among readable ones is still an ordinary page.
+repos_one_bad="$TMP/repos_one_bad.txt"
+printf '%s\n' data-quiet data-ghost > "$repos_one_bad"
+rc=$(run_health "$repos_one_bad" "$TMP/report_one_bad.md")
+[ "$rc" -eq 1 ] && pass "a single unreadable repo still pages normally" \
+  || fail "single unreadable exit was $rc"
 
 echo "== detection: all-healthy fleet must exit 0 =="
-rc=0
-FLEET_HEALTH_FIXTURES="$FIX" FLEET_HEALTH_REPOS_FILE="$repos_healthy" \
-  "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report_ok.md" \
-  > /dev/null || rc=$?
+rc=$(run_health "$repos_healthy" "$TMP/report_ok.md")
 [ "$rc" -eq 0 ] && pass "healthy fleet exits 0" || fail "healthy exit was $rc"
 grep -q 'All 2 repos healthy' "$TMP/report_ok.md" \
   && pass "healthy summary present" || fail "healthy summary missing"
+grep -q '<!-- fleet-health-state: healthy -->' "$TMP/report_ok.md" \
+  && pass "healthy state marker present" || fail "healthy state marker missing"
 
-echo "== issue upsert: create once, then comment, never duplicate =="
+echo "== acknowledgement: suppresses paging until review-by =="
+# data-dead is thoroughly broken (state disabled_inactively), so it is
+# unhealthy at every frozen instant below; only the acknowledgement can
+# keep it from paging. data-ackok is healthy at each instant, so when it
+# pages, only the acknowledgement can be the cause.
+healthy_fixture_at data-ackok "$NOW_AFTER"
+healthy_fixture_at data-badack "$NOW_BEFORE"
+
+repos_ack="$TMP/repos_ack.txt"
+printf 'data-dead ack:parked for maintainer ruling:2026-09-07\n' > "$repos_ack"
+rc=$(run_health "$repos_ack" "$TMP/report_ack.md" \
+  FLEET_HEALTH_NOW_EPOCH="$NOW_BEFORE")
+[ "$rc" -eq 0 ] && pass "acknowledged breakage exits 0" || fail "ack exit was $rc"
+expect_status data-dead ACKNOWLEDGED "$TMP/report_ack.md"
+grep -q '<!-- fleet-health-state: healthy -->' "$TMP/report_ack.md" \
+  && pass "acknowledged repo stays out of the state signature" \
+  || fail "acknowledged repo leaked into the state signature"
+expect_reason data-dead "acknowledged until 2026-09-07" "$TMP/report_ack.md"
+expect_reason data-dead "parked for maintainer ruling" "$TMP/report_ack.md"
+grep -q '1 acknowledged and deliberately silent' "$TMP/report_ack.md" \
+  && pass "acknowledged count reported" || fail "acknowledged count missing"
+
+echo "== acknowledgement: still acknowledged ON the review-by date =="
+rc=$(run_health "$repos_ack" "$TMP/report_ackday.md" \
+  FLEET_HEALTH_NOW_EPOCH="$NOW_ONDAY")
+[ "$rc" -eq 0 ] && pass "review-by day still exits 0" || fail "ack-day exit was $rc"
+expect_status data-dead ACKNOWLEDGED "$TMP/report_ackday.md"
+
+echo "== acknowledgement: expires into a page =="
+rc=$(run_health "$repos_ack" "$TMP/report_exp.md" \
+  FLEET_HEALTH_NOW_EPOCH="$NOW_AFTER")
+[ "$rc" -eq 1 ] && pass "expired acknowledgement exits 1" || fail "expired exit was $rc"
+expect_status data-dead EXPIRED-ACK "$TMP/report_exp.md"
+expect_reason data-dead "acknowledgement expired (review-by 2026-09-07)" \
+  "$TMP/report_exp.md"
+grep -q '<!-- fleet-health-state: data-dead=EXPIRED-ACK -->' "$TMP/report_exp.md" \
+  && pass "expiry shows up in the state signature" || fail "expiry not in signature"
+
+echo "== acknowledgement: an expired ack on a HEALTHY repo still pages =="
+# The date is a forcing function: the ruling is owed even if the repo
+# fixed itself, otherwise the ack line lives forever.
+repos_ack_ok="$TMP/repos_ack_ok.txt"
+printf 'data-ackok ack:parked pending ruling:2026-09-07\n' > "$repos_ack_ok"
+rc=$(run_health "$repos_ack_ok" "$TMP/report_expok.md" \
+  FLEET_HEALTH_NOW_EPOCH="$NOW_AFTER")
+[ "$rc" -eq 1 ] && pass "expired ack pages even when healthy" \
+  || fail "expired-ack-on-healthy exit was $rc"
+expect_status data-ackok EXPIRED-ACK "$TMP/report_expok.md"
+expect_reason data-ackok "no outstanding health problem" "$TMP/report_expok.md"
+
+echo "== acknowledgement: an unexpired ack on a healthy repo is quiet =="
+repos_ack_quiet="$TMP/repos_ack_quiet.txt"
+printf 'data-badack ack:parked pending ruling:2026-09-07\n' > "$repos_ack_quiet"
+rc=$(run_health "$repos_ack_quiet" "$TMP/report_ackquiet.md" \
+  FLEET_HEALTH_NOW_EPOCH="$NOW_BEFORE")
+[ "$rc" -eq 0 ] && pass "healthy acknowledged repo exits 0" \
+  || fail "healthy-acknowledged exit was $rc"
+
+echo "== acknowledgement: a malformed one pages instead of muting =="
+# data-badack is healthy at NOW_BEFORE, so any page here comes from the
+# acknowledgement itself, not from the repo.
+for bad in 'ack:no date here' 'ack:bad date:07-09-2026' 'ack:not real:2026-02-31' \
+           'ack::2026-09-07' 'parked:2026-09-07'; do
+  repos_bad="$TMP/repos_bad.txt"
+  printf 'data-badack %s\n' "$bad" > "$repos_bad"
+  rc=$(run_health "$repos_bad" "$TMP/report_bad.md" \
+    FLEET_HEALTH_NOW_EPOCH="$NOW_BEFORE")
+  if [ "$rc" -eq 1 ] &&
+     grep -E "^\| data-badack \| UNHEALTHY " "$TMP/report_bad.md" > /dev/null; then
+    pass "malformed ack pages: $bad"
+  else
+    fail "malformed ack was tolerated (exit $rc): $bad"
+  fi
+done
+
+echo "== queries: only scheduled runs may reach the streak =="
+# The fixture layer bypasses URL building entirely, so this drives the
+# real query builder through a stubbed gh. The stub answers scheduled
+# queries with successes and everything else with failures: if the
+# monitor ever drops event=schedule, a red PR run pages the fleet.
+cat > "$TMP/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "api" ]; then
+  echo "$2" >> "$GH_PATHS"
+  case "$2" in
+    *"/runs?"*"event=schedule"*"per_page=1") printf '{"workflow_runs":[{"created_at":"%s","conclusion":"success"}]}' "$SCHED_TS" ;;
+    *"/runs?"*"event=schedule"*) printf '{"workflow_runs":[{"conclusion":"success"},{"conclusion":"success"},{"conclusion":"success"}]}' ;;
+    *"/runs?"*) printf '{"workflow_runs":[{"conclusion":"failure"},{"conclusion":"failure"},{"conclusion":"failure"},{"conclusion":"failure"}]}' ;;
+    *) printf '{"path":".github/workflows/fetch.yml","state":"active"}' ;;
+  esac
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$TMP/bin/gh"
+printf 'data-prfail\n' > "$TMP/repos_q.txt"
+: > "$TMP/paths.txt"
+rc=0
+PATH="$TMP/bin:$PATH" GH_TOKEN=stub-token GH_PATHS="$TMP/paths.txt" \
+  SCHED_TS="$(iso '3 hours ago')" FLEET_HEALTH_FIXTURES= \
+  FLEET_HEALTH_REPOS_FILE="$TMP/repos_q.txt" \
+  "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report_q.md" > /dev/null || rc=$?
+[ "$rc" -eq 0 ] && pass "PR/push failures do not page (exit 0)" \
+  || fail "unscheduled runs leaked into the verdict (exit $rc)"
+expect_status data-prfail OK "$TMP/report_q.md"
+unscheduled="$(grep '/runs?' "$TMP/paths.txt" | grep -v 'event=schedule' || true)"
+[ -z "$unscheduled" ] && pass "no run query is missing event=schedule" \
+  || fail "run query without event=schedule: $unscheduled"
+grep -q 'runs?event=schedule&status=completed' "$TMP/paths.txt" \
+  && pass "streak query is scheduled runs, completed only" \
+  || fail "streak query wrong: $(grep '/runs?' "$TMP/paths.txt" | tr '\n' ' ')"
+
+echo "== auth: an older gh must not fall through to the anonymous API =="
+# `gh auth token` arrived in gh 2.6. Probing with it alone made gh 2.4
+# look logged-out, so a full pass went out over anonymous curl and died
+# on the 60/hour limit. A logged-in gh must be used whichever probe
+# answers.
+mkdir -p "$TMP/bin2"
+cat > "$TMP/bin2/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$1 ${2:-}" in
+  "auth token")  exit 1 ;;   # as on gh < 2.6
+  "auth status") exit 0 ;;   # but the CLI is logged in
+esac
+if [ "$1" = "api" ]; then
+  echo "$2" >> "$GH_PATHS"
+  case "$2" in
+    *"/runs?"*"per_page=1") printf '{"workflow_runs":[{"created_at":"%s","conclusion":"success"}]}' "$SCHED_TS" ;;
+    *"/runs?"*) printf '{"workflow_runs":[{"conclusion":"success"},{"conclusion":"success"}]}' ;;
+    *) printf '{"state":"active"}' ;;
+  esac
+fi
+exit 0
+STUB
+cat > "$TMP/bin2/curl" <<'STUB'
+#!/usr/bin/env bash
+echo "curl $*" >> "$CURL_LOG"
+STUB
+chmod +x "$TMP/bin2/gh" "$TMP/bin2/curl"
+: > "$TMP/paths2.txt"
+: > "$TMP/curl.log"
+rc=0
+env -u GH_TOKEN -u GITHUB_TOKEN PATH="$TMP/bin2:$PATH" \
+  GH_PATHS="$TMP/paths2.txt" CURL_LOG="$TMP/curl.log" \
+  SCHED_TS="$(iso '3 hours ago')" FLEET_HEALTH_FIXTURES= \
+  FLEET_HEALTH_REPOS_FILE="$TMP/repos_q.txt" \
+  "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report_auth.md" > /dev/null || rc=$?
+[ "$rc" -eq 0 ] && pass "logged-in gh 2.4-style CLI produces a verdict" \
+  || fail "auth fallback exit was $rc"
+[ -s "$TMP/paths2.txt" ] && pass "requests went through gh" \
+  || fail "gh was never called"
+[ -s "$TMP/curl.log" ] \
+  && fail "fell through to anonymous curl: $(cat "$TMP/curl.log")" \
+  || pass "did not fall through to anonymous curl"
+
+echo "== issue: announces state changes, and only state changes =="
 # gh stub: logs every invocation; "gh api" answers with a canned issue
 # list so the title match runs against realistic JSON.
 cat > "$TMP/bin/gh" <<'STUB'
@@ -147,42 +400,124 @@ STUB
 chmod +x "$TMP/bin/gh"
 
 title='Fleet health: data-repo fetch schedules unhealthy'
-echo '[]' > "$TMP/issues_none.json"
-# The open list holds a PR with the exact title (must be ignored) and
-# the real issue #42 (must be matched).
-printf '[{"number":7,"title":"%s","pull_request":{}},{"number":42,"title":"%s"}]' \
-  "$title" "$title" > "$TMP/issues_open.json"
+state_now="$(sed -n 's/.*fleet-health-state:[[:space:]]*\(.*\)[[:space:]]*-->.*/\1/p' \
+  "$TMP/report.md" | tail -n 1 | sed 's/[[:space:]]*$//')"
+[ -n "$state_now" ] && pass "report carries a state signature" \
+  || fail "report has no state signature"
 
-run_upsert() { # issues-json log-file
+issues_json() { # file body
+  # An open PR with the exact title (must be ignored) plus the real
+  # issue #42 (must be matched).
+  jq -n --arg t "$title" --arg b "$2" \
+    '[{number:7,title:$t,pull_request:{}},{number:42,title:$t,body:$b}]' > "$1"
+}
+echo '[]' > "$TMP/issues_none.json"
+issues_json "$TMP/issues_same.json" \
+  "stored report
+
+<!-- fleet-health-state: $state_now -->"
+issues_json "$TMP/issues_diff.json" \
+  "stored report
+
+<!-- fleet-health-state: data-somethingelse=UNHEALTHY -->"
+
+run_upsert() { # issues-json log-file report
+  : > "$2"
   PATH="$TMP/bin:$PATH" GH_LOG="$2" GH_ISSUES_JSON="$1" \
     FLEET_HEALTH_ALLOW_ISSUE_WRITE=1 \
     FLEET_HEALTH_ISSUE_REPO=ammitto/ammitto \
-    "$SCRIPT_DIR/fleet_health_issue.sh" "$TMP/report.md" > /dev/null
+    "$SCRIPT_DIR/fleet_health_issue.sh" "$3" > /dev/null
+}
+wrote_nothing() { # log-file label
+  if grep -qE '^gh issue ' "$1"; then
+    fail "$2: wrote to GitHub ($(grep -E '^gh issue ' "$1" | tr '\n' ' '))"
+  else
+    pass "$2: no writes"
+  fi
 }
 
-: > "$TMP/log1"; run_upsert "$TMP/issues_none.json" "$TMP/log1"
+run_upsert "$TMP/issues_none.json" "$TMP/log1" "$TMP/report.md"
 grep -q '^gh issue create ' "$TMP/log1" \
-  && pass "no open issue -> creates" || fail "create path broken"
+  && pass "unhealthy + no open issue -> creates" || fail "create path broken"
 grep -q '^gh issue comment ' "$TMP/log1" \
   && fail "created AND commented" || pass "create path does not comment"
 
-: > "$TMP/log2"; run_upsert "$TMP/issues_open.json" "$TMP/log2"
+run_upsert "$TMP/issues_diff.json" "$TMP/log2" "$TMP/report.md"
 grep -q '^gh issue comment 42 ' "$TMP/log2" \
-  && pass "open issue #42 -> comments (PR with same title ignored)" \
+  && pass "changed state -> comments on #42 (PR with same title ignored)" \
   || fail "comment path broken"
+grep -q '^gh issue edit 42 ' "$TMP/log2" \
+  && pass "changed state -> stores the new signature in the body" \
+  || fail "signature not stored back"
 grep -q '^gh issue create ' "$TMP/log2" \
   && fail "duplicate issue created" || pass "comment path does not create"
 
-echo "== issue upsert: refuses to write outside Actions =="
+run_upsert "$TMP/issues_same.json" "$TMP/log3" "$TMP/report.md"
+wrote_nothing "$TMP/log3" "unchanged state"
+
+run_upsert "$TMP/issues_none.json" "$TMP/log4" "$TMP/report_ok.md"
+wrote_nothing "$TMP/log4" "healthy with no open issue"
+
+run_upsert "$TMP/issues_diff.json" "$TMP/log5" "$TMP/report_ok.md"
+grep -q '^gh issue comment 42 ' "$TMP/log5" \
+  && pass "recovery -> comments on #42" || fail "recovery comment missing"
+grep -q '^gh issue close 42 ' "$TMP/log5" \
+  && pass "recovery -> closes #42" || fail "recovery does not close"
+
+echo "== issue: an expiring acknowledgement announces itself =="
+# ACKNOWLEDGED is invisible to the signature, so the ack going stale is
+# a plain none -> EXPIRED-ACK transition through the normal path.
+issues_json "$TMP/issues_ackstate.json" \
+  "stored report
+
+<!-- fleet-health-state: healthy -->"
+run_upsert "$TMP/issues_ackstate.json" "$TMP/log6" "$TMP/report_ack.md"
+wrote_nothing "$TMP/log6" "acknowledged repo"
+run_upsert "$TMP/issues_ackstate.json" "$TMP/log7" "$TMP/report_exp.md"
+grep -q '^gh issue comment 42 ' "$TMP/log7" \
+  && pass "expired acknowledgement -> comments" || fail "expiry not announced"
+
+echo "== issue: refuses a report with no state marker =="
+printf 'not a fleet report\n' > "$TMP/bogus.md"
 rc=0
-: > "$TMP/log3"
-PATH="$TMP/bin:$PATH" GH_LOG="$TMP/log3" GH_ISSUES_JSON="$TMP/issues_none.json" \
+: > "$TMP/log8"
+PATH="$TMP/bin:$PATH" GH_LOG="$TMP/log8" GH_ISSUES_JSON="$TMP/issues_none.json" \
+  FLEET_HEALTH_ALLOW_ISSUE_WRITE=1 FLEET_HEALTH_ISSUE_REPO=ammitto/ammitto \
+  "$SCRIPT_DIR/fleet_health_issue.sh" "$TMP/bogus.md" > /dev/null 2>&1 || rc=$?
+[ "$rc" -eq 65 ] && pass "markerless report refused (exit 65)" \
+  || fail "markerless report exit was $rc"
+wrote_nothing "$TMP/log8" "markerless report"
+
+echo "== issue: refuses to write outside Actions =="
+rc=0
+: > "$TMP/log9"
+PATH="$TMP/bin:$PATH" GH_LOG="$TMP/log9" GH_ISSUES_JSON="$TMP/issues_none.json" \
   GITHUB_ACTIONS= FLEET_HEALTH_ALLOW_ISSUE_WRITE= \
   FLEET_HEALTH_ISSUE_REPO=ammitto/ammitto \
   "$SCRIPT_DIR/fleet_health_issue.sh" "$TMP/report.md" \
   > /dev/null 2>&1 || rc=$?
 [ "$rc" -eq 78 ] && pass "guard refuses (exit 78)" || fail "guard exit was $rc"
-[ -s "$TMP/log3" ] && fail "guard still called gh" || pass "guard called no gh"
+[ -s "$TMP/log9" ] && fail "guard still called gh" || pass "guard called no gh"
+
+echo "== shipped repos file parses, and data-ru is acknowledged =="
+if [ -f "$SCRIPT_DIR/fleet_repos.txt" ]; then
+  ack_line="$(grep -E '^data-ru[[:space:]]' "$SCRIPT_DIR/fleet_repos.txt" || true)"
+  case "$ack_line" in
+    *"ack:parked for maintainer ruling on ru revival:2026-09-07")
+      pass "data-ru ships acknowledged until 2026-09-07" ;;
+    *)
+      fail "data-ru acknowledgement missing or altered: ${ack_line:-no line}" ;;
+  esac
+  # Every non-comment line is either a bare repo or a well-formed ack.
+  bad_lines="$(sed 's/#.*//' "$SCRIPT_DIR/fleet_repos.txt" |
+    grep -vE '^[[:space:]]*$' |
+    grep -vE '^[A-Za-z0-9._-]+([[:space:]]+ack:.+:[0-9]{4}-[0-9]{2}-[0-9]{2})?[[:space:]]*$' \
+    || true)"
+  [ -z "$bad_lines" ] && pass "every repos-file line is well formed" \
+    || fail "malformed repos-file lines: $bad_lines"
+else
+  fail "fleet_repos.txt missing"
+fi
 
 echo
 if [ "$failures" -eq 0 ]; then

--- a/scripts/fleet_repos.txt
+++ b/scripts/fleet_repos.txt
@@ -6,6 +6,18 @@
 # lib/ammitto/config/defaults.rb — adding a source there without adding its
 # repo here leaves the new schedule unwatched.
 #
+# A line may carry an acknowledgement:
+#
+#   <repo> ack:<reason>:<review-by YYYY-MM-DD>
+#
+# The repo still appears in every report, but as ACKNOWLEDGED: it is left out
+# of the paging count and never reaches the tracking issue. The date is a
+# deadline, not a mute button — from the day after review-by the repo reports
+# EXPIRED-ACK and pages like anything else, so a parked decision cannot stay
+# parked by accident. The reason may contain colons; the date is taken from
+# the last one. A malformed acknowledgement pages instead of suppressing, so a
+# typo cannot silence a repo forever.
+#
 # data-cn is listed even though its YAML is manually managed: its fetch.yml
 # still runs on a schedule (verified 2026-08-07, conclusion success), so it
 # can die the same silent death as the others.
@@ -17,7 +29,7 @@ data-eu
 data-eu-vessels
 data-jp
 data-nz
-data-ru
+data-ru ack:parked for maintainer ruling on ru revival:2026-09-07
 data-tr
 data-uk
 data-un

--- a/scripts/fleet_repos.txt
+++ b/scripts/fleet_repos.txt
@@ -1,0 +1,26 @@
+# Repositories watched by the fleet health monitor (scripts/fleet_health.sh).
+# One repository name per line; the org is fixed to "ammitto" (override with
+# FLEET_HEALTH_ORG). Blank lines and "#" comments are ignored.
+#
+# Keep this list in sync with DATA_REPO_TO_SOURCE in
+# lib/ammitto/config/defaults.rb — adding a source there without adding its
+# repo here leaves the new schedule unwatched.
+#
+# data-cn is listed even though its YAML is manually managed: its fetch.yml
+# still runs on a schedule (verified 2026-08-07, conclusion success), so it
+# can die the same silent death as the others.
+data-au
+data-ca
+data-ch
+data-cn
+data-eu
+data-eu-vessels
+data-jp
+data-nz
+data-ru
+data-tr
+data-uk
+data-un
+data-un-vessels
+data-us
+data-wb


### PR DESCRIPTION
Six of the fifteen data-repository fetch schedules died silently and nobody
noticed for roughly three months. Nothing watches them, which is how it
happened. This adds one central scheduled workflow in the hub repo that judges
the whole fleet.

## Changes

- `scripts/fleet_health.sh` — three signals per repo: workflow state not
  active, no `event=schedule` run in 48 hours, or three hard scheduled failures
  since the last success. Quiet-but-healthy is structurally safe: only run
  conclusions are read, never commit deltas, so a legitimate zero-delta day
  cannot flag.
- Any of the three API documents being missing, malformed, or carrying members
  that cannot hold a verdict makes the repo UNREADABLE, never OK.
- Acknowledgements: a `repo ack:<reason>:<review-by>` line reports
  ACKNOWLEDGED without paging, and pages as EXPIRED-ACK once the date passes,
  so a known-broken repo cannot train readers to ignore the monitor. `data-ru`
  ships acknowledged to 2026-09-07 pending its revival decision.
- `scripts/fleet_health_issue.sh` writes only on state changes — new unhealthy,
  recovered, ack expired — with paging state persisted in the tracking issue
  so a missed run does not lose it.
- `scripts/fleet_health_test.sh` self-tests offline before every live check: a
  monitor with a silently broken parser would report healthy forever.

## Test plan

- 80 fixture assertions pass, covering dead schedules, failure streaks,
  repeated cancellations, healthy-but-quiet, unreadable documents, null and
  scalar run members, acknowledgement suppression, expiry, and
  state-change-only commenting
- Live pass over all fifteen repos: exit 0, fleet healthy, `data-ru`
  ACKNOWLEDGED
- `bash -n` on every script

Residual risk is documented in the workflow: if the hub repo itself goes quiet
for 60 days the watchdog dies with the fleet. Closing that needs an external
pinger, deliberately omitted to stay dependency-free.
