### PR TITLE
Add a shared HTTPS downloader and move the nz extractor onto it

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -222,7 +222,6 @@ Security/Open:
     - 'lib/ammitto/extractors/ch_extractor.rb'
     - 'lib/ammitto/extractors/eu_extractor.rb'
     - 'lib/ammitto/extractors/eu_vessels_extractor.rb'
-    - 'lib/ammitto/extractors/nz_extractor.rb'
     - 'lib/ammitto/extractors/tr_extractor.rb'
     - 'lib/ammitto/extractors/us_extractor.rb'
     - 'lib/ammitto/extractors/wb_extractor.rb'

--- a/lib/ammitto/extractors/http_client.rb
+++ b/lib/ammitto/extractors/http_client.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'open-uri' # OpenURI::HTTPError only; this file never calls URI.open
+
+module Ammitto
+  module Extractors
+    # One HTTPS downloader for every extractor.
+    #
+    # The extractors reached their sources through +URI.open+, which is
+    # convenient but carries policy nobody declared: RuboCop's
+    # Security/Open flags it because a string beginning "|" runs a
+    # subprocess, and on Ruby 3.3 open-uri applies no numeric redirect
+    # cap at all. None of the call sites build a URL from untrusted
+    # input, so the pipe form was never reachable here — the reason to
+    # move is that every source now follows ONE written-down policy
+    # instead of open-uri's defaults varying across the supported Ruby
+    # range.
+    #
+    # Deliberately preserved from open-uri, because changing them would
+    # be a behaviour change wearing a cleanup's clothes:
+    #
+    # - HTTPS-only, at every hop. open-uri already refuses an
+    #   https->http redirect; so does this. Nothing here closes a
+    #   downgrade that open-uri permitted.
+    # - Environment proxies. +Net::HTTP.start+ consults http_proxy /
+    #   https_proxy / no_proxy by default and that default is left
+    #   alone.
+    # - Transparent gzip. Net::HTTP advertises the encodings it can
+    #   decode and decodes them, but only while the caller leaves
+    #   Accept-Encoding unset — so this never sets it.
+    # - 60-second open and read timeouts, Net::HTTP's own defaults,
+    #   which is what open-uri was already using. Callers that had
+    #   chosen something else keep choosing it.
+    # - +OpenURI::HTTPError+ on a non-2xx terminal response, so callers
+    #   that rescue it keep working.
+    class HttpClient
+      # Redirect hops allowed after the initial request. open-uri on
+      # Ruby 3.4+ allows 64 and on 3.3 allows unlimited; no sanctions
+      # source legitimately needs more than a couple.
+      MAX_REDIRECTS = 3
+
+      # Net::HTTP's own defaults, which is what open-uri applied here.
+      OPEN_TIMEOUT = 60
+      READ_TIMEOUT = 60
+
+      # The statuses open-uri treats as redirects. Net::HTTPRedirection
+      # is deliberately NOT used as the test: 304 Not Modified is one
+      # of its subclasses and carries no Location, so following it
+      # blindly turns a valid response into a crash.
+      REDIRECT_CODES = %w[301 302 303 307 308].freeze
+
+      class << self
+        # Fetches +url+ and returns the response body.
+        #
+        # @param url [String] an https URL
+        # @param headers [Hash] request headers, sent on every hop
+        #   unless +redirect+ is :same_origin
+        # @param open_timeout [Integer] seconds to wait for the connection
+        # @param read_timeout [Integer] seconds to wait for the body
+        # @param max_redirects [Integer] hops allowed after the first request
+        # @param redirect [Symbol] :any_https follows an https redirect to
+        #   any host — correct for public downloads. :same_origin refuses
+        #   to leave the original scheme/host/port, which is what a
+        #   request carrying a credential needs: +headers+ travel with
+        #   every hop, so a cross-host redirect would hand the secret to
+        #   whoever answered.
+        # @return [String] the response body
+        # @raise [OpenURI::HTTPError] on a non-2xx terminal response, a
+        #   non-https hop, or a missing Location
+        # @raise [ArgumentError] if +url+ is not https
+        def get(url, headers: {}, open_timeout: OPEN_TIMEOUT,
+                read_timeout: READ_TIMEOUT, max_redirects: MAX_REDIRECTS,
+                redirect: :any_https)
+          uri = parse_https(url)
+          origin = uri.dup
+          seen = [uri.to_s]
+
+          (max_redirects + 1).times do
+            response = request(uri, headers, open_timeout, read_timeout)
+            return response.body if response.is_a?(Net::HTTPSuccess)
+
+            uri = redirect_target(response, uri, origin, redirect, seen)
+            seen << uri.to_s
+          end
+
+          raise OpenURI::HTTPError.new(
+            "more than #{max_redirects} redirects for #{url}", nil
+          )
+        end
+
+        private
+
+        # Anything that is not a usable https URL is refused the same
+        # way, whether it parses to another scheme or does not parse at
+        # all — "|whoami", the shape Security/Open warns about, lands
+        # here as an unparseable URI rather than a second error class.
+        #
+        # @param url [String]
+        # @return [URI::HTTPS]
+        def parse_https(url)
+          uri = begin
+            URI.parse(url.to_s)
+          rescue URI::InvalidURIError
+            nil
+          end
+          return uri if uri.is_a?(URI::HTTPS)
+
+          raise ArgumentError, "https required, got: #{url}"
+        end
+
+        # Resolves one redirect, or raises if it must not be followed.
+        #
+        # @return [URI::HTTPS]
+        def redirect_target(response, uri, origin, redirect, seen)
+          unless REDIRECT_CODES.include?(response.code)
+            raise OpenURI::HTTPError.new(
+              "#{response.code} #{response.message}", nil
+            )
+          end
+
+          location = response['Location']
+          if location.nil? || location.empty?
+            raise OpenURI::HTTPError.new(
+              "#{response.code} redirect without a Location", nil
+            )
+          end
+
+          target = URI.join(uri.to_s, location)
+          check_hop(target, origin, redirect, seen)
+          target
+        end
+
+        # @raise [OpenURI::HTTPError] if the hop breaks policy
+        def check_hop(target, origin, redirect, seen)
+          unless target.is_a?(URI::HTTPS)
+            raise OpenURI::HTTPError.new(
+              "redirection to non-https forbidden: #{target}", nil
+            )
+          end
+
+          if redirect == :same_origin && !same_origin?(target, origin)
+            raise OpenURI::HTTPError.new(
+              'cross-origin redirect forbidden for a credentialed ' \
+              "request: #{target}", nil
+            )
+          end
+
+          return unless seen.include?(target.to_s)
+
+          raise OpenURI::HTTPError.new("redirect loop at #{target}", nil)
+        end
+
+        # @return [Boolean]
+        def same_origin?(target, origin)
+          target.host == origin.host && target.port == origin.port
+        end
+
+        # One GET; the caller's loop owns redirect following.
+        #
+        # Net::HTTP.start's proxy argument is left at its default so the
+        # environment's proxy settings keep applying, and
+        # Accept-Encoding is never set so gzip stays transparent.
+        #
+        # @return [Net::HTTPResponse]
+        def request(uri, headers, open_timeout, read_timeout)
+          Net::HTTP.start(
+            uri.host, uri.port,
+            use_ssl: true,
+            open_timeout: open_timeout, read_timeout: read_timeout
+          ) do |http|
+            http.request(Net::HTTP::Get.new(uri, headers))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ammitto/extractors/http_client.rb
+++ b/lib/ammitto/extractors/http_client.rb
@@ -23,9 +23,13 @@ module Ammitto
     # - HTTPS-only, at every hop. open-uri already refuses an
     #   https->http redirect; so does this. Nothing here closes a
     #   downgrade that open-uri permitted.
