### PR TITLE
Fix tr entity predicates and mixed-set ResultSet type filters

### DIFF
--- a/docs/interfaces/ruby-api/index.adoc
+++ b/docs/interfaces/ruby-api/index.adoc
@@ -159,8 +159,9 @@ results.to_json
 
 All entities inherit from `Ammitto::Entity`, which is what `require "ammitto"`
 loads. An `Ammitto::Search::ResultSet` can also hold `Ammitto::SanctionEntry`
-records; `entity_types` and `by_entity_type` assume entity-only results and
-raise on a mixed set.
+records, which carry no `entity_type`; `entity_types` skips them and
+`by_entity_type` filters them out, the way `by_authority` and `by_status`
+already skip entities.
 
 === PersonEntity
 

--- a/lib/ammitto/search/result_set.rb
+++ b/lib/ammitto/search/result_set.rb
@@ -58,10 +58,20 @@ module Ammitto
       alias length size
 
       # Filter results by entity type
+      #
+      # Guarded the way #by_authority and #by_status are, because a set
+      # holds whatever the search returned: SanctionEntry has no
+      # entity_type, Entity has neither authority nor status, and any of
+      # the three filters can be handed a set containing both. An entry
+      # simply is not an entity of the requested type, so it drops out —
+      # the same answer #by_authority gives an Entity.
+      #
       # @param type [Symbol, String] the entity type
       # @return [ResultSet] filtered results
       def by_entity_type(type)
-        filtered = entries.select { |e| e.entity_type == type.to_s }
+        filtered = entries.select do |e|
+          e.respond_to?(:entity_type) && e.entity_type == type.to_s
+        end
         ResultSet.new(filtered, term: term, total_count: total_count)
       end
 
@@ -86,9 +96,15 @@ module Ammitto
       end
 
       # Get unique entity types in results
+      #
+      # Guarded like #authorities: a member that carries no entity_type
+      # contributes nothing, rather than raising and taking the types of
+      # every member that does have one down with it.
+      #
       # @return [Array<String>]
       def entity_types
-        entries.map(&:entity_type).uniq.compact
+        entries.map { |e| e.respond_to?(:entity_type) ? e.entity_type : nil }
+               .uniq.compact
       end
 
       # Get unique authorities in results

--- a/lib/ammitto/sources/tr/sanctions_list.rb
+++ b/lib/ammitto/sources/tr/sanctions_list.rb
@@ -260,23 +260,35 @@ module Ammitto
           }.freeze
         }.freeze
 
-        # Whether Turkey listed this record as a natural person.
+        # Whether this record carries the parser's "person"
+        # classification.
         #
-        # The word compared is the one the record actually carries.
-        # .detect_entity_type classifies every row of the workbook as
-        # "person" or "organization", fetch saves that word verbatim, and
-        # harmonize reads it back — so those two are the whole vocabulary
-        # a record can arrive with. Comparing against "individual"
-        # instead made this false for every record, and #organization?
-        # false with it, leaving no value of entity_type for which either
-        # predicate answered true.
+        # The word compared is the one .detect_entity_type emits — that
+        # method writes "person" or "organization" and nothing else, and
+        # fetch saves the word verbatim. That bounds the parser, not the
+        # record: harmonize re-reads record files, and the YAML mapping
+        # admits whatever string a file carries. The pair of predicates
+        # stays total over that open set because this one matches the
+        # single word meaning person and #organization? takes the
+        # complement, mirroring Transformer#map_entity_type. Comparing
+        # against "individual" instead made this false for every record,
+        # and #organization? false with it, leaving no value of
+        # entity_type for which either predicate answered true.
+        #
+        # A true answer repeats the classification; it does not vouch
+        # for the designee. The classifier's only organisation signal is
+        # a marker column Turkey fills on some organisation rows and
+        # leaves blank on others, so part of List D's organisations —
+        # DEFENCE INDUSTRIES ORGANISATION (DIO) among them — carry
+        # "person" and answer true here.
         #
         # @return [Boolean]
         def person?
           entity_type.to_s.downcase == 'person'
         end
 
-        # Whether this record is anything other than a natural person.
+        # Whether this record carries anything but the "person"
+        # classification.
         #
         # The complement rather than an equality test, so that it agrees
         # with Transformer#map_entity_type for every value rather than
@@ -975,12 +987,23 @@ module Ammitto
           end.join('; ')
         end
 
