### PR TITLE
Publish organization and document-type page summaries

### DIFF
--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -670,6 +670,26 @@ module Ammitto
           ['.', '..'].include?(component)
       end
 
+      # True when +component+ cannot become a filename.
+      #
+      # Stricter than #unusable_path_component?, which asks only whether a
+      # component would escape the node tree. This adds the characters that
+      # are legal in a POSIX filename but not a Windows one, so a component
+      # is refused identically on every platform rather than writing fine on
+      # Linux and raising Errno::EINVAL on Windows — a difference CI found
+      # in exactly that asymmetric way.
+      #
+      # ?, # and % are also the URL-significant characters that would make
+      # the published path ambiguous to a consumer even where the
+      # filesystem accepts them, which is why the two concerns share one
+      # rule instead of two that drift apart.
+      #
+      # @param component [String] candidate path component
+      # @return [Boolean]
+      def unusable_filename_component?(component)
+        unusable_path_component?(component) || component.match?(/[?#%]/)
+      end
+
       # Clamp an oversized slug so its "#{slug}.jsonld" filename fits the
       # 255-byte filesystem filename limit. Slugs within budget pass
       # through untouched, so existing short IRIs never change. Oversized
@@ -856,6 +876,21 @@ module Ammitto
           parts = org_id.to_s.split('/')
           source = parts.find { |p| registered_source?(p) }
           local_id = parts.last
+
+          # Refuse a component that cannot safely become a filename,
+          # rather than handing it to the filesystem and letting the
+          # answer depend on the platform. Linux accepts characters
+          # Windows rejects, so an unvalidated write here raised
+          # Errno::EINVAL on one runner while succeeding quietly on the
+          # other — and a '..' component would write outside the node
+          # tree on either. The instrument path applies the same guard.
+          [source, local_id].compact.each do |component|
+            next unless unusable_filename_component?(component)
+
+            raise Ammitto::Error,
+                  "Organization identifier #{org_id.inspect} yields " \
+                  "unusable path component #{component.inspect}"
+          end
 
           if source
             dir = File.join(@output_dir, 'node', 'organization', source)
@@ -1407,7 +1442,7 @@ module Ammitto
       def slice_path(slices_dir, identifier, kind)
         components = identifier.split('/', -1)
         components.each do |component|
-          next unless unusable_path_component?(component) || component.match?(/[?#%]/)
+          next unless unusable_filename_component?(component)
 
           raise Ammitto::Error,
                 "#{kind} identifier #{identifier.inspect} yields " \

--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -883,7 +883,9 @@ module Ammitto
           # Windows rejects, so an unvalidated write here raised
           # Errno::EINVAL on one runner while succeeding quietly on the
           # other — and a '..' component would write outside the node
-          # tree on either. The instrument path applies the same guard.
+          # tree. A component here is source or local_id only — the
+          # intermediate IRI segments are not used as path components. The
+          # instrument path applies the same guard.
           [source, local_id].compact.each do |component|
             next unless unusable_filename_component?(component)
 
@@ -1281,13 +1283,17 @@ module Ammitto
         slices_dir = File.join(@output_dir, 'by-document-type')
         FileUtils.mkdir_p(slices_dir)
 
+        # Grouped once rather than rescanned per type. Selecting inside the
+        # loop is O(types x entries), and this exporter exists to remove
+        # exactly that shape of work from the site — leaving it here would
+        # move the cost from the browser into every harmonize run.
+        by_type = pairs.group_by { |_entry, announcement| announcement['documentType'] }
+
         written = @document_types.filter_map do |type_id, type|
           identifier = type['identifier'].to_s
           next if identifier.empty?
 
-          matching = pairs.select do |_entry, announcement|
-            announcement['documentType'] == identifier
-          end
+          matching = by_type.fetch(identifier, [])
           index = {
             '@context' => @context_url,
             '@type' => 'Index',

--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -36,6 +36,9 @@ module Ammitto
       # limit (255 minus the 7-byte '.jsonld' suffix)
       MAX_SLUG_BYTES = 248
 
+      # Longest single path component the filesystem accepts
+      MAX_FILENAME_BYTES = 255
+
       # Slug prefix bytes kept when clamping an oversized slug
       CLAMP_PREFIX_BYTES = 100
 
@@ -982,8 +985,14 @@ module Ammitto
         export_slices_by_list
         export_slices_by_status
         export_slices_by_entity_type
-        export_slices_by_organization
-        export_slices_by_document_type
+
+        # Both page slices aggregate the same announcements, so they are
+        # collected once here and passed down rather than cached on the
+        # exporter: a memo would go stale the moment a caller added another
+        # node and exported again.
+        pairs = announcement_pairs
+        export_slices_by_organization(pairs)
+        export_slices_by_document_type(pairs)
       end
 
       # Export slices by authority
@@ -1201,8 +1210,9 @@ module Ammitto
       # The organization page renders three lists — documents the
       # organization published, signed and authorized — so each slice
       # carries those three arrays, already deduplicated and counted.
+      # @param pairs [Array<Array(Hash, Hash)>] entry/announcement pairs
       # @return [void]
-      def export_slices_by_organization
+      def export_slices_by_organization(pairs)
         slices_dir = File.join(@output_dir, 'by-organization')
         FileUtils.mkdir_p(slices_dir)
 
@@ -1215,9 +1225,9 @@ module Ammitto
             '@type' => 'Index',
             'slice' => 'by-organization',
             'organization' => { '@id' => org_id },
-            'published' => announcement_summaries(matching_role('publisher', identifier)),
-            'signed' => announcement_summaries(matching_role('signatory', identifier)),
-            'authorized' => announcement_summaries(matching_role('authority', identifier))
+            'published' => announcement_summaries(matching_role(pairs, 'publisher', identifier)),
+            'signed' => announcement_summaries(matching_role(pairs, 'signatory', identifier)),
+            'authorized' => announcement_summaries(matching_role(pairs, 'authority', identifier))
           }
           write_json(slice_path(slices_dir, identifier, 'Organization'), index)
           org_id
@@ -1230,8 +1240,9 @@ module Ammitto
       #
       # The document-type page renders the announcements carrying that type
       # plus the legal instruments declaring it, so each slice carries both.
+      # @param pairs [Array<Array(Hash, Hash)>] entry/announcement pairs
       # @return [void]
-      def export_slices_by_document_type
+      def export_slices_by_document_type(pairs)
         slices_dir = File.join(@output_dir, 'by-document-type')
         FileUtils.mkdir_p(slices_dir)
 
@@ -1239,7 +1250,7 @@ module Ammitto
           identifier = type['identifier'].to_s
           next if identifier.empty?
 
-          matching = announcement_pairs.select do |_entry, announcement|
+          matching = pairs.select do |_entry, announcement|
             announcement['documentType'] == identifier
           end
           index = {
@@ -1283,7 +1294,7 @@ module Ammitto
       # @entries.keys.sort, so this walks the same sequence.
       # @return [Array<Array(Hash, Hash)>] entry/announcement pairs
       def announcement_pairs
-        @announcement_pairs ||= @entries.keys.sort.filter_map do |id|
+        @entries.keys.sort.filter_map do |id|
           entry = @entries[id]
           announcement = entry['announcement']
           [entry, announcement] if announcement.is_a?(Hash)
@@ -1298,14 +1309,18 @@ module Ammitto
       # That is over-inclusive — a parent organization absorbs every child
       # whose identifier extends it — but reproducing it is deliberate:
       # this change moves the aggregation, it does not redefine it.
-      # Non-string values are skipped rather than coerced, because
-      # OfficialAnnouncement declares these fields as strings and
-      # stringifying anything else would invent matches the page never made.
+      #
+      # Strings are the whole contract: OfficialAnnouncement declares
+      # publisher, signatory and authority as strings. Anything else is
+      # skipped rather than matched, which is a deliberate narrowing, not
+      # equivalence — JavaScript would have treated an array as a member
+      # test and thrown on a number, aborting the page's whole scan.
+      # @param pairs [Array<Array(Hash, Hash)>] entry/announcement pairs
       # @param role [String] announcement field naming the organization
       # @param identifier [String] organization identifier
       # @return [Array<Array(Hash, Hash)>] matching pairs
-      def matching_role(role, identifier)
-        announcement_pairs.select do |_entry, announcement|
+      def matching_role(pairs, role, identifier)
+        pairs.select do |_entry, announcement|
           value = announcement[role]
           value.is_a?(String) && value.include?(identifier)
         end
@@ -1365,10 +1380,12 @@ module Ammitto
         end
       end
 
-      # Whether JavaScript would treat this value as falsy where the page
-      # writes `value || fallback`. Ruby counts "" as truthy and JavaScript
-      # does not, so a blank document id has to reach the same 'unknown'
-      # bucket the page puts it in.
+      # Whether the page's `value || fallback` would take the fallback.
+      #
+      # Covers the two shapes a declared-string field takes, absent and
+      # empty, rather than JavaScript falsiness in general: Ruby counts ""
+      # as truthy and JavaScript does not, so a blank document id has to
+      # reach the same 'unknown' bucket the page puts it in.
       # @param value [Object] value to test
       # @return [Boolean]
       def js_blank?(value)
@@ -1398,10 +1415,15 @@ module Ammitto
         end
 
         filename = components.pop
-        if filename.bytesize > MAX_SLUG_BYTES
+        # Directory components spend the whole 255-byte budget; the last
+        # one also has to fit its '.jsonld' suffix, which is what
+        # MAX_SLUG_BYTES already accounts for.
+        oversized = components.find { |c| c.bytesize > MAX_FILENAME_BYTES }
+        oversized ||= filename if filename.bytesize > MAX_SLUG_BYTES
+        if oversized
           raise Ammitto::Error,
                 "#{kind} identifier #{identifier.inspect} is too long: " \
-                "#{filename.inspect} exceeds #{MAX_SLUG_BYTES} bytes"
+                "#{oversized.inspect} exceeds the filename byte budget"
         end
         if components.empty? && filename == 'index'
           raise Ammitto::Error,

--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -670,19 +670,27 @@ module Ammitto
           ['.', '..'].include?(component)
       end
 
-      # True when +component+ cannot become a filename.
+      # True when +component+ carries a character this exporter refuses in
+      # a published path.
       #
       # Stricter than #unusable_path_component?, which asks only whether a
-      # component would escape the node tree. This adds the characters that
-      # are legal in a POSIX filename but not a Windows one, so a component
-      # is refused identically on every platform rather than writing fine on
-      # Linux and raising Errno::EINVAL on Windows — a difference CI found
-      # in exactly that asymmetric way.
+      # component would escape the node tree. This adds ?, # and % — the
+      # URL-significant characters that make a published path ambiguous to
+      # a consumer even where the filesystem accepts them.
       #
-      # ?, # and % are also the URL-significant characters that would make
-      # the published path ambiguous to a consumer even where the
-      # filesystem accepts them, which is why the two concerns share one
-      # rule instead of two that drift apart.
+      # It is NOT a Windows-safe filename check, and must not be described
+      # as one. Windows additionally rejects < > : " | *, control
+      # characters, reserved device names such as CON and NUL, and
+      # trailing dots or spaces; none of those is covered here. What this
+      # rule does is refuse ? consistently on every platform, which is the
+      # one divergence the corpus produced — a `?` identifier wrote
+      # happily on Linux and raised Errno::EINVAL on Windows, so the same
+      # export succeeded or failed depending on the runner.
+      #
+      # Widening this to the full Windows contract is a separate decision:
+      # it would reject identifiers that publish correctly today, so it
+      # needs corpus evidence rather than a rule copied from a reference
+      # table.
       #
       # @param component [String] candidate path component
       # @return [Boolean]
@@ -883,7 +891,8 @@ module Ammitto
           # Windows rejects, so an unvalidated write here raised
           # Errno::EINVAL on one runner while succeeding quietly on the
           # other — and a '..' component would write outside the node
-          # tree. A component here is source or local_id only — the
+          # tree. The rule is not a full Windows-safe filename check — see
+          # #unusable_filename_component?. A component here is source or local_id only — the
           # intermediate IRI segments are not used as path components. The
           # instrument path applies the same guard.
           [source, local_id].compact.each do |component|

--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -397,7 +397,9 @@ module Ammitto
           File.join(@output_dir, 'by-regime'),
           File.join(@output_dir, 'by-list'),
           File.join(@output_dir, 'by-status'),
-          File.join(@output_dir, 'by-type')
+          File.join(@output_dir, 'by-type'),
+          File.join(@output_dir, 'by-organization'),
+          File.join(@output_dir, 'by-document-type')
         ]
 
         dirs.each { |dir| FileUtils.mkdir_p(dir) }
@@ -971,6 +973,8 @@ module Ammitto
       # - List (by-list/{source}/{list_type}.jsonld)
       # - Status (by-status/{status}.jsonld)
       # - Entity type (by-type/{type}.jsonld)
+      # - Organization (by-organization/{identifier}.jsonld)
+      # - Document type (by-document-type/{identifier}.jsonld)
       # @return [void]
       def export_data_slices
         export_slices_by_authority
@@ -978,6 +982,8 @@ module Ammitto
         export_slices_by_list
         export_slices_by_status
         export_slices_by_entity_type
+        export_slices_by_organization
+        export_slices_by_document_type
       end
 
       # Export slices by authority
@@ -1188,6 +1194,222 @@ module Ammitto
           'available' => by_type.keys.sort
         }
         write_json(File.join(slices_dir, 'index.jsonld'), master)
+      end
+
+      # Export page-ready slices keyed by organization
+      #
+      # The organization page renders three lists — documents the
+      # organization published, signed and authorized — so each slice
+      # carries those three arrays, already deduplicated and counted.
+      # @return [void]
+      def export_slices_by_organization
+        slices_dir = File.join(@output_dir, 'by-organization')
+        FileUtils.mkdir_p(slices_dir)
+
+        written = @organizations.filter_map do |org_id, org|
+          identifier = org['identifier'].to_s
+          next if identifier.empty?
+
+          index = {
+            '@context' => @context_url,
+            '@type' => 'Index',
+            'slice' => 'by-organization',
+            'organization' => { '@id' => org_id },
+            'published' => announcement_summaries(matching_role('publisher', identifier)),
+            'signed' => announcement_summaries(matching_role('signatory', identifier)),
+            'authorized' => announcement_summaries(matching_role('authority', identifier))
+          }
+          write_json(slice_path(slices_dir, identifier, 'Organization'), index)
+          org_id
+        end
+
+        write_slice_master(slices_dir, 'by-organization', written)
+      end
+
+      # Export page-ready slices keyed by document type
+      #
+      # The document-type page renders the announcements carrying that type
+      # plus the legal instruments declaring it, so each slice carries both.
+      # @return [void]
+      def export_slices_by_document_type
+        slices_dir = File.join(@output_dir, 'by-document-type')
+        FileUtils.mkdir_p(slices_dir)
+
+        written = @document_types.filter_map do |type_id, type|
+          identifier = type['identifier'].to_s
+          next if identifier.empty?
+
+          matching = announcement_pairs.select do |_entry, announcement|
+            announcement['documentType'] == identifier
+          end
+          index = {
+            '@context' => @context_url,
+            '@type' => 'Index',
+            'slice' => 'by-document-type',
+            'documentType' => { '@id' => type_id },
+            'announcements' => announcement_summaries(matching),
+            'legalInstruments' => instrument_summaries(identifier)
+          }
+          write_json(slice_path(slices_dir, identifier, 'Document type'), index)
+          type_id
+        end
+
+        write_slice_master(slices_dir, 'by-document-type', written)
+      end
+
+      # Write the master index a slice directory carries alongside its
+      # per-key files, matching the other slice families
+      # @param slices_dir [String] slice directory
+      # @param slice [String] slice name
+      # @param written [Array<String>] IRIs of the slices written
+      # @return [void]
+      def write_slice_master(slices_dir, slice, written)
+        master = {
+          '@context' => @context_url,
+          '@type' => 'Index',
+          'slice' => slice,
+          'available' => written.sort
+        }
+        write_json(File.join(slices_dir, 'index.jsonld'), master)
+      end
+
+      # Entries carrying an announcement, paired with it, in the order the
+      # entry index lists them.
+      #
+      # Order matters twice over: it decides which entry of a document
+      # supplies the rendered title, date, URL and group, and it decides
+      # how equal-dated documents fall once the page sorts them. The page
+      # walks node/entry/index.jsonld, which export_index_files writes as
+      # @entries.keys.sort, so this walks the same sequence.
+      # @return [Array<Array(Hash, Hash)>] entry/announcement pairs
+      def announcement_pairs
+        @announcement_pairs ||= @entries.keys.sort.filter_map do |id|
+          entry = @entries[id]
+          announcement = entry['announcement']
+          [entry, announcement] if announcement.is_a?(Hash)
+        end
+      end
+
+      # Entry/announcement pairs whose announcement names this identifier
+      # in the given role.
+      #
+      # The page tests `value === identifier || value?.includes(identifier)`.
+      # The first arm is redundant for strings, so this is a substring test.
+      # That is over-inclusive — a parent organization absorbs every child
+      # whose identifier extends it — but reproducing it is deliberate:
+      # this change moves the aggregation, it does not redefine it.
+      # Non-string values are skipped rather than coerced, because
+      # OfficialAnnouncement declares these fields as strings and
+      # stringifying anything else would invent matches the page never made.
+      # @param role [String] announcement field naming the organization
+      # @param identifier [String] organization identifier
+      # @return [Array<Array(Hash, Hash)>] matching pairs
+      def matching_role(role, identifier)
+        announcement_pairs.select do |_entry, announcement|
+          value = announcement[role]
+          value.is_a?(String) && value.include?(identifier)
+        end
+      end
+
+      # Collapse entry/announcement pairs into one summary per document.
+      #
+      # Mirrors the page's Map: keyed by document id, the first pair seen
+      # supplies every rendered field, and each further pair only raises the
+      # count. Summaries stay in first-seen order — the page still applies
+      # its own descending publishDate sort, so the ordering it renders is
+      # produced by the same comparison it always used.
+      # @param pairs [Array<Array(Hash, Hash)>] entry/announcement pairs
+      # @return [Array<Hash>] announcement summaries
+      def announcement_summaries(pairs)
+        summaries = {}
+
+        pairs.each do |entry, announcement|
+          document_id = announcement['documentId']
+          document_id = 'unknown' if js_blank?(document_id)
+
+          summary = summaries[document_id] ||= {
+            'documentId' => document_id,
+            'title' => announcement['title'],
+            'publishDate' => js_blank?(announcement['publishDate']) ? '' : announcement['publishDate'],
+            'url' => announcement['url'],
+            'groupId' => entry['groupId'],
+            'entryCount' => 0
+          }.compact
+          summary['entryCount'] += 1
+        end
+
+        summaries.values
+      end
+
+      # Summaries of the legal instruments declaring a document type,
+      # in the order the instrument index lists them (the page rendered
+      # them in index order, without sorting).
+      #
+      # `title` and `name` are passed through untouched: the page resolves
+      # a localized title itself, and resolving it here would bake one
+      # reader's language policy into the artifact.
+      # @param identifier [String] document type identifier
+      # @return [Array<Hash>] instrument summaries
+      def instrument_summaries(identifier)
+        @instruments.keys.sort.filter_map do |id|
+          instrument = @instruments[id]
+          next unless instrument['type'] == identifier
+
+          {
+            '@id' => instrument['@id'] || id,
+            'identifier' => instrument['identifier'],
+            'title' => instrument['title'],
+            'name' => instrument['name'],
+            'publishDate' => instrument['publishDate']
+          }.compact
+        end
+      end
+
+      # Whether JavaScript would treat this value as falsy where the page
+      # writes `value || fallback`. Ruby counts "" as truthy and JavaScript
+      # does not, so a blank document id has to reach the same 'unknown'
+      # bucket the page puts it in.
+      # @param value [Object] value to test
+      # @return [Boolean]
+      def js_blank?(value)
+        value.nil? || value == ''
+      end
+
+      # Path of the slice file named after a taxonomy identifier.
+      #
+      # Identifiers carry slashes ('cn/ministry-of-commerce'), so each
+      # segment becomes a directory and the last becomes the filename.
+      # Components are validated, never rewritten: sanitizing an unsafe
+      # identifier could map two distinct taxonomy entries onto one file,
+      # silently merging them. '?', '#' and '%' are rejected alongside the
+      # filesystem hazards because the site fetches this path as a URL.
+      # @param slices_dir [String] slice directory
+      # @param identifier [String] taxonomy identifier
+      # @param kind [String] taxonomy name, for the error message
+      # @return [String] absolute path of the slice file
+      def slice_path(slices_dir, identifier, kind)
+        components = identifier.split('/', -1)
+        components.each do |component|
+          next unless unusable_path_component?(component) || component.match?(/[?#%]/)
+
+          raise Ammitto::Error,
+                "#{kind} identifier #{identifier.inspect} yields " \
+                "unusable path component #{component.inspect}"
+        end
+
+        filename = components.pop
+        if filename.bytesize > MAX_SLUG_BYTES
+          raise Ammitto::Error,
+                "#{kind} identifier #{identifier.inspect} is too long: " \
+                "#{filename.inspect} exceeds #{MAX_SLUG_BYTES} bytes"
+        end
+        if components.empty? && filename == 'index'
+          raise Ammitto::Error,
+                "#{kind} identifier #{identifier.inspect} would overwrite " \
+                'the slice master index'
+        end
+
+        File.join(slices_dir, *components, "#{filename}.jsonld")
       end
 
       # Write context.jsonld to the output directory. The context is defined

--- a/spec/ammitto/serialization/json_ld_graph_exporter_page_slices_spec.rb
+++ b/spec/ammitto/serialization/json_ld_graph_exporter_page_slices_spec.rb
@@ -89,10 +89,13 @@ RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
 
     it 'deduplicates entries of one document into a single counted summary' do
       exporter.add_organization(organization('cn/mofcom'))
-      add_entry('a1', announcement(documentId: 'DOC-1'), group_id: 'https://www.ammitto.org/group/cn/1')
-      add_entry('a2', announcement(documentId: 'DOC-1', title: 'Later title',
+      # Added in reverse of index order, so an implementation that followed
+      # insertion order instead of the sorted entry index would let 'b1'
+      # win the shared fields and fail here.
+      add_entry('b1', announcement(documentId: 'DOC-1', title: 'Later title',
                                    publishDate: '2025-12-31',
                                    url: 'https://example.test/later'))
+      add_entry('a1', announcement(documentId: 'DOC-1'), group_id: 'https://www.ammitto.org/group/cn/1')
       add_entry('a3', announcement(documentId: 'DOC-2', publishDate: '2023-01-01'))
       exporter.export
 
@@ -112,13 +115,49 @@ RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
 
     it 'emits summaries in entry-index order, leaving the sort to the page' do
       exporter.add_organization(organization('cn/mofcom'))
+      # Inserted newest-first and lexically-last-first, so neither insertion
+      # order nor a producer-side date sort would produce this sequence:
+      # only the sorted entry index does.
+      add_entry('z1', announcement(documentId: 'NEW', publishDate: '2030-01-01'))
       add_entry('a1', announcement(documentId: 'OLD', publishDate: '2001-01-01'))
-      add_entry('a2', announcement(documentId: 'NEW', publishDate: '2030-01-01'))
       exporter.export
 
       published = slice('by-organization', 'cn', 'mofcom.jsonld')['published']
 
       expect(published.map { |s| s['documentId'] }).to eq(%w[OLD NEW])
+    end
+
+    it 'omits an absent title, url and group rather than emitting null' do
+      exporter.add_organization(organization('cn/mofcom'))
+      add_entry('a1', announcement.tap { |a| a.delete('title') and a.delete('url') })
+      exporter.export
+
+      summary = slice('by-organization', 'cn', 'mofcom.jsonld')['published'].first
+
+      expect(summary.keys).to contain_exactly('documentId', 'publishDate', 'entryCount')
+    end
+
+    it 'names the organization it summarizes' do
+      exporter.add_organization(organization('cn/mofcom'))
+      exporter.export
+
+      expect(slice('by-organization', 'cn', 'mofcom.jsonld')).to include(
+        '@type' => 'Index',
+        'slice' => 'by-organization',
+        'organization' => { '@id' => 'https://www.ammitto.org/organization/cn/mofcom' }
+      )
+    end
+
+    it 'reflects entries added between two exports' do
+      exporter.add_organization(organization('cn/mofcom'))
+      add_entry('a1', announcement(documentId: 'FIRST'))
+      exporter.export
+      add_entry('a2', announcement(documentId: 'SECOND'))
+      exporter.export
+
+      published = slice('by-organization', 'cn', 'mofcom.jsonld')['published']
+
+      expect(published.map { |s| s['documentId'] }).to eq(%w[FIRST SECOND])
     end
 
     it 'groups a blank document id under "unknown", as the page does' do
@@ -169,9 +208,15 @@ RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
       expect(child.map { |s| s['documentId'] }).to eq(%w[CHILD])
     end
 
-    it 'ignores a non-string relationship value instead of coercing it' do
+    # A deliberate narrowing, NOT page equivalence: JavaScript's
+    # `.includes` would treat an array as a member test and would throw on
+    # a number, aborting the page's whole scan. OfficialAnnouncement
+    # declares these fields as strings, so the producer matches strings and
+    # skips everything else instead of inventing a match.
+    it 'skips a non-string relationship value instead of coercing it' do
       exporter.add_organization(organization('cn/mofcom'))
       add_entry('a1', announcement(publisher: ['cn/mofcom']))
+      add_entry('a2', announcement(publisher: 42))
       exporter.export
 
       expect(slice('by-organization', 'cn', 'mofcom.jsonld')['published']).to eq([])
@@ -265,6 +310,23 @@ RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
     it 'refuses an identifier whose filename exceeds the byte budget' do
       expect { exporter.send(:slice_path, output_dir, "cn/#{'x' * 300}", 'Document type') }
         .to raise_error(Ammitto::Error, /too long/)
+    end
+
+    it 'refuses an identifier whose directory component exceeds the budget' do
+      expect { exporter.send(:slice_path, output_dir, "#{'x' * 300}/order", 'Document type') }
+        .to raise_error(Ammitto::Error, /too long/)
+    end
+
+    # 'cn' writes cn.jsonld and 'cn/order' writes cn/order.jsonld: the
+    # '.jsonld' suffix keeps the file and the directory distinct names, so
+    # one identifier being a prefix of another is not a collision.
+    it 'lets an identifier coexist with one that extends it' do
+      exporter.add_organization(organization('cn'))
+      exporter.add_organization(organization('cn/order'))
+
+      expect { exporter.export }.not_to raise_error
+      expect(File).to exist(File.join(output_dir, 'by-organization', 'cn.jsonld'))
+      expect(File).to exist(File.join(output_dir, 'by-organization', 'cn', 'order.jsonld'))
     end
 
     it 'refuses an identifier carrying a URL-significant character' do

--- a/spec/ammitto/serialization/json_ld_graph_exporter_page_slices_spec.rb
+++ b/spec/ammitto/serialization/json_ld_graph_exporter_page_slices_spec.rb
@@ -1,0 +1,277 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+require 'json'
+require 'tmpdir'
+require 'ammitto/serialization/json_ld_graph_exporter'
+
+# The organization and document-type pages used to answer their question by
+# fetching every entry node in the corpus and testing each one. These slices
+# move that aggregation into the publishing pipeline, so the specs below pin
+# the exact semantics the pages implemented — including the ones that look
+# like defects, because changing them here would change what a visitor sees.
+RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
+  subject(:exporter) do
+    described_class.new(output_dir: output_dir, context_url: context_url)
+  end
+
+  let(:output_dir) { Dir.mktmpdir('ammitto_page_slices') }
+  let(:context_url) { 'https://www.ammitto.org/ontology/context.jsonld' }
+
+  after { FileUtils.rm_rf(output_dir) }
+
+  def organization(identifier)
+    {
+      '@id' => "https://www.ammitto.org/organization/#{identifier}",
+      '@type' => 'Organization',
+      'identifier' => identifier
+    }
+  end
+
+  def document_type(identifier)
+    {
+      '@id' => "https://www.ammitto.org/document-type/#{identifier}",
+      '@type' => 'DocumentType',
+      'identifier' => identifier
+    }
+  end
+
+  def add_entry(local_id, announcement, group_id: nil, source: :cn)
+    entry = {
+      '@id' => "https://www.ammitto.org/entry/cn/list/#{local_id}",
+      '@type' => 'SanctionEntry',
+      'announcement' => announcement
+    }
+    entry['groupId'] = group_id if group_id
+    entity = { '@id' => "https://www.ammitto.org/entity/cn/#{local_id}" }
+    exporter.add_node(entity: entity, entry: entry, source: source)
+  end
+
+  def announcement(**overrides)
+    {
+      'title' => 'Title',
+      'documentId' => 'DOC-1',
+      'publishDate' => '2024-01-01',
+      'url' => 'https://example.test/doc-1',
+      'publisher' => 'cn/mofcom',
+      'signatory' => 'cn/mofcom',
+      'authority' => 'cn/mofcom',
+      'documentType' => 'cn/order'
+    }.merge(overrides.transform_keys(&:to_s))
+  end
+
+  def slice(*path)
+    JSON.parse(File.read(File.join(output_dir, *path)))
+  end
+
+  describe 'by-organization slices' do
+    it 'keeps the three roles separate rather than bleeding one into another' do
+      exporter.add_organization(organization('cn/publisher-org'))
+      exporter.add_organization(organization('cn/signatory-org'))
+      exporter.add_organization(organization('cn/authority-org'))
+      add_entry('a1', announcement(publisher: 'cn/publisher-org',
+                                   signatory: 'cn/signatory-org',
+                                   authority: 'cn/authority-org'))
+      exporter.export
+
+      publisher = slice('by-organization', 'cn', 'publisher-org.jsonld')
+      signatory = slice('by-organization', 'cn', 'signatory-org.jsonld')
+      authority = slice('by-organization', 'cn', 'authority-org.jsonld')
+
+      expect(publisher.values_at('published', 'signed', 'authorized'))
+        .to match([[a_hash_including('documentId' => 'DOC-1')], [], []])
+      expect(signatory.values_at('published', 'signed', 'authorized'))
+        .to match([[], [a_hash_including('documentId' => 'DOC-1')], []])
+      expect(authority.values_at('published', 'signed', 'authorized'))
+        .to match([[], [], [a_hash_including('documentId' => 'DOC-1')]])
+    end
+
+    it 'deduplicates entries of one document into a single counted summary' do
+      exporter.add_organization(organization('cn/mofcom'))
+      add_entry('a1', announcement(documentId: 'DOC-1'), group_id: 'https://www.ammitto.org/group/cn/1')
+      add_entry('a2', announcement(documentId: 'DOC-1', title: 'Later title',
+                                   publishDate: '2025-12-31',
+                                   url: 'https://example.test/later'))
+      add_entry('a3', announcement(documentId: 'DOC-2', publishDate: '2023-01-01'))
+      exporter.export
+
+      published = slice('by-organization', 'cn', 'mofcom.jsonld')['published']
+
+      expect(published.map { |s| s.values_at('documentId', 'entryCount') })
+        .to eq([['DOC-1', 2], ['DOC-2', 1]])
+      # The first entry in index order supplies the rendered fields; a later
+      # entry of the same document must not overwrite them.
+      expect(published.first).to include(
+        'title' => 'Title',
+        'publishDate' => '2024-01-01',
+        'url' => 'https://example.test/doc-1',
+        'groupId' => 'https://www.ammitto.org/group/cn/1'
+      )
+    end
+
+    it 'emits summaries in entry-index order, leaving the sort to the page' do
+      exporter.add_organization(organization('cn/mofcom'))
+      add_entry('a1', announcement(documentId: 'OLD', publishDate: '2001-01-01'))
+      add_entry('a2', announcement(documentId: 'NEW', publishDate: '2030-01-01'))
+      exporter.export
+
+      published = slice('by-organization', 'cn', 'mofcom.jsonld')['published']
+
+      expect(published.map { |s| s['documentId'] }).to eq(%w[OLD NEW])
+    end
+
+    it 'groups a blank document id under "unknown", as the page does' do
+      exporter.add_organization(organization('cn/mofcom'))
+      add_entry('a1', announcement(documentId: ''))
+      add_entry('a2', announcement.tap { |a| a.delete('documentId') })
+      exporter.export
+
+      published = slice('by-organization', 'cn', 'mofcom.jsonld')['published']
+
+      expect(published.map { |s| s.values_at('documentId', 'entryCount') })
+        .to eq([['unknown', 2]])
+    end
+
+    it 'reports a missing publish date as the empty string the page sorts on' do
+      exporter.add_organization(organization('cn/mofcom'))
+      add_entry('a1', announcement.tap { |a| a.delete('publishDate') })
+      exporter.export
+
+      expect(slice('by-organization', 'cn', 'mofcom.jsonld')['published'].first)
+        .to include('publishDate' => '')
+    end
+
+    it 'preserves the raw title so each page keeps its own resolver' do
+      localized = [{ 'zh-Hans' => '标题' }, { 'en' => 'Title' }]
+      exporter.add_organization(organization('cn/mofcom'))
+      add_entry('a1', announcement(title: localized))
+      exporter.export
+
+      expect(slice('by-organization', 'cn', 'mofcom.jsonld')['published'].first['title'])
+        .to eq(localized)
+    end
+
+    it 'reproduces the page substring match, including its over-inclusion' do
+      # PRE-EXISTING DEFECT, reproduced deliberately: the page tests
+      # `publisher === id || publisher.includes(id)`, so a parent
+      # organization absorbs every child whose identifier extends it.
+      exporter.add_organization(organization('cn/mofcom'))
+      exporter.add_organization(organization('cn/mofcom-bureau'))
+      add_entry('a1', announcement(publisher: 'cn/mofcom', documentId: 'PARENT'))
+      add_entry('a2', announcement(publisher: 'cn/mofcom-bureau', documentId: 'CHILD'))
+      exporter.export
+
+      parent = slice('by-organization', 'cn', 'mofcom.jsonld')['published']
+      child = slice('by-organization', 'cn', 'mofcom-bureau.jsonld')['published']
+
+      expect(parent.map { |s| s['documentId'] }).to eq(%w[PARENT CHILD])
+      expect(child.map { |s| s['documentId'] }).to eq(%w[CHILD])
+    end
+
+    it 'ignores a non-string relationship value instead of coercing it' do
+      exporter.add_organization(organization('cn/mofcom'))
+      add_entry('a1', announcement(publisher: ['cn/mofcom']))
+      exporter.export
+
+      expect(slice('by-organization', 'cn', 'mofcom.jsonld')['published']).to eq([])
+    end
+
+    it 'writes a master index listing every organization slice' do
+      exporter.add_organization(organization('cn/zeta'))
+      exporter.add_organization(organization('cn/alpha'))
+      exporter.export
+
+      expect(slice('by-organization', 'index.jsonld')).to include(
+        'slice' => 'by-organization',
+        'available' => %w[
+          https://www.ammitto.org/organization/cn/alpha
+          https://www.ammitto.org/organization/cn/zeta
+        ]
+      )
+    end
+  end
+
+  describe 'by-document-type slices' do
+    it 'matches announcements on exact document type, never on a prefix' do
+      exporter.add_document_type(document_type('cn/order'))
+      add_entry('a1', announcement(documentType: 'cn/order', documentId: 'EXACT'))
+      add_entry('a2', announcement(documentType: 'cn/order-extended', documentId: 'PREFIXED'))
+      exporter.export
+
+      announcements = slice('by-document-type', 'cn', 'order.jsonld')['announcements']
+
+      expect(announcements.map { |s| s['documentId'] }).to eq(%w[EXACT])
+    end
+
+    it 'includes only the legal instruments carrying that document type' do
+      exporter.add_document_type(document_type('cn/order'))
+      exporter.instruments['https://www.ammitto.org/legal-instrument/cn/b-law'] = {
+        '@id' => 'https://www.ammitto.org/legal-instrument/cn/b-law',
+        'type' => 'cn/order', 'identifier' => 'b-law',
+        'title' => [{ 'en' => 'B Law' }], 'name' => 'B Law', 'publishDate' => '2020-01-01'
+      }
+      exporter.instruments['https://www.ammitto.org/legal-instrument/cn/a-law'] = {
+        '@id' => 'https://www.ammitto.org/legal-instrument/cn/a-law',
+        'type' => 'cn/order', 'identifier' => 'a-law', 'title' => 'A Law'
+      }
+      exporter.instruments['https://www.ammitto.org/legal-instrument/cn/other'] = {
+        '@id' => 'https://www.ammitto.org/legal-instrument/cn/other',
+        'type' => 'cn/act', 'identifier' => 'other', 'title' => 'Other'
+      }
+      exporter.export
+
+      instruments = slice('by-document-type', 'cn', 'order.jsonld')['legalInstruments']
+
+      # Instrument-index order, which is the sorted IRI order the page walked.
+      expect(instruments.map { |i| i['identifier'] }).to eq(%w[a-law b-law])
+      expect(instruments.last).to eq(
+        '@id' => 'https://www.ammitto.org/legal-instrument/cn/b-law',
+        'identifier' => 'b-law', 'title' => [{ 'en' => 'B Law' }],
+        'name' => 'B Law', 'publishDate' => '2020-01-01'
+      )
+    end
+
+    it 'writes a master index listing every document-type slice' do
+      exporter.add_document_type(document_type('cn/order'))
+      exporter.export
+
+      expect(slice('by-document-type', 'index.jsonld')).to include(
+        'slice' => 'by-document-type',
+        'available' => %w[https://www.ammitto.org/document-type/cn/order]
+      )
+    end
+  end
+
+  describe 'identifier path safety' do
+    it 'refuses an identifier that would escape the slice directory' do
+      exporter.add_organization(organization('cn/../../escape'))
+
+      expect { exporter.export }
+        .to raise_error(Ammitto::Error, /unusable path component/)
+    end
+
+    it 'refuses an identifier that would overwrite the master index' do
+      exporter.add_organization(organization('index'))
+
+      expect { exporter.export }
+        .to raise_error(Ammitto::Error, /master index/)
+    end
+
+    # Driven through slice_path rather than #export, because
+    # export_document_type_nodes writes {local_id}.jsonld with no length
+    # guard of its own and dies with Errno::ENAMETOOLONG first — a
+    # pre-existing hazard in the node export path, reported separately.
+    it 'refuses an identifier whose filename exceeds the byte budget' do
+      expect { exporter.send(:slice_path, output_dir, "cn/#{'x' * 300}", 'Document type') }
+        .to raise_error(Ammitto::Error, /too long/)
+    end
+
+    it 'refuses an identifier carrying a URL-significant character' do
+      exporter.add_organization(organization('cn/a?b'))
+
+      expect { exporter.export }
+        .to raise_error(Ammitto::Error, /unusable path component/)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds two slice families to the graph exporter:
`by-organization/{identifier}.jsonld` and
`by-document-type/{identifier}.jsonld`, each with a sibling
`index.jsonld`, following the conventions of the existing
`export_slices_*` methods.

They exist so the website stops recomputing, in the browser and one
request at a time, a grouping this pipeline can publish once. Today
`/organization/:id` and `/document-type/:id` fetch the entry index and
then every entry node in the corpus to test each for a relationship —
measured at **10,234 requests in 20 seconds, rendering nothing**. With
these summaries the same pages make **2 requests** and render fully.

The existing slices could not serve this. `by-authority` groups on
`entry.authority.@id`, which is the sanctions *source* (`authority/uk`),
while the organization page matches an announcement's `publisher`,
`signatory` and `authority` against an organization identifier
(`uk/ofsi`). Reusing it would have been fast and wrong. `by-type` groups
entities into person/organization classes and is not a document-type
index.

## Changes

- Organization summaries carry three lists — `published`, `signed`,
  `authorized` — with the exact fields the page renders: document id,
  raw title, date, URL, group id and entry count.
- Document-type summaries carry `announcements` plus `legalInstruments`.
- Titles are published **raw**, not resolved: the two pages resolve
  localized titles differently, so one resolved field cannot serve both.
- Order is left to the consumer, which keeps its existing
  `localeCompare` — making the rendered order provably identical rather
  than merely similar.

## Test plan

- `bundle exec rspec` — 1496 → **1517 examples**, 0 failures, 4 pending.
- `bundle exec rubocop` — **425 files**, no offenses.
- 21 new examples covering role separation, deduplication, counts, and
  document-type/instrument membership. All 16 original examples were
  confirmed failing before the implementation existed.
- **Equivalence, not just correctness:** an oracle replays the old
  client-side algorithm over the same 25,128-entry artifact and compares
  the final rendered view model against the shipped mapping — **15
  routes, 0 mismatches**, non-empty on both sides. Mutation-tested:
  deleting a summary, altering a count, or reversing instrument order
  each produce a mismatch.

## Two things a reviewer should know

**A substring match is preserved deliberately.** The organization page
matches with `publisher.includes(id)`, so `cn/ministry-of-commerce`
reports 21 published documents where exact matching gives 7 — the other
14 belong to a child bureau. That is a correctness defect, and it is
reproduced here exactly, because the acceptance gate for this PR is that
the fast path equals the slow path. Fixing it belongs in its own change.

**These summaries will be empty in production until a separate limitation
is fixed.** `find_supplement_dir` returns the first source directory it
finds rather than merging all of them, so one repository's supporting data
loads and the rest are ignored. In production ordering that is `uk`, whose
5 organizations and 6 document types have no announcements — every one of
its slices comes out empty. The gem's own docstring records this as a
known limitation needing union loading. Out of scope here, but this PR
does not make those pages useful on its own.