-    # - Environment proxies. +Net::HTTP.start+ consults http_proxy /
-    #   https_proxy / no_proxy by default and that default is left
-    #   alone.
+    # - Environment proxies, resolved the way open-uri resolved them.
+    #   +Net::HTTP+'s own :ENV default is NOT equivalent: on Ruby 3.3
+    #   and 3.4 it reads http_proxy and ignores https_proxy, so an
+    #   operator behind an https-only proxy would have silently gone
+    #   direct. +URI#find_proxy+ picks the right variable for the
+    #   scheme and honours no_proxy, so the proxy is resolved here and
+    #   passed in explicitly.
     # - Transparent gzip. Net::HTTP advertises the encodings it can
     #   decode and decodes them, but only while the caller leaves
     #   Accept-Encoding unset — so this never sets it.
@@ -50,28 +54,38 @@ module Ammitto
       # blindly turns a valid response into a crash.
       REDIRECT_CODES = %w[301 302 303 307 308].freeze
 
+      # Recognised redirect policies. An unrecognised value is refused
+      # rather than defaulted: silently falling back to :any_https
+      # would turn a typo like :same_orgin into a credential leak, and
+      # nothing in the request would look wrong.
+      REDIRECT_POLICIES = %i[any_https same_origin].freeze
+
       class << self
         # Fetches +url+ and returns the response body.
         #
         # @param url [String] an https URL
         # @param headers [Hash] request headers, sent on every hop
-        #   unless +redirect+ is :same_origin
+        #   unless +redirect_policy+ is :same_origin
         # @param open_timeout [Integer] seconds to wait for the connection
         # @param read_timeout [Integer] seconds to wait for the body
         # @param max_redirects [Integer] hops allowed after the first request
-        # @param redirect [Symbol] :any_https follows an https redirect to
-        #   any host — correct for public downloads. :same_origin refuses
-        #   to leave the original scheme/host/port, which is what a
-        #   request carrying a credential needs: +headers+ travel with
-        #   every hop, so a cross-host redirect would hand the secret to
-        #   whoever answered.
+        # @param redirect_policy [Symbol] :any_https follows an https
+        #   redirect to any host — correct for public downloads.
+        #   :same_origin refuses to leave the original host/port, which
+        #   is what a request carrying a credential needs: +headers+
+        #   travel with every hop, so a cross-host redirect would hand
+        #   the secret to whoever answered.
         # @return [String] the response body