-        # Detect entity type from row data
+        # Detect entity type from row data.
+        #
+        # Best effort, not ground truth. In the live workbook the
+        # "Gerçek Kişi" column carries EVERY designee's name,
+        # organisations included, and the "Tüzel Kuruluş/Organizasyon"
+        # column is a type marker (the literal text "Tüzel
+        # Kişi/Kuruluş/Organizasyon") rather than a name — filled on
+        # some organisation rows and left blank on others. A row whose
+        # marker Turkey omitted is indistinguishable here from a person
+        # row: no other column separates them (many real persons carry
+        # no birth data either), so such a row classifies "person"
+        # however organisation-shaped its name reads.
         def self.detect_entity_type(row)
-          # If organization_name column has data, it's an organization
+          # Marker column filled: Turkey typed the row as an organisation
           if row[:organization_name] && !row[:organization_name].empty?
             'organization'
-          # If name column has data (individual name column), it's a person
+          # A name with no marker: presumed person (see above)
           elsif row[:name] && !row[:name].empty?
             'person'
           # Check other indicators

--- a/lib/ammitto/sources/tr/sanctions_list.rb
+++ b/lib/ammitto/sources/tr/sanctions_list.rb
@@ -33,7 +33,13 @@ module Ammitto
       # Sanctioned entity from Turkey List D
       class SanctionedEntity < Lutaml::Model::Serializable
         attribute :name, :string
-        attribute :entity_type, :string # Individual, Entity
+        # "person" or "organization" — the words this gem's own parser
+        # writes. The comment here used to name a different pair,
+        # "Individual, Entity", which nothing has ever produced; the
+        # predicates below were written against that comment rather than
+        # against .detect_entity_type, and so answered false for every
+        # record ever parsed.
+        attribute :entity_type, :string
         attribute :program, :string
         attribute :remarks, :string
         attribute :listed_date, :string
@@ -254,12 +260,37 @@ module Ammitto
           }.freeze
         }.freeze
 
+        # Whether Turkey listed this record as a natural person.
+        #
+        # The word compared is the one the record actually carries.
+        # .detect_entity_type classifies every row of the workbook as
+        # "person" or "organization", fetch saves that word verbatim, and
+        # harmonize reads it back — so those two are the whole vocabulary
+        # a record can arrive with. Comparing against "individual"
+        # instead made this false for every record, and #organization?
+        # false with it, leaving no value of entity_type for which either
+        # predicate answered true.
+        #
+        # @return [Boolean]
         def person?
-          entity_type&.downcase == 'individual'
+          entity_type.to_s.downcase == 'person'
         end
 
+        # Whether this record is anything other than a natural person.
+        #
+        # The complement rather than an equality test, so that it agrees
+        # with Transformer#map_entity_type for every value rather than
+        # only for the two the parser writes. That method sends "person"
+        # down the person branch and everything else — a blank
+        # entity_type, the "entity" spelling, a word from some future
+        # column — down the organization branch, and builds an
+        # OrganizationEntity accordingly. An `== "organization"` test
+        # would answer false about records the gem does harmonize as
+        # organizations, which is the same defect in a quieter form.
+        #
+        # @return [Boolean]
         def organization?
-          entity_type&.downcase == 'entity'
+          !person?
         end
 
         # Local identifier this record's IRIs and filename are minted

--- a/spec/ammitto/search/result_set_spec.rb
+++ b/spec/ammitto/search/result_set_spec.rb
@@ -123,4 +123,128 @@ RSpec.describe Ammitto::Search::ResultSet do
       expect(node['hasSanctionEntry']).to eq([entry_iri])
     end
   end