-        # @raise [OpenURI::HTTPError] on a non-2xx terminal response, a
-        #   non-https hop, or a missing Location
-        # @raise [ArgumentError] if +url+ is not https
+        # @raise [OpenURI::HTTPError] on a non-2xx terminal response, or
+        #   any redirect this client refuses to follow — non-https,
+        #   cross-origin while credentialed, missing or unparseable
+        #   Location, a loop, or too many hops
+        # @raise [ArgumentError] if +url+ is not https, or
+        #   +redirect_policy+ is not one of REDIRECT_POLICIES
         def get(url, headers: {}, open_timeout: OPEN_TIMEOUT,
                 read_timeout: READ_TIMEOUT, max_redirects: MAX_REDIRECTS,
-                redirect: :any_https)
+                redirect_policy: :any_https)
+          validate_policy(redirect_policy)
           uri = parse_https(url)
           origin = uri.dup
           seen = [uri.to_s]
@@ -80,7 +94,7 @@ module Ammitto
             response = request(uri, headers, open_timeout, read_timeout)
             return response.body if response.is_a?(Net::HTTPSuccess)
 
-            uri = redirect_target(response, uri, origin, redirect, seen)
+            uri = redirect_target(response, uri, origin, redirect_policy, seen)
             seen << uri.to_s
           end
 
@@ -90,6 +104,15 @@ module Ammitto
         end
 
         private
+
+        # @raise [ArgumentError] on an unrecognised policy
+        def validate_policy(policy)
+          return if REDIRECT_POLICIES.include?(policy)
+
+          raise ArgumentError,
+                'redirect_policy must be one of ' \
+                "#{REDIRECT_POLICIES.inspect}, got: #{policy.inspect}"
+        end
 
         # Anything that is not a usable https URL is refused the same
         # way, whether it parses to another scheme or does not parse at
@@ -112,7 +135,7 @@ module Ammitto
         # Resolves one redirect, or raises if it must not be followed.
         #
         # @return [URI::HTTPS]
-        def redirect_target(response, uri, origin, redirect, seen)
+        def redirect_target(response, uri, origin, redirect_policy, seen)
           unless REDIRECT_CODES.include?(response.code)
             raise OpenURI::HTTPError.new(
               "#{response.code} #{response.message}", nil
@@ -126,20 +149,31 @@ module Ammitto
             )
           end
 
-          target = URI.join(uri.to_s, location)
-          check_hop(target, origin, redirect, seen)
+          # A server that sends a Location we cannot parse is a failed
+          # redirect, not a caller error — it surfaces as the same
+          # OpenURI::HTTPError every other refused hop raises, so
+          # callers need one rescue rather than two.
+          target = begin
+            URI.join(uri.to_s, location)
+          rescue URI::InvalidURIError => e
+            raise OpenURI::HTTPError.new(
+              "#{response.code} unparseable Location: #{e.message}", nil
+            )
+          end
+
+          check_hop(target, origin, redirect_policy, seen)
           target
         end
 
         # @raise [OpenURI::HTTPError] if the hop breaks policy
-        def check_hop(target, origin, redirect, seen)
+        def check_hop(target, origin, redirect_policy, seen)
           unless target.is_a?(URI::HTTPS)
             raise OpenURI::HTTPError.new(
               "redirection to non-https forbidden: #{target}", nil
             )
           end
 
-          if redirect == :same_origin && !same_origin?(target, origin)
+          if redirect_policy == :same_origin && !same_origin?(target, origin)
             raise OpenURI::HTTPError.new(
               'cross-origin redirect forbidden for a credentialed ' \
               "request: #{target}", nil
@@ -158,14 +192,20 @@ module Ammitto
 
         # One GET; the caller's loop owns redirect following.
         #
-        # Net::HTTP.start's proxy argument is left at its default so the
-        # environment's proxy settings keep applying, and
-        # Accept-Encoding is never set so gzip stays transparent.
+        # The proxy is resolved per-URI rather than left to
+        # Net::HTTP's :ENV default — see the class comment. A nil proxy
+        # means "go direct", which is exactly what find_proxy returns
+        # when no_proxy matches or nothing is configured.
+        #
+        # Accept-Encoding is never set, so Net::HTTP::Get advertises the
+        # encodings it can decode and gzip stays transparent.
         #
         # @return [Net::HTTPResponse]
         def request(uri, headers, open_timeout, read_timeout)
+          proxy = uri.find_proxy
           Net::HTTP.start(
             uri.host, uri.port,
+            proxy&.host, proxy&.port, proxy&.user, proxy&.password,
             use_ssl: true,
             open_timeout: open_timeout, read_timeout: read_timeout
           ) do |http|

--- a/lib/ammitto/extractors/http_client.rb
+++ b/lib/ammitto/extractors/http_client.rb
@@ -64,8 +64,10 @@ module Ammitto
         # Fetches +url+ and returns the response body.
         #
         # @param url [String] an https URL
-        # @param headers [Hash] request headers, sent on every hop
-        #   unless +redirect_policy+ is :same_origin
+        # @param headers [Hash] request headers, sent unchanged on
+        #   every hop. They are never stripped — a credentialed request
+        #   is protected by refusing the hop, not by dropping the
+        #   header, which is why +redirect_policy+ exists.
         # @param open_timeout [Integer] seconds to wait for the connection
         # @param read_timeout [Integer] seconds to wait for the body
         # @param max_redirects [Integer] hops allowed after the first request

--- a/lib/ammitto/extractors/nz_extractor.rb
+++ b/lib/ammitto/extractors/nz_extractor.rb
@@ -64,8 +64,15 @@ module Ammitto
         @temp_file.path
       end
 
-      # Clean up temp file after processing
+      # Clean up temp file after processing.
+      #
+      # Closes before unlinking: Tempfile#unlink removes the pathname
+      # but leaves the descriptor open until GC, so unlink-only left a
+      # live handle on a file nobody could find — and on platforms that
+      # refuse to unlink an open file it raises, which on the failure
+      # path would replace the download error that actually mattered.
       def cleanup
+        @temp_file&.close
         @temp_file&.unlink
         @temp_file = nil
       end

--- a/lib/ammitto/extractors/nz_extractor.rb
+++ b/lib/ammitto/extractors/nz_extractor.rb
@@ -49,6 +49,11 @@ module Ammitto
         # just-created temp file before re-raising, so a network error
         # cannot strand it until process exit — FetchCommand's ensure
         # block only owns files that reached the parser.
+        #
+        # Disposal must never become the reported failure: a 403 is this
+        # source's expected error and is what the operator needs to see,
+        # so a cleanup that raises on top of it is swallowed rather than
+        # allowed to overwrite the cause.
         @temp_file = Tempfile.new(['nz_sanctions', '.xlsx'])
         begin
           @temp_file.binmode
@@ -57,7 +62,11 @@ module Ammitto
           )
           @temp_file.close
         rescue StandardError
-          cleanup
+          begin
+            cleanup
+          rescue StandardError
+            nil
+          end
           raise
         end
 

--- a/lib/ammitto/extractors/nz_extractor.rb
+++ b/lib/ammitto/extractors/nz_extractor.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'base_extractor'
+require_relative 'http_client'
 require_relative 'registry'
 
 module Ammitto
@@ -17,6 +18,10 @@ module Ammitto
 
       # URL for Russia Sanctions Register (XLSX)
       RUSSIA_SANCTIONS_URL = 'https://www.mfat.govt.nz/assets/Countries-and-Regions/Europe/Ukraine/Russia-Sanctions-Register.xlsx'
+
+      # MFAT serves the register only to a browser-shaped agent; this is
+      # the string the open-uri download sent.
+      USER_AGENT = 'Mozilla/5.0'
 
       # @return [Symbol] the source code
       def code
@@ -36,17 +41,25 @@ module Ammitto
       # Fetch raw data from New Zealand (XLSX format)
       # @return [String] path to downloaded XLSX temp file
       def fetch
-        require 'open-uri'
         require 'tempfile'
 
         puts "[#{code}] Downloading XLSX from: #{api_endpoint}" if verbose
 
-        # Download XLSX to temp file
+        # Download XLSX to temp file. A failed download disposes of the
+        # just-created temp file before re-raising, so a network error
+        # cannot strand it until process exit — FetchCommand's ensure
+        # block only owns files that reached the parser.
         @temp_file = Tempfile.new(['nz_sanctions', '.xlsx'])
-        URI.open(api_endpoint, 'User-Agent' => 'Mozilla/5.0') do |remote_file|
-          @temp_file.write(remote_file.read)
+        begin
+          @temp_file.binmode
+          @temp_file.write(
+            HttpClient.get(api_endpoint, headers: { 'User-Agent' => USER_AGENT })
+          )
+          @temp_file.close
+        rescue StandardError
+          cleanup
+          raise
         end
-        @temp_file.close
 
         @temp_file.path
       end