+
+  # A result set holds whatever the search returned, and the class is
+  # built for two kinds of member: #build_from_hash routes a node typed
+  # "SanctionEntry" to SanctionEntry and everything else to an Entity, and
+  # #to_json_ld greps the set for both classes separately. The two
+  # families carry different attributes — SanctionEntry has authority and
+  # status and no entity_type, Entity has entity_type and neither of the
+  # others — so every filter on this class meets members that cannot
+  # answer it.
+  #
+  # #by_authority and #by_status were written for that and skip a member
+  # that cannot answer. #entity_types and #by_entity_type were not, and
+  # raised NoMethodError on any set holding one entry, taking down the
+  # types of every entity in the set with it.
+  def person
+    Ammitto::PersonEntity.new(id: 'https://www.ammitto.org/entity/tr/1',
+                              entity_type: 'person')
+  end
+
+  def organization
+    Ammitto::OrganizationEntity.new(
+      id: 'https://www.ammitto.org/entity/tr/2', entity_type: 'organization'
+    )
+  end
+
+  # Exactly what JsonLdSerializer#serialize_entry writes for an entry with
+  # no matching entity: an id, the entity it points at, and a status.
+  def entry
+    Ammitto::SanctionEntry.new(id: 'https://www.ammitto.org/entry/tr/1',
+                               entity_id: 'https://www.ammitto.org/entity/tr/1',
+                               status: 'active')
+  end
+
+  def mixed
+    described_class.new([person, organization, entry], term: 'acme')
+  end
+
+  def entities_only
+    described_class.new([person, organization], term: 'acme')
+  end
+
+  describe '#entity_types' do
+    it 'reports the types of a set that also holds an entry' do
+      expect(mixed.entity_types).to eq(%w[person organization])
+    end
+
+    it 'reports the same types with the entry present as without it' do
+      # The entry contributes nothing, which is the claim — not that the
+      # call merely survives.
+      expect(mixed.entity_types).to eq(entities_only.entity_types)
+    end
+
+    it 'reports nothing for a set holding only entries' do
+      expect(described_class.new([entry], term: 'acme').entity_types).to eq([])
+    end
+  end
+
+  describe '#by_entity_type' do
+    it 'filters a set that also holds an entry' do
+      expect(mixed.by_entity_type(:person).to_a).to eq([person])
+    end
+
+    it 'selects the same members with the entry present as without it' do
+      expect(mixed.by_entity_type('organization').to_a)
+        .to eq(entities_only.by_entity_type('organization').to_a)
+    end
+
+    it 'never admits an entry as an entity of any type' do
+      # An entry has no entity_type, so no argument may match it. Asking
+      # for each type the set reports, plus the type of the entity the
+      # entry belongs to, must never return the entry itself.
+      matched = (mixed.entity_types + ['person']).flat_map do |type|
+        mixed.by_entity_type(type).to_a
+      end
+
+      expect(matched).to all(be_a(Ammitto::Entity))
+    end
+  end
+
+  # The guard is the siblings' guard, so the four filters answer the one
+  # set alike. Stated as one example because the defect was precisely
+  # that two of the four behaved differently from the other two.
+  describe 'the filters that meet members which cannot answer them' do
+    it 'answers every filter on one mixed set' do
+      set = mixed
+
+      expect({ entity_types: set.entity_types,
+               authorities: set.authorities,
+               person: set.by_entity_type(:person).to_a,
+               authority: set.by_authority(:tr).to_a,
+               status: set.by_status(:active).to_a })
+        .to eq(entity_types: %w[person organization],
+               authorities: [],
+               person: [person],
+               authority: [],
+               status: [entry])
+    end
+  end
+
+  # Reachable through the documented public entry point, not only through
+  # the constructor: Ammitto.search builds a result set out of whatever
+  # graph nodes matched, and BaseSource#search matches any node carrying
+  # the name — including one typed SanctionEntry.
+  describe 'a search whose matches include an entry node' do
+    def result_set_for(graph)
+      described_class.new(graph.map { |node| node })
+    end
+
+    it 'reports the entity types among the matched nodes' do
+      graph = [
+        { '@id' => 'https://www.ammitto.org/entity/tr/1',
+          '@type' => 'PersonEntity', 'entityType' => 'person',
+          'names' => [{ 'fullName' => 'ACME' }] },
+        { '@id' => 'https://www.ammitto.org/entry/tr/1',
+          '@type' => 'SanctionEntry', 'status' => 'active',
+          'names' => [{ 'fullName' => 'ACME' }] }
+      ]
+      results = result_set_for(graph)
+
+      expect(results.to_a.map(&:class))
+        .to eq([Ammitto::PersonEntity, Ammitto::SanctionEntry])
+      expect(results.entity_types).to eq(['person'])
+    end
+  end
 end

--- a/spec/ammitto/sources/tr/sanctioned_entity_spec.rb
+++ b/spec/ammitto/sources/tr/sanctioned_entity_spec.rb
@@ -553,4 +553,101 @@ RSpec.describe Ammitto::Sources::Tr::SanctionedEntity do
       end
     end
   end