--- a/spec/ammitto/extractors/http_client_spec.rb
+++ b/spec/ammitto/extractors/http_client_spec.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ammitto/extractors/http_client'
+
+RSpec.describe Ammitto::Extractors::HttpClient do
+  # Every example stubs Net::HTTP.start, so nothing here touches the
+  # network. That proves this client's DECISIONS — which hops it will
+  # follow, which it refuses, what it sends. It cannot prove that a
+  # government server still accepts our user agent or that its real
+  # redirect chain matches these assumptions; only a live scheduled
+  # fetch proves that.
+  let(:url) { 'https://example.gov/list.xlsx' }
+
+  # Builds a real Net::HTTPResponse so subclass checks (HTTPSuccess,
+  # HTTPNotModified, ...) behave exactly as they do in production.
+  def response(code, body: '', location: nil)
+    klass = Net::HTTPResponse::CODE_TO_OBJ.fetch(code)
+    res = klass.new('1.1', code, 'msg')
+    res['Location'] = location if location
+    allow(res).to receive(:body).and_return(body)
+    res
+  end
+
+  # Records each requested URI and replays +responses+ in order.
+  def stub_hops(*responses)
+    requested = []
+    allow(Net::HTTP).to receive(:start) do |host, _port, **opts, &block|
+      http = instance_double(Net::HTTP)
+      allow(http).to receive(:request) do |req|
+        requested << { host: host, path: req.path, headers: req,
+                       use_ssl: opts[:use_ssl],
+                       open_timeout: opts[:open_timeout],
+                       read_timeout: opts[:read_timeout] }
+        responses[requested.size - 1]
+      end
+      block.call(http)
+    end
+    requested
+  end
+
+  describe 'the happy path' do
+    it 'returns the body of a 200' do
+      stub_hops(response('200', body: 'PAYLOAD'))
+
+      expect(described_class.get(url)).to eq('PAYLOAD')
+    end
+
+    it 'sends the caller headers and always uses TLS' do
+      hops = stub_hops(response('200'))
+
+      described_class.get(url, headers: { 'User-Agent' => 'Mozilla/5.0' })
+
+      expect(hops.first[:headers]['User-Agent']).to eq('Mozilla/5.0')
+      expect(hops.first[:use_ssl]).to be(true)
+    end
+
+    it 'applies the default timeouts, and the caller overrides them' do
+      hops = stub_hops(response('200'), response('200'))
+
+      described_class.get(url)
+      described_class.get(url, open_timeout: 120, read_timeout: 600)
+
+      expect(hops[0].values_at(:open_timeout, :read_timeout)).to eq([60, 60])
+      expect(hops[1].values_at(:open_timeout, :read_timeout)).to eq([120, 600])
+    end
+
+    it 'leaves Accept-Encoding unset so gzip stays transparent' do
+      hops = stub_hops(response('200'))
+
+      described_class.get(url)
+
+      # Net::HTTP::Get sets its own decodable encodings and decodes the
+      # body only while the caller has not overridden the header.
+      expect(hops.first[:headers].decode_content).to be(true)
+    end
+  end
+
+  describe 'redirects' do
+    %w[301 302 303 307 308].each do |code|
+      it "follows a #{code} to another https host" do
+        stub_hops(
+          response(code, location: 'https://cdn.example.gov/f.xlsx'),
+          response('200', body: 'MOVED')
+        )
+
+        expect(described_class.get(url)).to eq('MOVED')
+      end
+    end
+
+    it 'resolves a relative Location against the current URI' do
+      hops = stub_hops(
+        response('302', location: '/elsewhere/f.xlsx'),
+        response('200')
+      )
+
+      described_class.get(url)
+
+      expect(hops.last[:host]).to eq('example.gov')
+      expect(hops.last[:path]).to eq('/elsewhere/f.xlsx')
+    end
+
+    it 'refuses a downgrade to http' do
+      stub_hops(response('302', location: 'http://example.gov/f.xlsx'))
+
+      expect { described_class.get(url) }
+        .to raise_error(OpenURI::HTTPError, /non-https forbidden/)
+    end
+
+    it 'refuses a redirect to a non-http scheme' do
+      stub_hops(response('302', location: 'ftp://example.gov/f.xlsx'))
+
+      expect { described_class.get(url) }
+        .to raise_error(OpenURI::HTTPError, /non-https forbidden/)
+    end
+
+    it 'refuses a redirect that carries no Location' do
+      stub_hops(response('302'))
+
+      expect { described_class.get(url) }
+        .to raise_error(OpenURI::HTTPError, /without a Location/)
+    end
+
+    it 'refuses a loop rather than spending every hop on it' do
+      stub_hops(
+        response('302', location: 'https://example.gov/b'),
+        response('302', location: 'https://example.gov/list.xlsx')
+      )
+
+      expect { described_class.get(url) }
+        .to raise_error(OpenURI::HTTPError, /redirect loop/)
+    end
+
+    it 'allows exactly max_redirects hops' do
+      hops = stub_hops(
+        response('302', location: 'https://example.gov/a'),
+        response('302', location: 'https://example.gov/b'),
+        response('302', location: 'https://example.gov/c'),
+        response('200', body: 'THIRD')
+      )
+
+      expect(described_class.get(url)).to eq('THIRD')
+      expect(hops.size).to eq(4) # the initial request plus three hops
+    end
+
+    it 'stops one hop later' do
+      stub_hops(
+        response('302', location: 'https://example.gov/a'),
+        response('302', location: 'https://example.gov/b'),
+        response('302', location: 'https://example.gov/c'),
+        response('302', location: 'https://example.gov/d')
+      )
+
+      expect { described_class.get(url) }
+        .to raise_error(OpenURI::HTTPError, /more than 3 redirects/)
+    end
+
+    # 304 is a Net::HTTPRedirection subclass but carries no Location.
+    # Testing for the superclass instead of the status list turns this
+    # response into a crash.
+    # The message is matched whole on purpose. Testing for the
+    # superclass instead of the status list ALSO produces a 304-prefixed
+    # error ("304 redirect without a Location"), so a loose /^304 /
+    # match passes against the very mistake this example exists to
+    # catch.
+    it 'treats 304 as a terminal response, not a redirect' do
+      stub_hops(response('304'))
+
+      expect { described_class.get(url) }
+        .to raise_error(OpenURI::HTTPError, /\A304 msg\z/)
+    end
+  end
+
+  describe 'credentialed requests' do
+    # Headers travel with every hop, so a request carrying a key must
+    # not be allowed to leave its origin.
+    let(:key) { { 'apikey' => 'SECRET' } }
+
+    it 'refuses to carry credentials to another host' do
+      stub_hops(response('302', location: 'https://elsewhere.example/f'))
+
+      expect do
+        described_class.get(url, headers: key, redirect: :same_origin)
+      end.to raise_error(OpenURI::HTTPError, /cross-origin redirect forbidden/)
+    end
+
+    it 'still follows a redirect within the same origin' do
+      hops = stub_hops(
+        response('302', location: 'https://example.gov/v2/list.xlsx'),
+        response('200', body: 'SAME')
+      )
+
+      result = described_class.get(url, headers: key, redirect: :same_origin)
+
+      expect(result).to eq('SAME')
+      expect(hops.last[:headers]['apikey']).to eq('SECRET')
+    end
+  end
+
+  describe 'refusals before any request is made' do
+    it 'rejects an http URL' do
+      expect { described_class.get('http://example.gov/f') }
+        .to raise_error(ArgumentError, /https required/)
+    end
+
+    it 'rejects the pipe form Security/Open warns about' do
+      expect { described_class.get('|whoami') }
+        .to raise_error(ArgumentError, /https required/)
+    end
+  end
+
+  describe 'terminal failures' do
+    it 'raises the error class the open-uri download raised' do
+      stub_hops(response('403'))
+
+      expect { described_class.get(url) }
+        .to raise_error(OpenURI::HTTPError, /403/)
+    end
+  end
+end

--- a/spec/ammitto/extractors/http_client_spec.rb
+++ b/spec/ammitto/extractors/http_client_spec.rb
@@ -23,12 +23,15 @@ RSpec.describe Ammitto::Extractors::HttpClient do
   end
 
   # Records each requested URI and replays +responses+ in order.
+  # The proxy arrives as positional args (p_addr, p_port, ...), so they
+  # are captured rather than ignored — the proxy contract is asserted.
   def stub_hops(*responses)
     requested = []
-    allow(Net::HTTP).to receive(:start) do |host, _port, **opts, &block|
+    allow(Net::HTTP).to receive(:start) do |host, _port, *pos, **opts, &block|
       http = instance_double(Net::HTTP)
       allow(http).to receive(:request) do |req|
         requested << { host: host, path: req.path, headers: req,
+                       proxy: [pos[0], pos[1]],
                        use_ssl: opts[:use_ssl],
                        open_timeout: opts[:open_timeout],
                        read_timeout: opts[:read_timeout] }
@@ -37,6 +40,15 @@ RSpec.describe Ammitto::Extractors::HttpClient do
       block.call(http)
     end
     requested
+  end
+
+  # Sets env vars for the block and restores them afterwards.
+  def with_env(vars)
+    previous = vars.keys.to_h { |k| [k, ENV.fetch(k, nil)] }
+    vars.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
+    yield
+  ensure
+    previous.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
   end
 
   describe 'the happy path' do
@@ -65,14 +77,43 @@ RSpec.describe Ammitto::Extractors::HttpClient do
       expect(hops[1].values_at(:open_timeout, :read_timeout)).to eq([120, 600])
     end
 
-    it 'leaves Accept-Encoding unset so gzip stays transparent' do
+    # Narrow claim on purpose: Net::HTTP.start is stubbed, so no real
+    # body is ever decompressed here. What this proves is that the
+    # request is still ELIGIBLE for automatic decoding — Net::HTTP::Get
+    # generated its own Accept-Encoding and nothing overrode it. Real
+    # decompression is Ruby's, and only a live fetch exercises it.
+    it 'leaves the request eligible for automatic gzip decoding' do
       hops = stub_hops(response('200'))
 
       described_class.get(url)
 
-      # Net::HTTP::Get sets its own decodable encodings and decodes the
-      # body only while the caller has not overridden the header.
       expect(hops.first[:headers].decode_content).to be(true)
+    end
+
+    # The proxy must be resolved per-URI. Net::HTTP's own :ENV default
+    # reads http_proxy and IGNORES https_proxy on Ruby 3.3/3.4, so an
+    # operator behind an https-only proxy would silently go direct —
+    # which is not what open-uri did.
+    it 'honours https_proxy, which Net::HTTP\'s own default ignores' do
+      hops = stub_hops(response('200'))
+
+      with_env('https_proxy' => 'http://proxy.local:8080',
+               'http_proxy' => nil, 'no_proxy' => nil) do
+        described_class.get(url)
+      end
+
+      expect(hops.first[:proxy]).to eq(['proxy.local', 8080])
+    end
+
+    it 'goes direct when no_proxy covers the host' do
+      hops = stub_hops(response('200'))
+
+      with_env('https_proxy' => 'http://proxy.local:8080',
+               'http_proxy' => nil, 'no_proxy' => 'example.gov') do
+        described_class.get(url)
+      end
+
+      expect(hops.first[:proxy]).to eq([nil, nil])
     end
   end
 
@@ -119,6 +160,28 @@ RSpec.describe Ammitto::Extractors::HttpClient do
 
       expect { described_class.get(url) }
         .to raise_error(OpenURI::HTTPError, /without a Location/)
+    end
+
+    it 'refuses a Location that cannot be parsed, as the same error' do
+      stub_hops(response('302', location: 'http://[bad'))
+
+      expect { described_class.get(url) }
+        .to raise_error(OpenURI::HTTPError, /unparseable Location/)
+    end
+
+    # Headers travel with every hop by design. A mutant that dropped
+    # them after the first request would otherwise survive, since the
+    # credential examples only exercise the :same_origin branch.
+    it 'carries the caller headers across a cross-host hop' do
+      hops = stub_hops(
+        response('302', location: 'https://cdn.example.gov/f.xlsx'),
+        response('200')
+      )
+
+      described_class.get(url, headers: { 'User-Agent' => 'Mozilla/5.0' })
+
+      expect(hops.last[:host]).to eq('cdn.example.gov')
+      expect(hops.last[:headers]['User-Agent']).to eq('Mozilla/5.0')
     end
 
     it 'refuses a loop rather than spending every hop on it' do