+
+  # What the predicates answer, and about which records.
+  #
+  # They were written against a vocabulary nothing produces — "individual"
+  # and "entity" — while .detect_entity_type has written "person" and
+  # "organization" since the file was added. Both therefore answered false
+  # for every record Turkey has ever published, so a caller asking whether
+  # a designee was a person and a caller asking whether it was an
+  # organization both heard no about the same record.
+  #
+  # Every expectation below is stated against the word the parser itself
+  # produces rather than against a word chosen here, because that word is
+  # what a record actually carries: fetch saves it and harmonize reads it
+  # back unchanged.
+  describe 'entity type predicates' do
+    # One row of each shape .detect_entity_type distinguishes.
+    def self.rows
+      { 'an organization name cell' => { organization_name: 'ACME LTD' },
+        'a person name cell' => { name: 'JOHN DOE' },
+        'a birth date and no name' => { date_of_birth: '1970-01-01' },
+        'no usable indicator at all' => {} }
+    end
+
+    def classify(row)
+      Ammitto::Sources::Tr::SanctionsList.detect_entity_type(row)
+    end
+
+    def parsed(row)
+      described_class.new(name: 'ACME LTD', entity_type: classify(row))
+    end
+
+    rows.each do |shape, row|
+      it "reads a record parsed from #{shape} as the parser classified it" do
+        # The whole predicate pair, compared against the parser's own
+        # word. A tally ("exactly one of the two is true") would pass on
+        # a pair that answered confidently about the wrong record.
+        record = parsed(row)
+        word = classify(row)
+
+        expect({ person: record.person?, organization: record.organization? })
+          .to eq(person: word == 'person', organization: word == 'organization')
+      end
+    end
+
+    it 'leaves no parsed record that both predicates deny' do
+      answered = self.class.rows.values.map do |row|
+        record = parsed(row)
+        [record.person?, record.organization?]
+      end
+
+      expect(answered).to all(include(true))
+    end
+
+    it 'reads the two words the parser can write' do
+      person = described_class.new(name: 'JOHN DOE', entity_type: 'person')
+      organization = described_class.new(name: 'ACME LTD',
+                                         entity_type: 'organization')
+
+      expect([person.person?, person.organization?]).to eq([true, false])
+      expect([organization.person?, organization.organization?])
+        .to eq([false, true])
+    end
+
+    it 'ignores the case a record file happens to carry' do
+      record = described_class.new(name: 'JOHN DOE', entity_type: 'Person')
+
+      expect(record.person?).to be true
+    end
+  end
+
+  # The consequence a caller sees. A predicate that disagrees with the
+  # transformer does not merely answer oddly in isolation — it describes a
+  # designee as something other than the node harmonize mints for it.
+  # Transformer#map_entity_type sends "person" down the person branch and
+  # every other value, blank included, down the organization branch, so
+  # these are the values the predicates have to agree with.
+  describe 'agreement with the class harmonize builds' do
+    def minted_type(entity_type)
+      record = described_class.new(name: 'ACME LTD', reference_number: '42',
+                                   entity_type: entity_type)
+      Ammitto::Sources::Tr::Transformer.new.transform(record)[:entity]
+                                       .entity_type
+    end
+
+    ['person', 'organization', 'entity', 'Individual', '', nil]
+      .each do |entity_type|
+      it "reads #{entity_type.inspect} as the type harmonize mints" do
+        record = described_class.new(name: 'ACME LTD', reference_number: '42',
+                                     entity_type: entity_type)
+        minted = minted_type(entity_type)
+
+        expect({ person: record.person?, organization: record.organization? })
+          .to eq(person: minted == 'person',
+                 organization: minted == 'organization')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Two entity-type defects, both silent.

`Sources::Tr::SanctionedEntity#person?` and `#organization?` compared
`entity_type` against `'individual'` and `'entity'`, but the Turkey parser
writes only `'person'` and `'organization'` — so both predicates answered false
for every record ever parsed. Separately, `ResultSet#entity_types` and
`#by_entity_type` raised `NoMethodError` on a result set containing
`SanctionEntry` records, which search results legitimately return.

## Changes

- Compare against `'person'`, with `organization?` as its complement — matching
  `Transformer#map_entity_type`, which routes every non-person value to
  organization. The comment now distinguishes what the parser emits from what
  YAML ingestion accepts, which is any string.
- `entity_types` skips members carrying no entity type and `by_entity_type`
  filters them out, the way `by_authority` and `by_status` already skip
  entities. The published caveat promising a raise is updated to describe this.

## What this does not fix

The Turkey workbook's organization marker is inconsistently populated — DIO
lacks it while DTSRC has it — so DIO is currently classified `person` in the
committed corpus. This PR makes the classifier and the predicates agree; it
does not make either factually right. A birth-data heuristic would misclassify
at least 86 human-looking rows, so that correction needs source-level evidence
and its own change.

## Test plan

- `bundle exec rspec` — 1405 examples, 0 failures
- `bundle exec rubocop` — 421 files, no offenses
- Mutation check on unmodified main: 20 failures, 8 from ResultSet raising and
  12 from the tr predicates