@@ -180,7 +243,7 @@ RSpec.describe Ammitto::Extractors::HttpClient do
       stub_hops(response('302', location: 'https://elsewhere.example/f'))
 
       expect do
-        described_class.get(url, headers: key, redirect: :same_origin)
+        described_class.get(url, headers: key, redirect_policy: :same_origin)
       end.to raise_error(OpenURI::HTTPError, /cross-origin redirect forbidden/)
     end
 
@@ -190,10 +253,28 @@ RSpec.describe Ammitto::Extractors::HttpClient do
         response('200', body: 'SAME')
       )
 
-      result = described_class.get(url, headers: key, redirect: :same_origin)
+      result = described_class.get(url, headers: key,
+                                        redirect_policy: :same_origin)
 
       expect(result).to eq('SAME')
       expect(hops.last[:headers]['apikey']).to eq('SECRET')
+    end
+
+    # A misspelled policy previously fell through to :any_https, which
+    # silently disabled the credential boundary. Nothing in the request
+    # would have looked wrong.
+    it 'refuses an unrecognised policy instead of defaulting to open' do
+      expect do
+        described_class.get(url, headers: key, redirect_policy: :same_orgin)
+      end.to raise_error(ArgumentError, /redirect_policy must be one of/)
+    end
+
+    it 'refuses the policy before making any request' do
+      hops = stub_hops(response('200'))
+
+      expect { described_class.get(url, redirect_policy: :nope) }
+        .to raise_error(ArgumentError)
+      expect(hops).to be_empty
     end
   end
 

--- a/spec/ammitto/extractors/http_client_spec.rb
+++ b/spec/ammitto/extractors/http_client_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Ammitto::Extractors::HttpClient do
       allow(http).to receive(:request) do |req|
         requested << { host: host, path: req.path, headers: req,
                        proxy: [pos[0], pos[1]],
+                       proxy_auth: [pos[2], pos[3]],
                        use_ssl: opts[:use_ssl],
                        open_timeout: opts[:open_timeout],
                        read_timeout: opts[:read_timeout] }
@@ -103,6 +104,17 @@ RSpec.describe Ammitto::Extractors::HttpClient do
       end
 
       expect(hops.first[:proxy]).to eq(['proxy.local', 8080])
+    end
+
+    it 'carries proxy credentials from the environment URL' do
+      hops = stub_hops(response('200'))
+
+      with_env('https_proxy' => 'http://alice:s3cret@proxy.local:8080',
+               'http_proxy' => nil, 'no_proxy' => nil) do
+        described_class.get(url)
+      end
+
+      expect(hops.first[:proxy_auth]).to eq(%w[alice s3cret])
     end
 
     it 'goes direct when no_proxy covers the host' do

--- a/spec/ammitto/extractors/nz_extractor_spec.rb
+++ b/spec/ammitto/extractors/nz_extractor_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ammitto/extractors/nz_extractor'
+
+RSpec.describe Ammitto::Extractors::NzExtractor do
+  # The helper's own examples prove which hops it follows. They prove
+  # nothing about this extractor's temp-file lifecycle, which is where
+  # the real risk lives: a download that fails after the Tempfile is
+  # created must not strand it, because FetchCommand's ensure block
+  # only disposes of files that reached the parser.
+  subject(:extractor) { described_class.new }
+
+  let(:client) { Ammitto::Extractors::HttpClient }
+
+  describe '#fetch' do
+    it 'writes the downloaded bytes and returns a readable path' do
+      allow(client).to receive(:get).and_return("PK\x03\x04binary")
+
+      path = extractor.fetch
+
+      expect(File.binread(path)).to eq("PK\x03\x04binary")
+    ensure
+      extractor.cleanup
+    end
+
+    it 'sends the user agent MFAT requires' do
+      allow(client).to receive(:get).and_return('x')
+
+      extractor.fetch
+
+      expect(client).to have_received(:get).with(
+        described_class::RUSSIA_SANCTIONS_URL,
+        headers: { 'User-Agent' => described_class::USER_AGENT }
+      )
+    ensure
+      extractor.cleanup
+    end
+
+    it 'closes the file it hands to the parser' do
+      allow(client).to receive(:get).and_return('x')
+
+      extractor.fetch
+
+      expect(extractor.instance_variable_get(:@temp_file)).to be_closed
+    ensure
+      extractor.cleanup
+    end
+
+    context 'when the download fails' do
+      before { allow(client).to receive(:get).and_raise(OpenURI::HTTPError.new('403', nil)) }
+
+      it 're-raises the original error rather than a cleanup error' do
+        expect { extractor.fetch }.to raise_error(OpenURI::HTTPError, /403/)
+      end
+
+      it 'leaves no temp file on disk' do
+        paths = []
+        allow(Tempfile).to receive(:new).and_wrap_original do |orig, *args|
+          orig.call(*args).tap { |f| paths << f.path }
+        end
+
+        expect { extractor.fetch }.to raise_error(OpenURI::HTTPError)
+
+        expect(paths).not_to be_empty
+        expect(paths.select { |p| File.exist?(p) }).to be_empty
+      end
+
+      it 'closes the descriptor, not just the pathname' do
+        files = []
+        allow(Tempfile).to receive(:new).and_wrap_original do |orig, *args|
+          orig.call(*args).tap { |f| files << f }
+        end
+
+        expect { extractor.fetch }.to raise_error(OpenURI::HTTPError)
+
+        # unlink alone removes the name and leaves the handle open until
+        # GC — the defect this example exists to catch.
+        expect(files.first).to be_closed
+      end
+    end
+  end
+
+  describe '#cleanup' do
+    it 'is safe to call twice' do
+      allow(client).to receive(:get).and_return('x')
+      extractor.fetch
+
+      expect { 2.times { extractor.cleanup } }.not_to raise_error
+    end
+
+    it 'is safe to call when nothing was ever fetched' do
+      expect { extractor.cleanup }.not_to raise_error
+    end
+  end
+end

--- a/spec/ammitto/extractors/nz_extractor_spec.rb
+++ b/spec/ammitto/extractors/nz_extractor_spec.rb
@@ -54,6 +54,20 @@ RSpec.describe Ammitto::Extractors::NzExtractor do
         expect { extractor.fetch }.to raise_error(OpenURI::HTTPError, /403/)
       end
 
+      # The download error is what the operator has to act on. A
+      # platform that refuses to unlink an open file, or any other
+      # disposal failure, must not overwrite it with a less useful
+      # error about a temp file.
+      it 'still reports the download error when cleanup itself fails' do
+        allow(Tempfile).to receive(:new).and_wrap_original do |orig, *args|
+          orig.call(*args).tap do |f|
+            allow(f).to receive(:unlink).and_raise(Errno::EACCES)
+          end
+        end
+
+        expect { extractor.fetch }.to raise_error(OpenURI::HTTPError, /403/)
+      end
+
       it 'leaves no temp file on disk' do
         paths = []
         allow(Tempfile).to receive(:new).and_wrap_original do |orig, *args|


### PR DESCRIPTION
This PR adds `Ammitto::Extractors::HttpClient`, a shared HTTPS
downloader, and moves `NzExtractor` onto it as the pilot. It is the
first of four PRs replacing the `URI.open` family across the extractors.

RuboCop grandfathers `Security/Open` for nine extractors. That cop
warns because `URI.open` runs a subprocess when handed a string
beginning `|`, but every call site here builds its URL from a committed
literal, so the pipe form was never reachable — this is not a fix for
an exploitable defect and is not presented as one. The real gain is
that open-uri's behaviour varies across the supported Ruby range: on
3.3 it applies no numeric redirect cap at all, while 3.4 and 4.0 allow
64. One shared client gives every source the same written-down policy.

## Changes

- Add `lib/ammitto/extractors/http_client.rb`. HTTPS-only at every hop,
  an explicit `301/302/303/307/308` redirect list, a 3-hop cap and loop
  detection. `Net::HTTPRedirection` is deliberately not used as the
  test: `304 Not Modified` is one of its subclasses and carries no
  `Location`, so following it blindly turns a valid response into a
  crash.
- Resolve the proxy with `URI#find_proxy` per hop rather than relying on
  `Net::HTTP`'s `:ENV` default. They are not equivalent — on Ruby 3.3
  and 3.4 that default reads `http_proxy` and ignores `https_proxy`, so
  an operator behind an https-only proxy would silently have gone
  direct. `no_proxy` and proxy credentials are preserved.
- Add a `redirect_policy:` of `:any_https` or `:same_origin`, validated
  before the first request. Headers travel with every hop, so a
  credentialed request needs the origin boundary — this is what the
  World Bank `apikey` will use in PR 4. An unrecognised value raises
  rather than falling through to the permissive branch.
- Raise `OpenURI::HTTPError` for every refused hop, including an
  unparseable `Location`, so callers keep one rescue rather than two.
- Move `NzExtractor` onto the client, add `binmode`, and dispose of the
  temp file when the download fails. `cleanup` now closes before
  unlinking: `Tempfile#unlink` removes the pathname but leaves the
  descriptor open until GC. A disposal error is swallowed so it cannot
  replace the download error the operator needs to see.
- Drop `nz_extractor.rb` from the `Security/Open` exclusions.

Timeouts stay at Net::HTTP's 60/60 defaults, which is what open-uri was
already applying, and `Accept-Encoding` is never set so gzip decoding
stays transparent. Callers that chose their own timeouts keep them.

## Test plan

- `bundle exec rspec` — 1496 examples, 0 failures, 4 pending.
- `bundle exec rubocop` — 424 files, no offenses.
- New `spec/ammitto/extractors/http_client_spec.rb` and
  `spec/ammitto/extractors/nz_extractor_spec.rb`, 65 examples together.
  Every example stubs `Net::HTTP.start`, so nothing contacts the
  network. That proves which hops the client follows and refuses; it
  does not prove a government server still accepts our user agent.
  Only the first live scheduled fetch proves that.
- The guards were mutation-tested rather than assumed. Dropping
  `find_proxy`, dropping the policy validation, unlinking without
  closing, removing the failure cleanup, allowing `URI::HTTP` hops,
  dropping the same-origin check, dropping loop detection, and testing
  `Net::HTTPRedirection` instead of the status list each turn the suite
  red.
