### PR TITLE
Publish source-stated birth year ranges instead of one endpoint

### DIFF
--- a/lib/ammitto/birth_info.rb
+++ b/lib/ammitto/birth_info.rb
@@ -3,7 +3,29 @@
 module Ammitto
   # BirthInfo represents birth-related information for a person
   #
-  # Supports exact dates, approximate dates, and location information.
+  # Supports exact dates, approximate dates, year ranges, and location
+  # information.
+  #
+  # == What each field is allowed to say
+  #
+  # +date+::  ONE complete source-stated day, month and year.
+  # +year+::  ONE source-stated year.
+  # +year_range_from+ / +year_range_to+:: the bounds of a source-stated
+  #           span of years ("born between 1959 and 1965").
+  #
+  # A range never populates +year+ or +date+ with one of its endpoints:
+  # neither bound is the birth year, and there is no honest third value,
+  # so both stay nil while a range is present. Either bound may stand
+  # alone, so "1953 or later" and "no later than 1958" are both
+  # expressible. When both are present +year_range_from+ must not exceed
+  # +year_range_to+; a reversed pair is rejected at the transformer
+  # boundary rather than silently reordered, because reordering would
+  # invent a claim the source never made.
+  #
+  # +circa+ is independent of a range. A range is a span the source
+  # stated exactly, not an approximation, and sources emit circa
+  # alongside a range in both settings — so circa is carried through from
+  # the source and never inferred from the presence of a range.
   #
   # @example Creating birth info
   #   BirthInfo.new(
@@ -12,10 +34,15 @@ module Ammitto
   #     country: "Democratic People's Republic of Korea"
   #   )
   #
+  # @example A source-stated span of years
+  #   BirthInfo.new(year_range_from: 1959, year_range_to: 1965, circa: true)
+  #
   class BirthInfo < Lutaml::Model::Serializable
     attribute :date, :date
     attribute :circa, :boolean, default: false  # Approximate date
     attribute :year, :integer                   # Year only if full date unknown
+    attribute :year_range_from, :integer        # Lower bound of a year span
+    attribute :year_range_to, :integer          # Upper bound of a year span
     attribute :city, :string
     attribute :region, :string                  # State, province, etc.
     attribute :country, :string                 # Country name
@@ -25,6 +52,8 @@ module Ammitto
       map 'date', to: :date
       map 'circa', to: :circa
       map 'year', to: :year
+      map 'yearRangeFrom', to: :year_range_from
+      map 'yearRangeTo', to: :year_range_to
       map 'city', to: :city
       map 'region', to: :region
       map 'country', to: :country
@@ -36,12 +65,37 @@ module Ammitto
       [city, region, country].compact.reject(&:empty?).join(', ')
     end
 
-    # @return [String, nil] formatted birth date or year
+    # @return [Boolean] whether a year span is stated, on either side
+    def year_range?
+      !year_range_from.nil? || !year_range_to.nil?
+    end
+
+    # A range renders as its span rather than as a single year, and an
+    # open bound renders as the direction it leaves open: "1953 or
+    # later", "no later than 1958".
+    # @return [String, nil] formatted birth date, year, or year span
     def formatted_date
-      return year.to_s if year && !date
+      return with_circa(formatted_year_range) if year_range?
+      return with_circa(year.to_s) if year && !date
       return nil unless date
 
-      circa ? "c. #{date}" : date.to_s
+      with_circa(date.to_s)
+    end
+
+    private
+
+    # @return [String] the span, closed or open on either side
+    def formatted_year_range
+      return "#{year_range_from}-#{year_range_to}" if year_range_from && year_range_to
+      return "#{year_range_from} or later" if year_range_from
+
+      "no later than #{year_range_to}"
+    end
+
+    # @param label [String] the rendered date, year or span
+    # @return [String] the label, prefixed when the source said circa
+    def with_circa(label)
+      circa ? "c. #{label}" : label
     end
   end
 end

--- a/lib/ammitto/ontology/value_objects/birth_info.rb
+++ b/lib/ammitto/ontology/value_objects/birth_info.rb
@@ -9,8 +9,21 @@ module Ammitto
     module ValueObjects
       # Represents birth information for a person
       #
-      # Birth information may be partial (year only, city only, etc.)
-      # and may be approximate (circa flag).
+      # Birth information may be partial (year only, city only, etc.),
+      # may be a span of years, and may be approximate (circa flag).
+      #
+      # +date+ carries ONE complete source-stated day/month/year and
+      # +year+ ONE source-stated year. A source-stated span rides in
+      # +year_range_from+ / +year_range_to+ instead, and while a span is
+      # present +date+ and +year+ stay nil: neither bound is the birth
+      # year, so filling +year+ with an endpoint would assert something
+      # the source never said. Either bound may stand alone. A reversed
+      # closed pair is rejected upstream, at the transformer boundary,
+      # rather than reordered here.
+      #
+      # +circa+ is independent of a span: sources emit circa both with
+      # and without a range, so it is carried from the source and never
+      # inferred.
       #
       # @example Creating birth info
       #   birth = BirthInfo.new(
@@ -22,12 +35,17 @@ module Ammitto
       #     country_iso_code: "RU"
       #   )
       #
+      # @example A source-stated span of years
+      #   BirthInfo.new(year_range_from: 1959, year_range_to: 1965)
+      #
       class BirthInfo < Lutaml::Model::Serializable
         include Neo4jAdapter
 
         # Neo4j configuration for BirthInfo
         neo4j_labels 'BirthInfo'
-        neo4j_property :date, :circa, :year, :city, :region, :country, :country_iso_code
+        neo4j_property :date, :circa, :year, :year_range_from,
+                       :year_range_to, :city, :region, :country,
+                       :country_iso_code
 
         # Exact or approximate birth date
         # @return [Date, nil]
@@ -40,6 +58,14 @@ module Ammitto
         # Birth year only (when exact date unknown)
         # @return [Integer, nil]
         attribute :year, :integer
+
+        # Lower bound of a source-stated span of birth years
+        # @return [Integer, nil]
+        attribute :year_range_from, :integer
+
+        # Upper bound of a source-stated span of birth years
+        # @return [Integer, nil]
+        attribute :year_range_to, :integer
 
         # City / town of birth
         # @return [String, nil]
@@ -60,9 +86,16 @@ module Ammitto
         # Check if birth info has meaningful content
         # @return [Boolean]
         def present?
-          [date, year, city, region, country].any? do |v|
+          [date, year, year_range_from, year_range_to, city, region,
+           country].any? do |v|
             Utils::Presence.present?(v)
           end
+        end
+
+        # Whether a span of years is stated, on either side
+        # @return [Boolean]
+        def year_range?
+          !year_range_from.nil? || !year_range_to.nil?
         end
 
         # Get year of birth (from date or year field)
@@ -90,6 +123,8 @@ module Ammitto
           hash[:date] = date.to_s if date
           hash[:circa] = circa if circa
           hash[:year] = year if year
+          hash[:year_range_from] = year_range_from if year_range_from
+          hash[:year_range_to] = year_range_to if year_range_to
           hash[:city] = city if city
           hash[:region] = region if region
           hash[:country] = country if country
@@ -100,10 +135,22 @@ module Ammitto
         private
 
         def date_label
+          return year_range_label if year_range?
           return year.to_s if year && !date
           return date.to_s if date
 
           nil
+        end
+
+        # An open bound renders as the direction it leaves open, so a
+        # one-sided span is never mistaken for a closed one.
+        # @return [String] the span, closed or open on either side
+        def year_range_label
+          closed = year_range_from && year_range_to
+          return "#{year_range_from}-#{year_range_to}" if closed
+          return "#{year_range_from} or later" if year_range_from
+
+          "no later than #{year_range_to}"
         end
 
         # JSON mapping
@@ -111,6 +158,8 @@ module Ammitto
           map :date, to: :date
           map :circa, to: :circa
           map :year, to: :year
+          map :year_range_from, to: :year_range_from
+          map :year_range_to, to: :year_range_to
           map :city, to: :city
           map :region, to: :region
           map :country, to: :country
@@ -122,6 +171,8 @@ module Ammitto
           map :date, to: :date
           map :circa, to: :circa
           map :year, to: :year
+          map :year_range_from, to: :year_range_from
+          map :year_range_to, to: :year_range_to
           map :city, to: :city
           map :region, to: :region
           map :country, to: :country

--- a/lib/ammitto/schema/context.rb
+++ b/lib/ammitto/schema/context.rb
@@ -187,6 +187,17 @@ module Ammitto
               # BirthInfo full structure
               'birthDate' => { '@id' => 'schema:birthDate', '@type' => 'xsd:date' },
               'birthYear' => { '@id' => 'birthYear', '@type' => 'xsd:gYear' },
+              # The serializer emits a BirthInfo node's single stated
+              # year as 'year'; the 'birthYear' term above describes the
+              # flat entity-level key and never described this one, so
+              # 'year' went out undeclared.
+              'year' => { '@id' => 'year', '@type' => 'xsd:gYear' },
+              # Bounds of a stated span of birth years. Separate terms,
+              # not a refinement of 'year': a bound is not a birth year,
+              # and a consumer that treated one as such would answer an
+              # exact-year query with a record that never claimed one.
+              'yearRangeFrom' => { '@id' => 'yearRangeFrom', '@type' => 'xsd:gYear' },
+              'yearRangeTo' => { '@id' => 'yearRangeTo', '@type' => 'xsd:gYear' },
               'birthCity' => { '@id' => 'schema:birthPlace' },
               'birthCountry' => { '@id' => 'birthCountry' },
 

--- a/lib/ammitto/serialization/json_ld_serializer.rb
+++ b/lib/ammitto/serialization/json_ld_serializer.rb
@@ -226,6 +226,8 @@ module Ammitto
           'date' => birth_info.date,
           'circa' => birth_info.circa,
           'year' => birth_info.year,
+          'yearRangeFrom' => birth_info.year_range_from,
+          'yearRangeTo' => birth_info.year_range_to,
           'city' => birth_info.city,
           'region' => birth_info.region,
           'country' => birth_info.country,

--- a/lib/ammitto/serialization/ontology_exporter.rb
+++ b/lib/ammitto/serialization/ontology_exporter.rb
@@ -277,6 +277,12 @@ module Ammitto
 
         # BirthInfo properties
         { id: 'year', label: 'Year', comment: 'Birth year', domain: 'BirthInfo', range: 'integer' },
+        { id: 'yearRangeFrom', label: 'Year Range From',
+          comment: 'Lower bound of a stated span of birth years',
+          domain: 'BirthInfo', range: 'integer' },
+        { id: 'yearRangeTo', label: 'Year Range To',
+          comment: 'Upper bound of a stated span of birth years',
+          domain: 'BirthInfo', range: 'integer' },
         { id: 'place', label: 'Place', comment: 'Birth place', domain: 'BirthInfo', range: 'string' },
         { id: 'circa', label: 'Circa', comment: 'Approximate date', domain: 'BirthInfo', range: 'boolean' }
       ].freeze

--- a/lib/ammitto/serialization/ontology_exporter.rb
+++ b/lib/ammitto/serialization/ontology_exporter.rb
@@ -276,12 +276,15 @@ module Ammitto
         { id: 'expiryDate', label: 'Expiry Date', comment: 'Expiry date', domain: 'Identifier', range: 'date' },
 
         # BirthInfo properties. The three year-valued ones are gYear,
-        # matching the JSON-LD context: the ontology and the context
-        # describe the same properties, and a consumer reading both must
-        # not be told two different datatypes. 'year' was integer here
-        # and gYear in the context before the bounds existed; adding the
-        # bounds is what made the disagreement worth resolving rather
-        # than propagating.
+        # matching the JSON-LD context. The two artifacts mint their
+        # terms under different bases — this vocabulary under BASE_URI,
+        # the context under its own @vocab — so they are not literally
+        # the same RDF property, but they describe the same field to the
+        # same reader, and telling that reader "integer" in the ontology
+        # browser and "gYear" in the data is a contradiction either way.
+        # 'year' carried that contradiction before the bounds existed;
+        # adding the bounds is what made it worth resolving rather than
+        # propagating into two more properties.
         { id: 'year', label: 'Year', comment: 'Birth year', domain: 'BirthInfo', range: 'gYear' },
         { id: 'yearRangeFrom', label: 'Year Range From',
           comment: 'Lower bound of a stated span of birth years',

--- a/lib/ammitto/serialization/ontology_exporter.rb
+++ b/lib/ammitto/serialization/ontology_exporter.rb
@@ -142,7 +142,7 @@ module Ammitto
           label: 'Birth Information',
           comment: 'Birth date and place information',
           parent: nil,
-          properties: %w[date year place country circa]
+          properties: %w[date year yearRangeFrom yearRangeTo place country circa]
         },
         {
           id: 'Nationality',
@@ -275,14 +275,20 @@ module Ammitto
         { id: 'issueDate', label: 'Issue Date', comment: 'Date issued', domain: 'Identifier', range: 'date' },
         { id: 'expiryDate', label: 'Expiry Date', comment: 'Expiry date', domain: 'Identifier', range: 'date' },
 
-        # BirthInfo properties
-        { id: 'year', label: 'Year', comment: 'Birth year', domain: 'BirthInfo', range: 'integer' },
+        # BirthInfo properties. The three year-valued ones are gYear,
+        # matching the JSON-LD context: the ontology and the context
+        # describe the same properties, and a consumer reading both must
+        # not be told two different datatypes. 'year' was integer here
+        # and gYear in the context before the bounds existed; adding the
+        # bounds is what made the disagreement worth resolving rather
+        # than propagating.
+        { id: 'year', label: 'Year', comment: 'Birth year', domain: 'BirthInfo', range: 'gYear' },
         { id: 'yearRangeFrom', label: 'Year Range From',
           comment: 'Lower bound of a stated span of birth years',
-          domain: 'BirthInfo', range: 'integer' },
+          domain: 'BirthInfo', range: 'gYear' },
         { id: 'yearRangeTo', label: 'Year Range To',
           comment: 'Upper bound of a stated span of birth years',
-          domain: 'BirthInfo', range: 'integer' },
+          domain: 'BirthInfo', range: 'gYear' },
         { id: 'place', label: 'Place', comment: 'Birth place', domain: 'BirthInfo', range: 'string' },
         { id: 'circa', label: 'Circa', comment: 'Approximate date', domain: 'BirthInfo', range: 'boolean' }
       ].freeze
@@ -374,7 +380,7 @@ module Ammitto
       # @return [String] URI or XSD type
       def map_range(range)
         case range
-        when 'string', 'integer', 'date', 'boolean'
+        when 'string', 'integer', 'date', 'boolean', 'gYear'
           "http://www.w3.org/2001/XMLSchema##{range}"
         else
           "#{BASE_URI}/#{range}"

--- a/lib/ammitto/serialization/search_index_exporter.rb
+++ b/lib/ammitto/serialization/search_index_exporter.rb
@@ -525,18 +525,19 @@ module Ammitto
         entity_type = entity['entityType'] || entity['entity_type']
         return nil unless entity_type == 'person'
 
-        # From birth_info (snake_case)
-        if entity['birth_info'].is_a?(Array) && entity['birth_info'].first
-          birth = entity['birth_info'].first
-          date = birth['date'] || birth['year']
-          return extract_year_from_date(date) if date
+        # Every birth record is searched, not only the first. An entity
+        # can carry several — one per contributing source — and the record
+        # holding the exact date is not reliably the one at index 0, so
+        # taking `.first` dropped a stated year whenever another record
+        # happened to precede it. #birth_info_with_range already scans the
+        # whole list for span bounds; a year that is *more* precise than a
+        # span must not be found less often than one.
+        birth = birth_info_records(entity).find do |record|
+          record['date'] || record['year']
         end
-
-        # From birthInfo (camelCase)
-        if entity['birthInfo'].is_a?(Array) && entity['birthInfo'].first
-          birth = entity['birthInfo'].first
-          date = (birth['date'] || birth['year'])&.to_s
-          return date[0, 4] if date && date.length >= 4
+        if birth
+          year = extract_year_from_date(birth['date'] || birth['year'])
+          return year if year
         end
 
         # From birthDate

--- a/lib/ammitto/serialization/search_index_exporter.rb
+++ b/lib/ammitto/serialization/search_index_exporter.rb
@@ -474,6 +474,11 @@ module Ammitto
       # record that named no year answer as though it had. A record with
       # only one bound exports only that column, so an open span stays
       # open.
+      #
+      # An entity may carry several birth records, and the span is not
+      # always the first. Both bounds are read from the FIRST record
+      # that states either — never one bound from one record and the
+      # other from another, which would publish a span no source stated.
       # @param entity [Hash] entity data
       # @param keys [Array<String>] the bound's key spellings
       # @return [String, nil] the bound, as a string
@@ -481,26 +486,32 @@ module Ammitto
         entity_type = entity['entityType'] || entity['entity_type']
         return nil unless entity_type == 'person'
 
-        birth = first_birth_info(entity)
+        birth = birth_info_with_range(entity)
         return nil unless birth
 
-        keys.each do |key|
-          value = scalar_presence(birth[key])
-          return value if value
-        end
-        nil
+        keys.filter_map { |key| scalar_presence(birth[key]) }.first
       end
 
       # @param entity [Hash] entity data
-      # @return [Hash, nil] the first birth info record, either spelling
-      def first_birth_info(entity)
+      # @return [Hash, nil] the first birth record stating either bound
+      def birth_info_with_range(entity)
+        birth_info_records(entity).find do |birth|
+          (BIRTH_YEAR_FROM_KEYS + BIRTH_YEAR_TO_KEYS)
+            .any? { |key| scalar_presence(birth[key]) }
+        end
+      end
+
+      # @param entity [Hash] entity data
+      # @return [Array<Hash>] birth records, in either key spelling
+      def birth_info_records(entity)
         %w[birth_info birthInfo].each do |key|
           list = entity[key]
-          next unless list.is_a?(Array) && list.first.is_a?(Hash)
+          next unless list.is_a?(Array)
 
-          return list.first
+          records = list.grep(Hash)
+          return records unless records.empty?
         end
-        nil
+        []
       end
 
       # Extract birth year from entity.

--- a/lib/ammitto/serialization/search_index_exporter.rb
+++ b/lib/ammitto/serialization/search_index_exporter.rb
@@ -33,6 +33,11 @@ module Ammitto
     #   exporter.export('./api/v1')
     #
     class SearchIndexExporter
+      # Bounds of a stated span of birth years, in both spellings the
+      # exporter has to read.
+      BIRTH_YEAR_FROM_KEYS = %w[yearRangeFrom year_range_from].freeze
+      BIRTH_YEAR_TO_KEYS = %w[yearRangeTo year_range_to].freeze
+
       # Authority names for facet display
       AUTHORITY_NAMES = {
         'un' => 'United Nations',
@@ -138,6 +143,8 @@ module Ammitto
           listType: string_presence(extract_list_type(entry)),
           status: string_presence(entry['status']),
           birthYear: string_presence(extract_birth_year(entity)),
+          birthYearFrom: extract_birth_bound(entity, BIRTH_YEAR_FROM_KEYS),
+          birthYearTo: extract_birth_bound(entity, BIRTH_YEAR_TO_KEYS),
           imo: scalar_presence(extract_imo(entity))
         }.compact
       end
@@ -461,7 +468,46 @@ module Ammitto
         nil
       end
 
-      # Extract birth year from entity
+      # Export a span's bounds as their own columns. A bound NEVER
+      # becomes birthYear: birthYear answers "born in this exact year",
+      # and a lower bound is not that year — filling it in would let a
+      # record that named no year answer as though it had. A record with
+      # only one bound exports only that column, so an open span stays
+      # open.
+      # @param entity [Hash] entity data
+      # @param keys [Array<String>] the bound's key spellings
+      # @return [String, nil] the bound, as a string
+      def extract_birth_bound(entity, keys)
+        entity_type = entity['entityType'] || entity['entity_type']
+        return nil unless entity_type == 'person'
+
+        birth = first_birth_info(entity)
+        return nil unless birth
+
+        keys.each do |key|
+          value = scalar_presence(birth[key])
+          return value if value
+        end
+        nil
+      end
+
+      # @param entity [Hash] entity data
+      # @return [Hash, nil] the first birth info record, either spelling
+      def first_birth_info(entity)
+        %w[birth_info birthInfo].each do |key|
+          list = entity[key]
+          next unless list.is_a?(Array) && list.first.is_a?(Hash)
+
+          return list.first
+        end
+        nil
+      end
+
+      # Extract birth year from entity.
+      #
+      # Only an exact date or a stated single year answers here. A span
+      # is read by #extract_birth_bound instead, and the span keys are
+      # deliberately absent from the lookups below.
       # @param entity [Hash] entity data
       # @return [String, nil] birth year
       def extract_birth_year(entity)

--- a/lib/ammitto/sources/au/sanctions_list.rb
+++ b/lib/ammitto/sources/au/sanctions_list.rb
@@ -194,14 +194,36 @@ module Ammitto
 
       # ISO 8601 date with support for partial/imprecise dates
       class FlexibleDate < Lutaml::Model::Serializable
+        # DFAT states a span of birth years in one shape:
+        # "Approximately: Between 1959 and 1965", and the same shape
+        # without the "Approximately:" prefix. Anchored at both ends, so
+        # only a value that is wholly a span is read as one.
+        #
+        # The "Approximately" prefix is captured rather than discarded:
+        # it is what makes the span circa, and a span is not approximate
+        # by itself. "Between 1959 and 1965" states its bounds exactly.
+        YEAR_RANGE = /
+          \A(?:(approximately)\s*:?\s*)?
+          between\s+(\d{4})\s+and\s+(\d{4})\z
+        /xi
+
         attribute :raw_value, :string    # Original value from CSV
         attribute :year, :integer
         attribute :month, :integer
         attribute :day, :integer
         attribute :circa, :boolean       # Approximate date
-        # 'full', 'month', 'year', 'circa', or 'unknown' when the cell held
-        # no resolvable date at all. Nothing in the gem branches on this
-        # value; it is descriptive metadata carried alongside raw_value.
+        # Lower and upper bound of a stated span of years. While a span
+        # is present year, month and day stay nil: neither bound is the
+        # birth year, so storing one would assert a year DFAT did not
+        # state. An out-of-order span is rejected at the transformer
+        # boundary, where the harmonized contract lives, rather than
+        # reordered here.
+        attribute :year_range_from, :integer
+        attribute :year_range_to, :integer
+        # 'full', 'month', 'year', 'range', 'circa', or 'unknown' when the
+        # cell held no resolvable date at all. Nothing in the gem branches
+        # on this value; it is descriptive metadata carried alongside
+        # raw_value.
         attribute :precision, :string
 
         def self.parse(date_str)
@@ -213,6 +235,14 @@ module Ammitto
           # "5 May 1957", "April 1957", "1957", "circa 1957"
 
           cleaned = date_str.strip.downcase
+
+          # A span is recognised before anything else and returns at
+          # once. The year-only fallback below would otherwise seize the
+          # first year in the value and publish 1959 as THE birth year —
+          # which is what this parser did — and demote_unresolved_month
+          # would then rewrite a yearless span's precision to 'unknown'.
+          range = parse_year_range(flexible, cleaned)
+          return range if range
 
           if cleaned.start_with?('circa', 'c.', 'c')
             flexible.circa = true
@@ -267,6 +297,23 @@ module Ammitto
         # 'unknown' is a state callers did not previously see. It is emitted
         # into the serialized YAML.
         #
+        # Record a stated span of years, or nil when the value states no
+        # span. circa follows the source's own "Approximately" marker
+        # and is never inferred from the span itself.
+        # @param flexible [FlexibleDate] the parse being filled in
+        # @param cleaned [String] the stripped, downcased cell value
+        # @return [FlexibleDate, nil] the finished parse, or nil
+        def self.parse_year_range(flexible, cleaned)
+          match = YEAR_RANGE.match(cleaned)
+          return nil unless match
+
+          flexible.circa = !match[1].nil?
+          flexible.year_range_from = match[2].to_i
+          flexible.year_range_to = match[3].to_i
+          flexible.precision = 'range'
+          flexible
+        end
+
         # @param flexible [FlexibleDate] the parse being finalised
         # @return [void]
         def self.demote_unresolved_month(flexible)

--- a/lib/ammitto/sources/au/transformer.rb
+++ b/lib/ammitto/sources/au/transformer.rb
@@ -250,11 +250,15 @@ module Ammitto
             if dob.respond_to?(:to_date)
               # A FlexibleDate keeps its stated precision: the date is
               # used only when day, month and year all resolved; a bare
-              # year rides in BirthInfo#year instead of vanishing
+              # year rides in BirthInfo#year instead of vanishing; and a
+              # stated span rides in the range bounds, which suppress
+              # both scalars downstream
               create_birth_info(
                 date: complete_date_of(dob),
                 circa: dob.circa || false,
                 year: dob.year,
+                year_range_from: dob.year_range_from,
+                year_range_to: dob.year_range_to,
                 city: pob&.city,
                 country: pob&.country
               )

--- a/lib/ammitto/sources/eu/birthdate.rb
+++ b/lib/ammitto/sources/eu/birthdate.rb
@@ -16,6 +16,16 @@ module Ammitto
       #            countryDescription="IRAQ" regulationLanguage="en" logicalId="14">
       #   <regulationSummary .../>
       # </birthdate>
+      #
+      # The EU also states a span of birth years, as its own pair of
+      # attributes rather than as text:
+      # <birthdate circa="true" calendarType="GREGORIAN"
+      #            city="Tirin Kot District, Uruzgan Province" zipCode=""
+      #            yearRangeFrom="1953" yearRangeTo="1958" ...>
+      #
+      # The two are independent of circa and of each other: the corpus
+      # carries both circa="true" and circa="false" alongside a span, and
+      # one record states only yearRangeTo, leaving the span open below.
       class Birthdate < Lutaml::Model::Serializable
         attribute :birthdate, :string
         attribute :circa, :boolean
@@ -23,6 +33,8 @@ module Ammitto
         attribute :day_of_month, :integer
         attribute :month_of_year, :integer
         attribute :year, :integer
+        attribute :year_range_from, :integer
+        attribute :year_range_to, :integer
         attribute :city, :string
         attribute :region, :string
         attribute :place, :string
@@ -43,6 +55,8 @@ module Ammitto
           map_attribute 'dayOfMonth', to: :day_of_month
           map_attribute 'monthOfYear', to: :month_of_year
           map_attribute 'year', to: :year
+          map_attribute 'yearRangeFrom', to: :year_range_from
+          map_attribute 'yearRangeTo', to: :year_range_to
           map_attribute 'city', to: :city
           map_attribute 'region', to: :region
           map_attribute 'place', to: :place
@@ -61,6 +75,8 @@ module Ammitto
           map 'day_of_month', to: :day_of_month
           map 'month_of_year', to: :month_of_year
           map 'year', to: :year
+          map 'year_range_from', to: :year_range_from
+          map 'year_range_to', to: :year_range_to
           map 'city', to: :city
           map 'region', to: :region
           map 'place', to: :place

--- a/lib/ammitto/sources/eu/transformer.rb
+++ b/lib/ammitto/sources/eu/transformer.rb
@@ -190,11 +190,17 @@ module Ammitto
 
           birthdates.map do |bd|
             # A year without a full birthdate stays a year — it is not
-            # padded into an invented January 1 date
+            # padded into an invented January 1 date. A stated span of
+            # years rides in the range bounds instead, where it suppresses
+            # both scalars; either bound may arrive alone, and circa is
+            # passed through untouched because the EU sets it both with
+            # and without a span.
             create_birth_info(
               date: bd.birthdate,
               circa: bd.circa,
               year: bd.year,
+              year_range_from: bd.year_range_from,
+              year_range_to: bd.year_range_to,
               city: [bd.city, bd.place].compact.first,
               region: bd.region,
               country: bd.country_description,

--- a/lib/ammitto/transformers/base_transformer.rb
+++ b/lib/ammitto/transformers/base_transformer.rb
@@ -5,6 +5,21 @@ require_relative '../utils/list_types_registry'
 
 module Ammitto
   module Transformers
+    # Raised when a source states a closed span of birth years whose
+    # lower bound is above its upper bound.
+    #
+    # The span is rejected rather than reordered. Reordering would
+    # publish a claim the source never made, and a reversed pair is far
+    # likelier to be a source or parsing defect than an intended fact.
+    # Rejection raises rather than returning nil so that "this value
+    # names no span" and "this value names a span that cannot be true"
+    # stay distinguishable — the second is a defect and must be visible.
+    #
+    # HarmonizeCommand rescues per file, records the offending filename,
+    # and fails its health gate, so one bad record neither aborts the
+    # run nor vanishes from it.
+    class InvalidYearRangeError < StandardError; end
+
     # BaseTransformer provides common functionality for transforming
     # source-specific models to the harmonized Ammitto ontology.
     #
@@ -30,6 +45,30 @@ module Ammitto
     #   end
     #
     class BaseTransformer
+      # Spellings read as a bare span of birth years. Every pattern is
+      # ANCHORED at both ends: a span is recognised only when the WHOLE
+      # value is one. "28 Feb 1962 to 28 Feb 1963" and "Mar 1980 to Mar
+      # 1981" are both live OFAC shapes that carry finer precision than
+      # a year span, and flattening them into one would discard the
+      # months and days the source did state.
+      #
+      # The hyphen spelling ("1962-1964") is deliberately absent. It
+      # appears in none of the corpora that state spans as text — 0 of
+      # 5795 distinct OFAC dateOfBirth values, none in the DFAT corpus —
+      # and the EU states its bounds as XML attributes rather than text.
+      # Such a value still yields no scalar year, via #multiple_years?,
+      # so it is an unsupported input rather than a misread one.
+      YEAR_RANGE_PATTERNS = [
+        /\A(?:approximately\s*:?\s*)?between\s+(\d{4})\s+and\s+(\d{4})\z/i,
+        /\A(\d{4})\s+to\s+(\d{4})\z/i
+      ].freeze
+
+      # Connectors that join the two halves of a span. Used to tell a
+      # span from a single point in time before Date._parse is asked for
+      # a date, because Date._parse reads only the first half and would
+      # publish one endpoint as though the source had stated it alone.
+      SPAN_CONNECTOR = /\s+(?:to|and)\s+/i
+
       attr_reader :source_code, :list_type
 
       # Initialize with source code and optional list type
@@ -208,9 +247,22 @@ module Ammitto
 
       # Create a BirthInfo from birth data.
       #
-      # Invariant: BirthInfo#date is set only when the source states a
-      # complete day-month-year; a bare or partial year rides in
-      # BirthInfo#year and is never padded into an invented date.
+      # Invariants:
+      #
+      # * BirthInfo#date is set only when the source states a complete
+      #   day-month-year; a bare or partial year rides in BirthInfo#year
+      #   and is never padded into an invented date.
+      # * A span of years rides in BirthInfo#year_range_from /
+      #   #year_range_to, and while one is present both #date and #year
+      #   stay nil. Neither bound is the birth year, so filling #year
+      #   with an endpoint would assert something the source never said.
+      # * circa is carried through from the source, never inferred from
+      #   the presence of a span.
+      #
+      # Bounds passed by a caller are authoritative: when either is
+      # given, the date string is not searched for a span, and a missing
+      # bound stays missing rather than being filled from the string.
+      #
       # @param date [String, Date, nil] birth date
       # @param circa [Boolean] whether the date is approximate
       # @param city [String, nil] birth city
@@ -218,9 +270,17 @@ module Ammitto
       # @param country [String, nil] birth country
       # @param country_iso_code [String, nil] ISO country code
       # @param year [Integer, String, nil] source-stated birth year
+      # @param year_range_from [Integer, String, nil] lower bound
+      # @param year_range_to [Integer, String, nil] upper bound
+      # @raise [InvalidYearRangeError] when a closed span runs backwards
       # @return [BirthInfo] the birth info
       def create_birth_info(date: nil, circa: false, city: nil, region: nil, country: nil,
-                            country_iso_code: nil, year: nil)
+                            country_iso_code: nil, year: nil,
+                            year_range_from: nil, year_range_to: nil)
+        bounds = stated_year_range(year_range_from, year_range_to) ||
+                 extract_year_range(date)
+        return birth_info_for_range(bounds, circa, city, region, country, country_iso_code) if bounds
+
         parsed_date = parse_complete_date(date)
 
         Ammitto::BirthInfo.new(
@@ -234,10 +294,83 @@ module Ammitto
         )
       end
 
+      # A span of years suppresses both scalars: date and year are the
+      # source's single-value claims, and a span makes neither.
+      # @param bounds [Array<Integer, nil>] validated [from, to]
+      # @return [BirthInfo] the birth info
+      def birth_info_for_range(bounds, circa, city, region, country, country_iso_code)
+        Ammitto::BirthInfo.new(
+          date: nil,
+          year: nil,
+          year_range_from: bounds.first,
+          year_range_to: bounds.last,
+          circa: circa,
+          city: city,
+          region: region,
+          country: country,
+          country_iso_code: country_iso_code
+        )
+      end
+
+      # Bounds a caller stated outright, as the EU does through its
+      # yearRangeFrom / yearRangeTo XML attributes.
+      # @param from [Integer, String, nil] lower bound
+      # @param to [Integer, String, nil] upper bound
+      # @raise [InvalidYearRangeError] when a closed span runs backwards
+      # @return [Array<Integer, nil>, nil] validated bounds, or nil
+      def stated_year_range(from, to)
+        lower = normalize_year(from)
+        upper = normalize_year(to)
+        return nil if lower.nil? && upper.nil?
+
+        validate_year_range(lower, upper)
+      end
+
+      # Bounds of a span stated as text, or nil when the value names no
+      # span. Recognition is anchored (see YEAR_RANGE_PATTERNS), so a
+      # value carrying finer precision is left for the scalar path,
+      # where the span guards then keep it from becoming a false date.
+      # @param value [Object] candidate date string
+      # @raise [InvalidYearRangeError] when a closed span runs backwards
+      # @return [Array<Integer>, nil] validated bounds, or nil
+      def extract_year_range(value)
+        return nil unless value.is_a?(String)
+
+        str = value.strip
+        pattern = YEAR_RANGE_PATTERNS.find { |candidate| candidate.match?(str) }
+        return nil unless pattern
+
+        match = pattern.match(str)
+        validate_year_range(match[1].to_i, match[2].to_i)
+      end
+
+      # A closed span must run forwards. Only a closed one can: an open
+      # bound has nothing to be out of order with.
+      # @param lower [Integer, nil] lower bound
+      # @param upper [Integer, nil] upper bound
+      # @raise [InvalidYearRangeError] when a closed span runs backwards
+      # @return [Array<Integer, nil>] the bounds, unchanged
+      def validate_year_range(lower, upper)
+        if lower && upper && lower > upper
+          raise InvalidYearRangeError,
+                "birth year range runs backwards: #{lower} > #{upper}"
+        end
+
+        [lower, upper]
+      end
+
       # Parse a value into a Date only when it states day, month and year.
       # Partial expressions ("1975", "Oct 1988", "00/00/1963") yield nil
       # instead of a date padded with invented components. Date instances
       # pass through: the caller already resolved them.
+      #
+      # A span yields nil too. Date._parse reads only the first half of
+      # "28 Feb 1962 to 28 Feb 1963" and of "01 Jan 1973 to 31 Dec 1973",
+      # so without the guard the opening endpoint was published as
+      # though the source had stated it as the birth date — and for the
+      # "01 Jan" shape, which OFAC writes 37 distinct ways to mean
+      # "some day that year", that is the invented January date this
+      # gem already set out to stop asserting.
       # @param value [Date, String, nil]
       # @return [Date, nil]
       def parse_complete_date(value)
@@ -245,6 +378,7 @@ module Ammitto
 
         str = value.to_s.strip
         return nil if str.empty?
+        return nil if date_span?(str)
 
         parts = Date._parse(str)
         return nil unless parts[:year] && parts[:mon] && parts[:mday]
@@ -254,19 +388,40 @@ module Ammitto
         nil
       end
 
+      # Whether a value states a span rather than one point in time.
+      # A connector splits it into two halves and each half names a
+      # year: "1962 to 1964", "28 Feb 1962 to 28 Feb 1963",
+      # "Between 1959 and 1965". Both halves are required to carry a
+      # year so that ordinary values keep parsing — "Jan and Feb 1970"
+      # splits into a yearless first half and is not a span.
+      #
+      # This is broader than #multiple_years? on purpose:
+      # "01 Jan 1973 to 31 Dec 1973" names one distinct year twice, and
+      # a uniqueness test cannot see the span in it.
+      # @param value [Object] candidate date string
+      # @return [Boolean]
+      def date_span?(value)
+        return false unless value.is_a?(String)
+
+        halves = value.strip.split(SPAN_CONNECTOR, 2)
+        halves.length == 2 && halves.all? { |half| /\d{4}/.match?(half) }
+      end
+
       # Year stated by a partial date string ("1975", "circa 1975",
-      # "Oct 1988", "00/00/1963"). A range such as "1962 to 1964" names
-      # no single year and yields nil — range handling is a separate,
-      # dedicated concern. That rejection is stated here rather than
-      # left to Date._parse, which returns no year for today's range
-      # spellings only incidentally.
+      # "Oct 1988", "00/00/1963"). A span such as "1962 to 1964" or
+      # "01 Jan 1973 to 31 Dec 1973" names no single year and yields
+      # nil: a recognised span rides in the range fields instead, and an
+      # unrecognised one is a shape this gem does not publish. Both
+      # rejections are stated here rather than left to Date._parse,
+      # which returns no year for some span spellings only incidentally
+      # and happily returns one for others.
       # @param value [Object] candidate date string
       # @return [Integer, nil]
       def extract_birth_year(value)
         return nil unless value.is_a?(String)
 
         str = value.strip.sub(/\A(?:circa|approximately|c\.?)\s*/i, '')
-        return nil if multiple_years?(str)
+        return nil if date_span?(str) || multiple_years?(str)
         return str.to_i if /\A\d{4}\z/.match?(str)
 
         year = Date._parse(str)[:year]

--- a/lib/ammitto/transformers/base_transformer.rb
+++ b/lib/ammitto/transformers/base_transformer.rb
@@ -69,6 +69,26 @@ module Ammitto
       # publish one endpoint as though the source had stated it alone.
       SPAN_CONNECTOR = /\s+(?:to|and)\s+/i
 
+      # A full-date span whose endpoints are complete dates, e.g.
+      # "01 Jan 1962 to 31 Dec 1962". OFAC writes this in dozens of
+      # spellings and it must not become its opening date — but when
+      # both endpoints carry the SAME year, that year is stated
+      # outright, twice, and the whole interval lies inside it. Reading
+      # it out is parsing, not inference, so the year survives even
+      # though no single day does.
+      #
+      # Deliberately strict: both endpoints must be complete. An
+      # abbreviated tail ("01 Jan 1973 to 31 Dec") states no year on its
+      # second endpoint, and a qualified value ("circa ...") is a
+      # different grammar that has not been designed.
+      SAME_YEAR_FULL_DATE_SPAN = /
+        \A
+        \d{1,2}\s+[[:alpha:]]{3,9}\s+(\d{4})
+        \s+to\s+
+        \d{1,2}\s+[[:alpha:]]{3,9}\s+(\d{4})
+        \z
+      /ix
+
       attr_reader :source_code, :list_type
 
       # Initialize with source code and optional list type
@@ -290,7 +310,8 @@ module Ammitto
           region: region,
           country: country,
           country_iso_code: country_iso_code,
-          year: normalize_year(year) || parsed_date&.year || extract_birth_year(date)
+          year: normalize_year(year) || parsed_date&.year ||
+                same_year_full_date_span(date) || extract_birth_year(date)
         )
       end
 
@@ -438,6 +459,26 @@ module Ammitto
       # here but not matched there publishes nothing, which is the point
       # — it is rejection of a value known to be misparsed, not support
       # for a spelling.
+      # The year both endpoints of a full-date span agree on, or nil.
+      #
+      # This runs only after parse_complete_date has already declined
+      # the value, so it never competes with a real date — it recovers
+      # the one fact a same-year span states unambiguously. A span whose
+      # endpoints name different years returns nil: no single birth year
+      # is asserted there, and the model has no date-valued range to
+      # hold what is.
+      #
+      # @param value [Object] candidate date string
+      # @return [Integer, nil]
+      def same_year_full_date_span(value)
+        return nil unless value.is_a?(String)
+
+        match = SAME_YEAR_FULL_DATE_SPAN.match(value.strip)
+        return nil unless match && match[1] == match[2]
+
+        match[1].to_i
+      end
+
       # @param value [Object] candidate date string
       # @return [Boolean]
       def date_span?(value)

--- a/lib/ammitto/transformers/base_transformer.rb
+++ b/lib/ammitto/transformers/base_transformer.rb
@@ -314,16 +314,32 @@ module Ammitto
 
       # Bounds a caller stated outright, as the EU does through its
       # yearRangeFrom / yearRangeTo XML attributes.
+      #
+      # Presence is decided BEFORE normalization, so a stated bound that
+      # is not a year cannot quietly become "no bound stated" and hand
+      # authority back to the date string. That fallback would let a
+      # record publish a span extracted from its text while the bounds
+      # the source actually stated were dropped unmentioned.
       # @param from [Integer, String, nil] lower bound
       # @param to [Integer, String, nil] upper bound
-      # @raise [InvalidYearRangeError] when a closed span runs backwards
+      # @raise [InvalidYearRangeError] when a bound is not a year, or a
+      #   closed span runs backwards
       # @return [Array<Integer, nil>, nil] validated bounds, or nil
       def stated_year_range(from, to)
-        lower = normalize_year(from)
-        upper = normalize_year(to)
-        return nil if lower.nil? && upper.nil?
+        return nil if from.nil? && to.nil?
 
-        validate_year_range(lower, upper)
+        validate_year_range(year_bound(from), year_bound(to))
+      end
+
+      # @param value [Integer, String, nil] a stated bound
+      # @raise [InvalidYearRangeError] when stated but not a year
+      # @return [Integer, nil]
+      def year_bound(value)
+        return nil if value.nil?
+
+        normalize_year(value) ||
+          raise(InvalidYearRangeError,
+                "birth year range bound is not a year: #{value.inspect}")
       end
 
       # Bounds of a span stated as text, or nil when the value names no
@@ -388,23 +404,47 @@ module Ammitto
         nil
       end
 
-      # Whether a value states a span rather than one point in time.
-      # A connector splits it into two halves and each half names a
-      # year: "1962 to 1964", "28 Feb 1962 to 28 Feb 1963",
-      # "Between 1959 and 1965". Both halves are required to carry a
-      # year so that ordinary values keep parsing — "Jan and Feb 1970"
-      # splits into a yearless first half and is not a span.
+      # Whether a value states a span rather than one point in time:
+      # some connector in it splits the value into two halves that each
+      # name a year. "1962 to 1964", "28 Feb 1962 to 28 Feb 1963",
+      # "Between 1959 and 1965". Both halves must carry a year so that
+      # ordinary values keep parsing — "Jan and Feb 1970" has a yearless
+      # first half and is not a span.
+      #
+      # EVERY connector is tried, not only the first, so a value whose
+      # opening connector is not the span connector still reads
+      # correctly. The two rules agree on all evidence available — 5795
+      # distinct OFAC dateOfBirth values and 12433 distinct birth-field
+      # strings across the fetched corpora classify identically either
+      # way — so this is the cheaper assumption to drop, not a fix for
+      # an observed failure.
       #
       # This is broader than #multiple_years? on purpose:
       # "01 Jan 1973 to 31 Dec 1973" names one distinct year twice, and
       # a uniqueness test cannot see the span in it.
+      #
+      # Known boundary: an abbreviated span whose second half omits the
+      # year ("01 Jan 1973 to 31 Dec") is NOT recognised, and Date._parse
+      # would still yield its opening endpoint. No corpus states one —
+      # 0 of 5795 OFAC values, 0 across the fetched corpora — so the
+      # shape is left unhandled rather than guessed at.
       # @param value [Object] candidate date string
       # @return [Boolean]
       def date_span?(value)
         return false unless value.is_a?(String)
 
-        halves = value.strip.split(SPAN_CONNECTOR, 2)
-        halves.length == 2 && halves.all? { |half| /\d{4}/.match?(half) }
+        str = value.strip
+        span_connector_offsets(str).any? do |start, finish|
+          /\d{4}/.match?(str[0...start]) && /\d{4}/.match?(str[finish..])
+        end
+      end
+
+      # @param str [String] candidate date string
+      # @return [Array<Array<Integer>>] each connector's [start, end]
+      def span_connector_offsets(str)
+        offsets = []
+        str.scan(SPAN_CONNECTOR) { offsets << Regexp.last_match.offset(0) }
+        offsets
       end
 
       # Year stated by a partial date string ("1975", "circa 1975",

--- a/lib/ammitto/transformers/base_transformer.rb
+++ b/lib/ammitto/transformers/base_transformer.rb
@@ -405,29 +405,39 @@ module Ammitto
       end
 
       # Whether a value states a span rather than one point in time:
-      # some connector in it splits the value into two halves that each
-      # name a year. "1962 to 1964", "28 Feb 1962 to 28 Feb 1963",
-      # "Between 1959 and 1965". Both halves must carry a year so that
-      # ordinary values keep parsing — "Jan and Feb 1970" has a yearless
-      # first half and is not a span.
+      # some connector in it splits the value into a dated first half
+      # and a second half that continues the date. "1962 to 1964",
+      # "28 Feb 1962 to 28 Feb 1963", "Between 1959 and 1965".
+      #
+      # The FIRST half must name a year and the second must carry at
+      # least a digit. That asymmetry is deliberate. Requiring a year on
+      # both sides would read "01 Jan 1973 to 31 Dec" as a single date
+      # and publish 1 January 1973 — a date the source never stated —
+      # because Date._parse reads the opening half and stops. This
+      # predicate exists to answer "is this NOT one complete date", and
+      # an abbreviated span is not one, whatever else it may be. The
+      # weaker second-half test costs nothing measurable: over the 5795
+      # distinct OFAC dateOfBirth values and the 12433 distinct
+      # birth-field strings in the fetched corpora it classifies exactly
+      # the same values as the both-halves rule.
+      #
+      # Requiring a year in the FIRST half is what keeps ordinary values
+      # parsing: "Jan and Feb 1970" has a yearless first half and is not
+      # a span.
       #
       # EVERY connector is tried, not only the first, so a value whose
       # opening connector is not the span connector still reads
-      # correctly. The two rules agree on all evidence available — 5795
-      # distinct OFAC dateOfBirth values and 12433 distinct birth-field
-      # strings across the fetched corpora classify identically either
-      # way — so this is the cheaper assumption to drop, not a fix for
-      # an observed failure.
+      # correctly.
       #
       # This is broader than #multiple_years? on purpose:
       # "01 Jan 1973 to 31 Dec 1973" names one distinct year twice, and
       # a uniqueness test cannot see the span in it.
       #
-      # Known boundary: an abbreviated span whose second half omits the
-      # year ("01 Jan 1973 to 31 Dec") is NOT recognised, and Date._parse
-      # would still yield its opening endpoint. No corpus states one —
-      # 0 of 5795 OFAC values, 0 across the fetched corpora — so the
-      # shape is left unhandled rather than guessed at.
+      # Recognising a span is not the same as publishing one: only the
+      # anchored YEAR_RANGE_PATTERNS produce bounds. A span recognised
+      # here but not matched there publishes nothing, which is the point
+      # — it is rejection of a value known to be misparsed, not support
+      # for a spelling.
       # @param value [Object] candidate date string
       # @return [Boolean]
       def date_span?(value)
@@ -435,7 +445,7 @@ module Ammitto
 
         str = value.strip
         span_connector_offsets(str).any? do |start, finish|
-          /\d{4}/.match?(str[0...start]) && /\d{4}/.match?(str[finish..])
+          /\d{4}/.match?(str[0...start]) && /\d/.match?(str[finish..])
         end
       end
 

--- a/spec/ammitto/birth_info_spec.rb
+++ b/spec/ammitto/birth_info_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# The harmonized birth record. Its contract is that each field states
+# exactly what the source stated: `date` one complete day-month-year,
+# `year` one year, and the range bounds a span. A span never borrows
+# either scalar, because neither bound is the birth year.
+RSpec.describe Ammitto::BirthInfo do
+  describe 'year range serialization' do
+    let(:span) do
+      described_class.new(year_range_from: 1959, year_range_to: 1965)
+    end
+
+    it 'publishes the bounds as camelCase JSON keys' do
+      json = JSON.parse(span.to_json)
+
+      expect(json['yearRangeFrom']).to eq(1959)
+      expect(json['yearRangeTo']).to eq(1965)
+    end
+
+    it 'round-trips both bounds through JSON' do
+      restored = described_class.from_json(span.to_json)
+
+      expect(restored.year_range_from).to eq(1959)
+      expect(restored.year_range_to).to eq(1965)
+    end
+
+    # YAML is the fetch artifact's format, so a bound that does not
+    # survive it never reaches harmonize at all.
+    it 'round-trips both bounds through YAML' do
+      restored = described_class.from_yaml(span.to_yaml)
+
+      expect(restored.year_range_from).to eq(1959)
+      expect(restored.year_range_to).to eq(1965)
+    end
+
+    it 'round-trips a bound that stands alone' do
+      open_above = described_class.new(year_range_from: 1953)
+      restored = described_class.from_yaml(open_above.to_yaml)
+
+      expect(restored.year_range_from).to eq(1953)
+      expect(restored.year_range_to).to be_nil
+    end
+  end
+
+  describe '#year_range?' do
+    it 'is true for either bound alone, and false for neither' do
+      expect(described_class.new(year_range_from: 1953)).to be_year_range
+      expect(described_class.new(year_range_to: 1958)).to be_year_range
+      expect(described_class.new(year: 1953)).not_to be_year_range
+    end
+  end
+
+  describe '#formatted_date' do
+    it 'renders a closed span as the span, not as either endpoint' do
+      span = described_class.new(year_range_from: 1959, year_range_to: 1965)
+
+      expect(span.formatted_date).to eq('1959-1965')
+    end
+
+    # An open bound must read as the direction it leaves open, or a
+    # one-sided span would be indistinguishable from a closed one.
+    it 'renders an open span as the direction it leaves open' do
+      expect(described_class.new(year_range_from: 1953).formatted_date)
+        .to eq('1953 or later')
+      expect(described_class.new(year_range_to: 1958).formatted_date)
+        .to eq('no later than 1958')
+    end
+
+    it 'still renders a single year and a complete date' do
+      expect(described_class.new(year: 1964).formatted_date).to eq('1964')
+      expect(described_class.new(date: Date.new(1964, 7, 17)).formatted_date)
+        .to eq('1964-07-17')
+    end
+  end
+
+  # The EU emits circa="true" and circa="false" alongside a span, so
+  # circa is the source's own claim about the span, not a consequence of
+  # there being one.
+  describe 'circa independence' do
+    it 'keeps circa false on a span by default' do
+      span = described_class.new(year_range_from: 1960, year_range_to: 1962)
+
+      expect(span.circa).to be false
+      expect(span.formatted_date).to eq('1960-1962')
+    end
+
+    it 'carries circa true alongside a span' do
+      span = described_class.new(year_range_from: 1953, year_range_to: 1958,
+                                 circa: true)
+
+      expect(span.circa).to be true
+      expect(span.formatted_date).to eq('c. 1953-1958')
+    end
+  end
+end

--- a/spec/ammitto/ontology/value_objects/birth_info_spec.rb
+++ b/spec/ammitto/ontology/value_objects/birth_info_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe Ammitto::Ontology::ValueObjects::BirthInfo do
       expect(described_class.new(region: 'BE')).to be_present
       expect(described_class.new(circa: true)).not_to be_present
     end
+
+    # A span is content. Counting only the scalars would drop a
+    # range-only record from every consumer that gates on #present?.
+    it 'counts either range bound on its own' do
+      expect(described_class.new(year_range_from: 1953)).to be_present
+      expect(described_class.new(year_range_to: 1958)).to be_present
+    end
   end
 
   describe '#to_s' do
@@ -44,6 +51,55 @@ RSpec.describe Ammitto::Ontology::ValueObjects::BirthInfo do
   describe '#to_hash' do
     it 'omits the default circa=false' do
       expect(described_class.new(year: 1964).to_hash).to eq({ year: 1964 })
+    end
+
+    it 'carries both bounds, and a lone bound alone' do
+      span = described_class.new(year_range_from: 1959, year_range_to: 1965)
+      expect(span.to_hash)
+        .to eq({ year_range_from: 1959, year_range_to: 1965 })
+
+      expect(described_class.new(year_range_to: 1980).to_hash)
+        .to eq({ year_range_to: 1980 })
+    end
+  end
+
+  describe 'year range display and serialization' do
+    it 'renders a closed span, and an open one as its open direction' do
+      expect(described_class.new(year_range_from: 1959, year_range_to: 1965).to_s)
+        .to eq('1959-1965')
+      expect(described_class.new(year_range_from: 1953).to_s)
+        .to eq('1953 or later')
+      expect(described_class.new(year_range_to: 1958).to_s)
+        .to eq('no later than 1958')
+    end
+
+    it 'keeps circa independent of the span' do
+      expect(described_class.new(year_range_from: 1953, year_range_to: 1958,
+                                 circa: true).to_s)
+        .to eq('c. 1953-1958')
+      expect(described_class.new(year_range_from: 1960, year_range_to: 1962).to_s)
+        .to eq('1960-1962')
+    end
+
+    it 'round-trips both bounds through YAML and JSON' do
+      span = described_class.new(year_range_from: 1959, year_range_to: 1965)
+
+      from_yaml = described_class.from_yaml(span.to_yaml)
+      expect(from_yaml.year_range_from).to eq(1959)
+      expect(from_yaml.year_range_to).to eq(1965)
+
+      from_json = described_class.from_json(span.to_json)
+      expect(from_json.year_range_from).to eq(1959)
+      expect(from_json.year_range_to).to eq(1965)
+    end
+
+    # The Neo4j property list drives both import and export, so a name
+    # missing from it is a field that never reaches the graph.
+    it 'carries both bounds into the Neo4j properties' do
+      span = described_class.new(year_range_from: 1959, year_range_to: 1965)
+
+      expect(span.neo4j_properties)
+        .to include(year_range_from: 1959, year_range_to: 1965)
     end
   end
 end

--- a/spec/ammitto/serialization/json_ld_serializer_spec.rb
+++ b/spec/ammitto/serialization/json_ld_serializer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'ammitto'
+require 'json/ld'
 
 RSpec.describe Ammitto::Serialization::JsonLdSerializer do
   subject(:serializer) { described_class.new }
@@ -203,6 +204,27 @@ RSpec.describe Ammitto::Serialization::JsonLdSerializer do
     it 'keeps the existing birthYear term untouched' do
       expect(terms['birthYear'])
         .to eq({ '@id' => 'birthYear', '@type' => 'xsd:gYear' })
+    end
+
+    # Two configuration hashes agreeing proves only that two hashes
+    # agree. This expands a real birth node against the real context and
+    # reads the datatype off the resulting literals, which is what a
+    # consumer actually gets.
+    it 'expands the year keys to gYear literals, not bare numbers' do
+      node = serializer.serialize_entity(
+        build_entity(birth_info: [Ammitto::BirthInfo.new(
+          year_range_from: 1953, year_range_to: 1958
+        )])
+      ).merge(Ammitto::Schema::Context.context)
+
+      vocab = 'https://ammitto.org/schema/v1/'
+      birth = JSON::LD::API.expand(node).first["#{vocab}birthInfo"].first
+
+      %w[yearRangeFrom yearRangeTo].each do |term|
+        literal = birth["#{vocab}#{term}"].first
+        expect(literal['@type'])
+          .to eq('http://www.w3.org/2001/XMLSchema#gYear')
+      end
     end
   end
 

--- a/spec/ammitto/serialization/json_ld_serializer_spec.rb
+++ b/spec/ammitto/serialization/json_ld_serializer_spec.rb
@@ -142,6 +142,70 @@ RSpec.describe Ammitto::Serialization::JsonLdSerializer do
     end
   end
 
+  # A field that is not serialized is a field the website never sees,
+  # however faithfully the models carry it.
+  describe 'birth year ranges' do
+    def birth_node(**attrs)
+      entity = build_entity(birth_info: [Ammitto::BirthInfo.new(**attrs)])
+      serializer.serialize_entity(entity)['birthInfo'].first
+    end
+
+    it 'emits both bounds under the camelCase contract names' do
+      node = birth_node(year_range_from: 1953, year_range_to: 1958)
+
+      expect(node['yearRangeFrom']).to eq(1953)
+      expect(node['yearRangeTo']).to eq(1958)
+    end
+
+    it 'emits only the bound that exists, leaving the span open' do
+      node = birth_node(year_range_to: 1980)
+
+      expect(node['yearRangeTo']).to eq(1980)
+      expect(node).not_to have_key('yearRangeFrom')
+    end
+
+    it 'emits no year alongside a span' do
+      expect(birth_node(year_range_from: 1953, year_range_to: 1958))
+        .not_to have_key('year')
+    end
+
+    it 'keeps circa independent of the span' do
+      expect(birth_node(year_range_from: 1953, year_range_to: 1958, circa: true)['circa'])
+        .to be true
+    end
+
+    # An exact-year record must come out the shape it always did, so a
+    # consumer reading today's artifacts sees no change at all.
+    it 'leaves an exact-year record byte-identical apart from ordering' do
+      expect(birth_node(year: 1964, city: 'Bern').sort.to_h)
+        .to eq({ '@type' => 'BirthInfo', 'circa' => false,
+                 'year' => 1964, 'city' => 'Bern' }.sort.to_h)
+    end
+  end
+
+  describe 'the generated JSON-LD context' do
+    let(:terms) { Ammitto::Schema::Context.context['@context'] }
+
+    it 'declares both bounds as gYear, so a consumer can type them' do
+      expect(terms['yearRangeFrom'])
+        .to eq({ '@id' => 'yearRangeFrom', '@type' => 'xsd:gYear' })
+      expect(terms['yearRangeTo'])
+        .to eq({ '@id' => 'yearRangeTo', '@type' => 'xsd:gYear' })
+    end
+
+    # The serializer has always emitted 'year' inside a BirthInfo node,
+    # and the pre-existing 'birthYear' term describes the flat
+    # entity-level key, not this one.
+    it 'declares the year key the serializer actually emits' do
+      expect(terms['year']).to eq({ '@id' => 'year', '@type' => 'xsd:gYear' })
+    end
+
+    it 'keeps the existing birthYear term untouched' do
+      expect(terms['birthYear'])
+        .to eq({ '@id' => 'birthYear', '@type' => 'xsd:gYear' })
+    end
+  end
+
   describe '#serialize_document' do
     let(:document) { serializer.serialize_document(entities: [build_entity], entries: [build_entry]) }
     let(:entity_node) { document['@graph'].find { |n| n['@id'] == entity_iri } }

--- a/spec/ammitto/serialization/ontology_exporter_spec.rb
+++ b/spec/ammitto/serialization/ontology_exporter_spec.rb
@@ -42,6 +42,47 @@ RSpec.describe Ammitto::Serialization::OntologyExporter do
       expect(data['@graph']).to be_an(Array)
     end
 
+    # The ontology and the JSON-LD context describe the SAME properties.
+    # A consumer that reads both must not be told two datatypes for one
+    # property, so the year-valued BirthInfo properties are gYear in
+    # both places.
+    describe 'the BirthInfo year properties' do
+      let(:properties) do
+        file = File.join(output_dir, 'ontology', 'properties.jsonld')
+        JSON.parse(File.read(file))['@graph']
+      end
+
+      def range_of(id)
+        properties.find { |p| p['@id'].to_s.end_with?("/#{id}") }&.fetch('range')
+      end
+
+      it 'publishes both range bounds' do
+        expect(range_of('yearRangeFrom'))
+          .to eq('http://www.w3.org/2001/XMLSchema#gYear')
+        expect(range_of('yearRangeTo'))
+          .to eq('http://www.w3.org/2001/XMLSchema#gYear')
+      end
+
+      it 'agrees with the context on the year datatype' do
+        context_type =
+          Ammitto::Schema::Context.context['@context']['year']['@type']
+
+        expect(context_type).to eq('xsd:gYear')
+        expect(range_of('year'))
+          .to eq('http://www.w3.org/2001/XMLSchema#gYear')
+      end
+
+      it 'lists both bounds among the BirthInfo class properties' do
+        file = File.join(output_dir, 'ontology', 'classes.jsonld')
+        birth = JSON.parse(File.read(file))['@graph']
+                    .find { |c| c['@id'].to_s.end_with?('/BirthInfo') }
+
+        expect(birth['properties'])
+          .to include('https://www.ammitto.org/ontology/yearRangeFrom',
+                      'https://www.ammitto.org/ontology/yearRangeTo')
+      end
+    end
+
     it 'creates hierarchy.json' do
       hierarchy_file = File.join(output_dir, 'ontology', 'hierarchy.json')
       expect(File.exist?(hierarchy_file)).to be true

--- a/spec/ammitto/serialization/ontology_exporter_spec.rb
+++ b/spec/ammitto/serialization/ontology_exporter_spec.rb
@@ -42,10 +42,11 @@ RSpec.describe Ammitto::Serialization::OntologyExporter do
       expect(data['@graph']).to be_an(Array)
     end
 
-    # The ontology and the JSON-LD context describe the SAME properties.
-    # A consumer that reads both must not be told two datatypes for one
-    # property, so the year-valued BirthInfo properties are gYear in
-    # both places.
+    # The ontology browser and the JSON-LD context describe the same
+    # fields to the same reader (under different bases, so they are not
+    # literally one RDF property). Telling that reader "integer" in one
+    # and "gYear" in the other is a contradiction, so the year-valued
+    # BirthInfo properties are gYear in both.
     describe 'the BirthInfo year properties' do
       let(:properties) do
         file = File.join(output_dir, 'ontology', 'properties.jsonld')

--- a/spec/ammitto/serialization/search_index_exporter_spec.rb
+++ b/spec/ammitto/serialization/search_index_exporter_spec.rb
@@ -132,6 +132,63 @@ RSpec.describe Ammitto::Serialization::SearchIndexExporter do
       expect(exporter.entities.first[:birthYear]).to eq('1984')
     end
 
+    # birthYear answers "born in this exact year". A span names no such
+    # year, so it gets its own columns and birthYear stays absent — a
+    # lower bound written there would let a record that never claimed a
+    # year answer an exact-year query.
+    context 'with a stated span of birth years' do
+      def row_for(birth_info)
+        exporter.add({
+                       '@id' => 'https://www.ammitto.org/entity/eu/test',
+                       'entityType' => 'person',
+                       'names' => [{ 'fullName' => 'Test' }],
+                       'birthInfo' => [birth_info]
+                     },
+                     { 'authority' => { '@id' => 'https://www.ammitto.org/authority/eu' },
+                       'status' => 'active' })
+        exporter.entities.first
+      end
+
+      it 'exports the bounds and omits birthYear entirely' do
+        row = row_for({ 'yearRangeFrom' => 1953, 'yearRangeTo' => 1958 })
+
+        expect(row[:birthYearFrom]).to eq('1953')
+        expect(row[:birthYearTo]).to eq('1958')
+        expect(row).not_to have_key(:birthYear)
+      end
+
+      it 'exports only the bound that exists, leaving the span open' do
+        row = row_for({ 'yearRangeTo' => 1980 })
+
+        expect(row[:birthYearTo]).to eq('1980')
+        expect(row).not_to have_key(:birthYearFrom)
+        expect(row).not_to have_key(:birthYear)
+      end
+
+      it 'reads the snake_case spelling too' do
+        row = row_for({ 'year_range_from' => 1959, 'year_range_to' => 1965 })
+
+        expect(row[:birthYearFrom]).to eq('1959')
+        expect(row[:birthYearTo]).to eq('1965')
+      end
+    end
+
+    it 'still exports birthYear for a stated single year, with no bounds' do
+      exporter.add({
+                     '@id' => 'https://www.ammitto.org/entity/eu/y',
+                     'entityType' => 'person',
+                     'names' => [{ 'fullName' => 'Test' }],
+                     'birthInfo' => [{ 'year' => 1964 }]
+                   },
+                   { 'authority' => { '@id' => 'https://www.ammitto.org/authority/eu' },
+                     'status' => 'active' })
+
+      row = exporter.entities.first
+      expect(row[:birthYear]).to eq('1964')
+      expect(row).not_to have_key(:birthYearFrom)
+      expect(row).not_to have_key(:birthYearTo)
+    end
+
     it 'extracts IMO for vessels' do
       entity = {
         '@id' => 'https://www.ammitto.org/entity/eu_vessels/test',

--- a/spec/ammitto/serialization/search_index_exporter_spec.rb
+++ b/spec/ammitto/serialization/search_index_exporter_spec.rb
@@ -132,6 +132,45 @@ RSpec.describe Ammitto::Serialization::SearchIndexExporter do
       expect(exporter.entities.first[:birthYear]).to eq('1984')
     end
 
+    # An entity can carry one birth record per contributing source, and
+    # the one holding the exact date is not reliably first. Reading only
+    # `birthInfo.first` dropped a stated year whenever a location-only or
+    # empty record preceded it — while the span path already scanned the
+    # whole list, so a range was found where a more precise year was not.
+    it 'finds an exact year in a birth record that is not the first' do
+      entity = {
+        '@id' => 'https://www.ammitto.org/entity/un/later-record',
+        'entityType' => 'person',
+        'names' => [{ 'fullName' => 'Test' }],
+        'birthInfo' => [
+          { 'city' => 'Pyongyang' },
+          { 'date' => '1984-01-08' }
+        ]
+      }
+
+      exporter.add(entity, 'authority' => { '@id' => 'https://www.ammitto.org/authority/un' },
+                           'status' => 'active')
+
+      expect(exporter.entities.first[:birthYear]).to eq('1984')
+    end
+
+    it 'still prefers the earliest record that states one' do
+      entity = {
+        '@id' => 'https://www.ammitto.org/entity/un/two-records',
+        'entityType' => 'person',
+        'names' => [{ 'fullName' => 'Test' }],
+        'birthInfo' => [
+          { 'year' => 1984 },
+          { 'date' => '1990-01-08' }
+        ]
+      }
+
+      exporter.add(entity, 'authority' => { '@id' => 'https://www.ammitto.org/authority/un' },
+                           'status' => 'active')
+
+      expect(exporter.entities.first[:birthYear]).to eq('1984')
+    end
+
     # birthYear answers "born in this exact year". A span names no such
     # year, so it gets its own columns and birthYear stays absent — a
     # lower bound written there would let a record that never claimed a

--- a/spec/ammitto/serialization/search_index_exporter_spec.rb
+++ b/spec/ammitto/serialization/search_index_exporter_spec.rb
@@ -173,6 +173,41 @@ RSpec.describe Ammitto::Serialization::SearchIndexExporter do
       end
     end
 
+    # An entity can carry several birth records, and the span is not
+    # always the first one. Reading only the first dropped it silently.
+    context 'with several birth records' do
+      def row_for_all(birth_infos)
+        exporter.add({
+                       '@id' => 'https://www.ammitto.org/entity/eu/multi',
+                       'entityType' => 'person',
+                       'names' => [{ 'fullName' => 'Test' }],
+                       'birthInfo' => birth_infos
+                     },
+                     { 'authority' => { '@id' => 'https://www.ammitto.org/authority/eu' },
+                       'status' => 'active' })
+        exporter.entities.first
+      end
+
+      it 'finds a span that is not the first record' do
+        row = row_for_all([{ 'year' => 1964 },
+                           { 'yearRangeFrom' => 1953, 'yearRangeTo' => 1958 }])
+
+        expect(row[:birthYearFrom]).to eq('1953')
+        expect(row[:birthYearTo]).to eq('1958')
+      end
+
+      # Both bounds must come from ONE record. Taking a lower bound from
+      # one and an upper from another would publish a span no source
+      # ever stated.
+      it 'takes both bounds from the same record' do
+        row = row_for_all([{ 'yearRangeFrom' => 1953 },
+                           { 'yearRangeFrom' => 1970, 'yearRangeTo' => 1975 }])
+
+        expect(row[:birthYearFrom]).to eq('1953')
+        expect(row).not_to have_key(:birthYearTo)
+      end
+    end
+
     it 'still exports birthYear for a stated single year, with no bounds' do
       exporter.add({
                      '@id' => 'https://www.ammitto.org/entity/eu/y',

--- a/spec/ammitto/sources/au/flexible_date_spec.rb
+++ b/spec/ammitto/sources/au/flexible_date_spec.rb
@@ -42,15 +42,59 @@ RSpec.describe Ammitto::Sources::Au::FlexibleDate do
       expect(described_class.parse(nil)).to be_nil
     end
 
-    # DFAT publishes ranges in this shape. The day group used to match the
-    # "59" inside 1959, and parse_month returned 0 for "and", so the record
-    # asserted day 59 of month 0 at full precision.
+    # DFAT publishes ranges in this shape, and it is the only multi-year
+    # date-of-birth spelling in the whole corpus. The day group used to
+    # match the "59" inside 1959, and parse_month returned 0 for "and",
+    # so the record asserted day 59 of month 0 at full precision.
     it 'does not read a day out of the middle of a year' do
       date = described_class.parse('Approximately: Between 1959 and 1965')
 
       expect(date.day).to be_nil
       expect(date.month).to be_nil
-      expect(date.precision).to eq('year')
+      expect(date.precision).to eq('range')
+    end
+
+    # The year-only fallback used to seize the first year in the value
+    # and publish 1959 as THE birth year. Neither bound is that.
+    it 'records both bounds of a span and claims no single year' do
+      date = described_class.parse('Approximately: Between 1959 and 1965')
+
+      expect(date.year_range_from).to eq(1959)
+      expect(date.year_range_to).to eq(1965)
+      expect(date.year).to be_nil
+    end
+
+    it 'marks the "Approximately" span circa, which it did not before' do
+      expect(described_class.parse('Approximately: Between 1959 and 1965').circa)
+        .to be true
+    end
+
+    # Circa follows the source's own marker. A span is not approximate
+    # by itself: "Between 1959 and 1965" states its bounds exactly.
+    it 'leaves a span without the marker un-circa' do
+      date = described_class.parse('Between 1959 and 1965')
+
+      expect(date.year_range_from).to eq(1959)
+      expect(date.year_range_to).to eq(1965)
+      expect(date.circa).to be false
+      expect(date.precision).to eq('range')
+    end
+
+    it 'has no date to offer for a span' do
+      expect(described_class.parse('Between 1959 and 1965').to_date).to be_nil
+    end
+
+    # A span parse must survive the fetch artifact, which is where these
+    # values live between fetch and harmonize.
+    it 'round-trips both bounds through YAML' do
+      date = described_class.parse('Approximately: Between 1959 and 1965')
+      restored = described_class.from_yaml(date.to_yaml)
+
+      expect(restored.year_range_from).to eq(1959)
+      expect(restored.year_range_to).to eq(1965)
+      expect(restored.circa).to be true
+      expect(restored.precision).to eq('range')
+      expect(restored.year).to be_nil
     end
 
     it 'drops a month that did not resolve rather than storing zero' do

--- a/spec/ammitto/sources/au/transformer_spec.rb
+++ b/spec/ammitto/sources/au/transformer_spec.rb
@@ -127,6 +127,42 @@ RSpec.describe Ammitto::Sources::Au::Transformer do
       end
     end
 
+    # DFAT states a span of years in one shape, and it is the only
+    # multi-year date-of-birth value in the corpus (record au-8824).
+    # The transformer used to publish 1959 as THE birth year.
+    context 'when transforming a stated span of years' do
+      def birth_for(raw)
+        individual = Ammitto::Sources::Au::Individual.new(
+          reference: '8824',
+          dates_of_birth: [Ammitto::Sources::Au::FlexibleDate.parse(raw)],
+          places_of_birth: []
+        )
+        transformer.send(:transform_birth_info, individual).first
+      end
+
+      it 'carries both bounds through and claims no year or date' do
+        birth = birth_for('Approximately: Between 1959 and 1965')
+
+        expect(birth.year_range_from).to eq(1959)
+        expect(birth.year_range_to).to eq(1965)
+        expect(birth.year).to be_nil
+        expect(birth.date).to be_nil
+      end
+
+      it 'marks the "Approximately" span circa' do
+        expect(birth_for('Approximately: Between 1959 and 1965').circa).to be true
+      end
+
+      # A span is not approximate by itself; without the source's own
+      # marker it states its bounds exactly.
+      it 'leaves a span without the marker un-circa' do
+        birth = birth_for('Between 1959 and 1965')
+
+        expect(birth.year_range_from).to eq(1959)
+        expect(birth.circa).to be false
+      end
+    end
+
     context 'when transforming a vessel' do
       let(:vessel) do
         Ammitto::Sources::Au::Vessel.new(

--- a/spec/ammitto/sources/eu/birthdate_spec.rb
+++ b/spec/ammitto/sources/eu/birthdate_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# The EU states a span of birth years as two XML attributes rather than
+# as text. The pipeline runs XML -> source model -> YAML (the fetch
+# artifact) -> BirthInfo (harmonize), so each hop is checked: a bound
+# that survives parsing but not the YAML artifact never reaches
+# harmonize at all.
+#
+# The fixture attributes are copied verbatim from the live EU
+# consolidated export, which carries 55 yearRangeFrom and 56
+# yearRangeTo attributes.
+RSpec.describe Ammitto::Sources::Eu::Birthdate do
+  def parse(attributes)
+    described_class.from_xml(<<~XML)
+      <birthdate xmlns="http://eu.europa.ec/fpi/fsd/export" #{attributes}/>
+    XML
+  end
+
+  # logicalId 1865 in the live export.
+  let(:closed_span) do
+    parse('circa="true" calendarType="GREGORIAN" ' \
+          'city="Tirin Kot District, Uruzgan Province" ' \
+          'yearRangeFrom="1953" yearRangeTo="1958" countryIso2Code="AF" ' \
+          'countryDescription="AFGHANISTAN" logicalId="1865"')
+  end
+
+  # logicalId 117055 — the one record in the export that states an upper
+  # bound and no lower one.
+  let(:open_below) do
+    parse('circa="false" calendarType="GREGORIAN" yearRangeTo="1980" ' \
+          'countryIso2Code="ER" countryDescription="ERITREA" ' \
+          'logicalId="117055"')
+  end
+
+  it 'reads both native attributes off the XML' do
+    expect(closed_span.year_range_from).to eq(1953)
+    expect(closed_span.year_range_to).to eq(1958)
+  end
+
+  it 'reads a bound that stands alone' do
+    expect(open_below.year_range_to).to eq(1980)
+    expect(open_below.year_range_from).to be_nil
+  end
+
+  it 'carries both bounds through the YAML fetch artifact' do
+    restored = described_class.from_yaml(closed_span.to_yaml)
+
+    expect(restored.year_range_from).to eq(1953)
+    expect(restored.year_range_to).to eq(1958)
+  end
+
+  it 'carries a lone bound through the YAML fetch artifact' do
+    restored = described_class.from_yaml(open_below.to_yaml)
+
+    expect(restored.year_range_to).to eq(1980)
+    expect(restored.year_range_from).to be_nil
+  end
+
+  # circa and the span are independent claims: the export carries both
+  # settings alongside a span, so circa must not be read off the span.
+  it 'keeps circa independent of the span, in both settings' do
+    expect(closed_span.circa).to be true
+    expect(open_below.circa).to be false
+  end
+
+  describe 'through the transformer, from the YAML artifact' do
+    let(:transformer) { Ammitto::Sources::Eu::Transformer.new }
+
+    def birth_from_yaml(birthdate)
+      restored = described_class.from_yaml(birthdate.to_yaml)
+      transformer.send(:transform_birthdates, [restored]).first
+    end
+
+    it 'lands both bounds in BirthInfo and claims no single year' do
+      birth = birth_from_yaml(closed_span)
+
+      expect(birth.year_range_from).to eq(1953)
+      expect(birth.year_range_to).to eq(1958)
+      expect(birth.year).to be_nil
+      expect(birth.date).to be_nil
+    end
+
+    it 'preserves circa=true alongside the span' do
+      expect(birth_from_yaml(closed_span).circa).to be true
+    end
+
+    it 'lands a lone upper bound without inventing a lower one' do
+      birth = birth_from_yaml(open_below)
+
+      expect(birth.year_range_to).to eq(1980)
+      expect(birth.year_range_from).to be_nil
+      expect(birth.year).to be_nil
+    end
+
+    it 'keeps the birth place on a span record' do
+      expect(birth_from_yaml(closed_span).country).to eq('AFGHANISTAN')
+    end
+
+    it 'leaves an ordinary year-only record alone' do
+      plain = parse('year="1962" countryIso2Code="AF"')
+      birth = birth_from_yaml(plain)
+
+      expect(birth.year).to eq(1962)
+      expect(birth.year_range_from).to be_nil
+      expect(birth.year_range_to).to be_nil
+    end
+  end
+end

--- a/spec/ammitto/sources/us/transformer_spec.rb
+++ b/spec/ammitto/sources/us/transformer_spec.rb
@@ -95,10 +95,18 @@ RSpec.describe Ammitto::Sources::Us::Transformer do
     # to go: OFAC writes "01 Jan YYYY to 31 Dec YYYY" 37 distinct ways to
     # mean "some day that year". Reading it as 1 January asserted the
     # invented January date this gem set out to stop asserting.
-    it 'never reads a whole-year span as its 1 January opening date' do
+    #
+    # The year survives, though. Both endpoints state 1973 and the whole
+    # interval lies inside it, so discarding the year to avoid the false
+    # day would throw away a certainly-true fact about a sanctioned
+    # person. All four fields are asserted because getting the day right
+    # and the bounds wrong would be just as much a defect.
+    it 'keeps the stated year of a whole-year span without its 1 January date' do
       birth = birth_for('01 Jan 1973 to 31 Dec 1973')
       expect(birth.date).to be_nil
-      expect(birth.year).to be_nil
+      expect(birth.year).to eq(1973)
+      expect(birth.year_range_from).to be_nil
+      expect(birth.year_range_to).to be_nil
     end
 
     it 'still resolves an ordinary date that merely contains a month name' do

--- a/spec/ammitto/sources/us/transformer_spec.rb
+++ b/spec/ammitto/sources/us/transformer_spec.rb
@@ -60,18 +60,49 @@ RSpec.describe Ammitto::Sources::Us::Transformer do
       expect(birth.year).to eq(1988)
     end
 
-    # Range handling is deliberately deferred (separate design); these
-    # pin today's behavior so a later range design changes it knowingly.
-    it 'pins year ranges to no date and no year, pending range handling' do
+    # "YYYY to YYYY" is the only bare year-span spelling OFAC uses: 52
+    # of the 5795 distinct dateOfBirth values in the live SDN export
+    # take that shape, and none takes a hyphenated one.
+    it 'reads a year span into the range bounds, leaving both scalars nil' do
       birth = birth_for('1962 to 1964')
+      expect(birth.year_range_from).to eq(1962)
+      expect(birth.year_range_to).to eq(1964)
       expect(birth.date).to be_nil
       expect(birth.year).to be_nil
     end
 
-    it 'pins full-date ranges to their opening date, pending range handling' do
+    it 'does not mark a span circa: OFAC states these bounds exactly' do
+      expect(birth_for('1962 to 1964').circa).to be false
+    end
+
+    # KNOWN GAP, deliberate. A full-date span carries day precision that
+    # year bounds cannot hold, and the harmonized contract has no
+    # date-valued range, so such a record publishes nothing at all.
+    # Reducing it to 1962-1964 would discard the days and months the
+    # source did state; asserting its opening date, which this
+    # transformer used to do, invented a single date the source never
+    # stated. Of the 117 spans in the live SDN export, 65 are of this
+    # finer-precision kind.
+    it 'publishes nothing for a full-date span rather than its opening date' do
       birth = birth_for('28 Feb 1962 to 28 Feb 1963')
-      expect(birth.date).to eq(Date.new(1962, 2, 28))
-      expect(birth.year).to eq(1962)
+      expect(birth.date).to be_nil
+      expect(birth.year).to be_nil
+      expect(birth.year_range_from).to be_nil
+      expect(birth.year_range_to).to be_nil
+    end
+
+    # The costliest case of that gap, and the reason the opening date had
+    # to go: OFAC writes "01 Jan YYYY to 31 Dec YYYY" 37 distinct ways to
+    # mean "some day that year". Reading it as 1 January asserted the
+    # invented January date this gem set out to stop asserting.
+    it 'never reads a whole-year span as its 1 January opening date' do
+      birth = birth_for('01 Jan 1973 to 31 Dec 1973')
+      expect(birth.date).to be_nil
+      expect(birth.year).to be_nil
+    end
+
+    it 'still resolves an ordinary date that merely contains a month name' do
+      expect(birth_for('28 Feb 1962').date).to eq(Date.new(1962, 2, 28))
     end
   end
 end

--- a/spec/ammitto/transformers/base_transformer_spec.rb
+++ b/spec/ammitto/transformers/base_transformer_spec.rb
@@ -157,8 +157,9 @@ RSpec.describe Ammitto::Transformers::BaseTransformer do
       end
     end
 
-    # A full-date span carries days the year bounds cannot hold, so it
-    # publishes nothing at all rather than a coarsened or invented claim.
+    # A full-date span crossing years carries days the year bounds
+    # cannot hold and names no single birth year, so it publishes
+    # nothing rather than a coarsened or invented claim.
     it 'does not reduce a full-date span to a year span' do
       info = birth(date: '28 Feb 1962 to 28 Feb 1963')
 
@@ -166,6 +167,39 @@ RSpec.describe Ammitto::Transformers::BaseTransformer do
       expect(info.year_range_to).to be_nil
       expect(info.date).to be_nil
       expect(info.year).to be_nil
+    end
+
+    # ...but when both endpoints state the SAME year, that year is
+    # asserted outright, twice, and the whole interval lies inside it.
+    # Publishing nothing there would discard a certainly-true fact to
+    # avoid a false one that is not on offer.
+    it 'retains the exact year from a same-year full-date span' do
+      info = birth(date: '01 Jan 1962 to 31 Dec 1962')
+
+      expect(info.year).to eq(1962)
+      expect(info.date).to be_nil
+      expect(info.year_range_from).to be_nil
+      expect(info.year_range_to).to be_nil
+    end
+
+    # Not special-cased to whole-calendar-year endpoints — what matters
+    # is that both endpoints name the same year, not which days they are.
+    it 'retains the year from a partial same-year span' do
+      info = birth(date: '28 Feb 1962 to 07 Dec 1962')
+
+      expect(info.year).to eq(1962)
+      expect(info.date).to be_nil
+    end
+
+    # A qualified span is a grammar nobody designed. It stays silent
+    # rather than being folded into the strict same-year rule.
+    it 'stays silent on a qualified same-year span' do
+      info = birth(date: 'circa 01 Jan 1962 to 31 Dec 1962')
+
+      expect(info.year).to be_nil
+      expect(info.date).to be_nil
+      expect(info.year_range_from).to be_nil
+      expect(info.year_range_to).to be_nil
     end
 
     it 'does not reduce a month span either' do

--- a/spec/ammitto/transformers/base_transformer_spec.rb
+++ b/spec/ammitto/transformers/base_transformer_spec.rb
@@ -175,6 +175,19 @@ RSpec.describe Ammitto::Transformers::BaseTransformer do
       expect(info.date).to be_nil
       expect(info.year).to be_nil
     end
+
+    # Recognising a span and publishing one are separate. An abbreviated
+    # span matches no anchored pattern, so it yields no bounds — but it
+    # must not yield the 1 January date Date._parse reads out of its
+    # opening half either.
+    it 'publishes nothing at all for an abbreviated span' do
+      info = birth(date: '01 Jan 1973 to 31 Dec')
+
+      expect(info.date).to be_nil
+      expect(info.year).to be_nil
+      expect(info.year_range_from).to be_nil
+      expect(info.year_range_to).to be_nil
+    end
   end
 
   # Rejected, not reordered: reordering would publish a span the source
@@ -314,12 +327,17 @@ RSpec.describe Ammitto::Transformers::BaseTransformer do
         .to be true
     end
 
-    # KNOWN BOUNDARY, stated rather than discovered later: an
-    # abbreviated span whose second half omits the year is not
-    # recognised. No corpus states one, so the shape is left unhandled
-    # rather than guessed at.
-    it 'does not recognise a span whose second half omits the year' do
-      expect(transformer.send(:date_span?, '01 Jan 1973 to 31 Dec')).to be false
+    # No corpus states an abbreviated span, so no bounds are extracted
+    # from one. It is still recognised as a span, because the question
+    # this predicate answers is "is this NOT one complete date" — and
+    # Date._parse would otherwise read its opening half and publish
+    # 1 January 1973 as a stated birth date.
+    it 'recognises a span whose second half omits the year' do
+      expect(transformer.send(:date_span?, '01 Jan 1973 to 31 Dec')).to be true
+    end
+
+    it 'needs a year in the first half, not merely digits' do
+      expect(transformer.send(:date_span?, 'Jan 5 and Feb 1970')).to be false
     end
   end
 

--- a/spec/ammitto/transformers/base_transformer_spec.rb
+++ b/spec/ammitto/transformers/base_transformer_spec.rb
@@ -316,7 +316,7 @@ RSpec.describe Ammitto::Transformers::BaseTransformer do
       end
     end
 
-    it 'needs a year on both sides of the connector' do
+    it 'needs a year before the connector' do
       expect(transformer.send(:date_span?, 'Jan and Feb 1970')).to be false
     end
 

--- a/spec/ammitto/transformers/base_transformer_spec.rb
+++ b/spec/ammitto/transformers/base_transformer_spec.rb
@@ -81,6 +81,198 @@ RSpec.describe Ammitto::Transformers::BaseTransformer do
     end
   end
 
+  # A span of years is not a year. It rides in its own two fields, and
+  # while it is there neither scalar may hold one of its endpoints:
+  # there is no honest single value to publish, and a consumer reading
+  # the lower bound as the birth year would be reading a fact the source
+  # never stated.
+  describe '#create_birth_info with a year range' do
+    def birth(**args)
+      transformer.send(:create_birth_info, **args)
+    end
+
+    it 'reads a closed span into the bounds and clears both scalars' do
+      info = birth(date: '1962 to 1964')
+
+      expect(info.year_range_from).to eq(1962)
+      expect(info.year_range_to).to eq(1964)
+      expect(info.year).to be_nil
+      expect(info.date).to be_nil
+    end
+
+    it 'leaves an exact year in year, with no span' do
+      info = birth(date: '1988')
+
+      expect(info.year).to eq(1988)
+      expect(info.year_range_from).to be_nil
+      expect(info.year_range_to).to be_nil
+    end
+
+    it 'takes caller-stated bounds, as the EU states them' do
+      info = birth(year_range_from: 1953, year_range_to: 1958)
+
+      expect(info.year_range_from).to eq(1953)
+      expect(info.year_range_to).to eq(1958)
+    end
+
+    # The EU corpus carries one record with only an upper bound, so a
+    # lone bound must survive rather than being discarded or paired off.
+    it 'keeps a bound that stands alone on either side' do
+      expect(birth(year_range_to: 1980).year_range_to).to eq(1980)
+      expect(birth(year_range_to: 1980).year_range_from).to be_nil
+      expect(birth(year_range_from: 1953).year_range_from).to eq(1953)
+      expect(birth(year_range_from: 1953).year_range_to).to be_nil
+    end
+
+    it 'suppresses a caller-stated year when a span is also stated' do
+      info = birth(date: '1955', year: 1955,
+                   year_range_from: 1953, year_range_to: 1958)
+
+      expect(info.year).to be_nil
+      expect(info.date).to be_nil
+      expect(info.year_range_from).to eq(1953)
+    end
+
+    it 'keeps the place on a span, so the record is not emptied' do
+      info = birth(date: '1962 to 1964', city: 'Kandahar', country: 'AFGHANISTAN')
+
+      expect(info.city).to eq('Kandahar')
+      expect(info.country).to eq('AFGHANISTAN')
+    end
+
+    # circa is the source's claim about the span, not a consequence of
+    # there being one: the EU emits both settings alongside a span.
+    it 'carries circa through a span in both settings' do
+      expect(birth(date: '1962 to 1964').circa).to be false
+      expect(birth(date: 'Approximately: Between 1959 and 1965',
+                   circa: true).circa).to be true
+    end
+
+    it 'reads the Between spelling, with and without the prefix' do
+      ['Between', 'Approximately: Between'].each do |prefix|
+        info = birth(date: "#{prefix} 1959 and 1965")
+
+        expect(info.year_range_from).to eq(1959)
+        expect(info.year_range_to).to eq(1965)
+      end
+    end
+
+    # A full-date span carries days the year bounds cannot hold, so it
+    # publishes nothing at all rather than a coarsened or invented claim.
+    it 'does not reduce a full-date span to a year span' do
+      info = birth(date: '28 Feb 1962 to 28 Feb 1963')
+
+      expect(info.year_range_from).to be_nil
+      expect(info.year_range_to).to be_nil
+      expect(info.date).to be_nil
+      expect(info.year).to be_nil
+    end
+
+    it 'does not reduce a month span either' do
+      info = birth(date: 'Mar 1980 to Mar 1981')
+
+      expect(info.year_range_from).to be_nil
+      expect(info.date).to be_nil
+      expect(info.year).to be_nil
+    end
+  end
+
+  # Rejected, not reordered: reordering would publish a span the source
+  # never stated. It raises rather than returning nil so that "names no
+  # span" and "names a span that cannot be true" stay distinguishable.
+  describe 'a reversed closed range' do
+    it 'is rejected when stated as text' do
+      expect { transformer.send(:create_birth_info, date: '1964 to 1962') }
+        .to raise_error(Ammitto::Transformers::InvalidYearRangeError,
+                        /1964 > 1962/)
+    end
+
+    it 'is rejected when stated as bounds' do
+      expect do
+        transformer.send(:create_birth_info,
+                         year_range_from: 1965, year_range_to: 1959)
+      end.to raise_error(Ammitto::Transformers::InvalidYearRangeError)
+    end
+
+    it 'accepts a span whose bounds are equal' do
+      info = transformer.send(:create_birth_info,
+                              year_range_from: 1962, year_range_to: 1962)
+
+      expect(info.year_range_from).to eq(1962)
+      expect(info.year_range_to).to eq(1962)
+    end
+
+    # An open bound has nothing to be out of order with.
+    it 'never rejects an open bound' do
+      expect { transformer.send(:create_birth_info, year_range_to: 1958) }
+        .not_to raise_error
+    end
+  end
+
+  describe '#extract_year_range' do
+    it 'accepts only a value that is wholly a year span' do
+      expect(transformer.send(:extract_year_range, '1962 to 1964'))
+        .to eq([1962, 1964])
+      expect(transformer.send(:extract_year_range, 'Between 1959 and 1965'))
+        .to eq([1959, 1965])
+    end
+
+    # Two years in a string is not enough. These carry finer precision,
+    # or no span at all, and reading them as year spans would either
+    # discard stated days or invent a span outright.
+    it 'refuses strings that merely contain two years' do
+      ['28 Feb 1962 to 28 Feb 1963', 'Mar 1980 to Mar 1981',
+       '01 Jan 1973 to 31 Dec 1973', 'born 1962, naturalised 1964',
+       'passport issued 1962 to 1964', '1962 to 1964 (unconfirmed)',
+       '19621964'].each do |value|
+        expect(transformer.send(:extract_year_range, value))
+          .to(be_nil, "expected #{value.inspect} not to be read as a year span")
+      end
+    end
+
+    # No corpus states a span this way — 0 of 5795 distinct OFAC
+    # dateOfBirth values, none in the DFAT corpus, and the EU uses XML
+    # attributes — so it is an unsupported input, not a misread one.
+    it 'does not recognise the hyphen spelling, in either dash' do
+      expect(transformer.send(:extract_year_range, '1962-1964')).to be_nil
+      expect(transformer.send(:extract_year_range, '1962–1964')).to be_nil
+    end
+
+    it 'ignores non-strings' do
+      expect(transformer.send(:extract_year_range, nil)).to be_nil
+      expect(transformer.send(:extract_year_range, Date.new(1970, 1, 1)))
+        .to be_nil
+    end
+  end
+
+  # Broader than #multiple_years? on purpose: "01 Jan 1973 to 31 Dec
+  # 1973" names one distinct year twice, so a uniqueness test cannot see
+  # the span in it, yet Date._parse happily returns its 1 January
+  # opening endpoint as though the source had stated that date.
+  describe '#date_span?' do
+    it 'is true for every span spelling the corpora use' do
+      ['1962 to 1964', '28 Feb 1962 to 28 Feb 1963',
+       '01 Jan 1973 to 31 Dec 1973', 'Mar 1980 to Mar 1981',
+       'Between 1959 and 1965',
+       'Approximately: Between 1959 and 1965'].each do |value|
+        expect(transformer.send(:date_span?, value))
+          .to(be(true), "expected #{value.inspect} to read as a span")
+      end
+    end
+
+    it 'is false for a single point in time, however written' do
+      ['03 Oct 1988', '1975', 'circa 1960', 'Oct 1988', '00/00/1963',
+       '19620101', '1963 (1963)', 'Toronto 1963'].each do |value|
+        expect(transformer.send(:date_span?, value))
+          .to(be(false), "expected #{value.inspect} not to read as a span")
+      end
+    end
+
+    it 'needs a year on both sides of the connector' do
+      expect(transformer.send(:date_span?, 'Jan and Feb 1970')).to be false
+    end
+  end
+
   describe '#parse_complete_date' do
     it 'parses a complete ISO date' do
       expect(transformer.send(:parse_complete_date, '1957-05-05'))
@@ -102,6 +294,23 @@ RSpec.describe Ammitto::Transformers::BaseTransformer do
     it 'returns nil for an impossible date' do
       expect(transformer.send(:parse_complete_date, '31/02/1990')).to be_nil
     end
+
+    # Date._parse reads only the opening half of a span and returns it
+    # as a complete date. "01 Jan 1973 to 31 Dec 1973" is OFAC's way of
+    # saying "some day in 1973"; reading it as 1 January invented the
+    # very January date this gem stopped asserting elsewhere.
+    it 'returns nil for a span rather than its opening endpoint' do
+      ['28 Feb 1962 to 28 Feb 1963', '01 Jan 1973 to 31 Dec 1973',
+       '26 Sep 1946 to 07 Dec 1946'].each do |value|
+        expect(transformer.send(:parse_complete_date, value))
+          .to(be_nil, "expected #{value.inspect} to yield no single date")
+      end
+    end
+
+    it 'still parses an ordinary complete date unchanged' do
+      expect(transformer.send(:parse_complete_date, '28 Feb 1962'))
+        .to eq(Date.new(1962, 2, 28))
+    end
   end
 
   describe '#extract_birth_year' do
@@ -117,7 +326,7 @@ RSpec.describe Ammitto::Transformers::BaseTransformer do
       expect(transformer.send(:extract_birth_year, '00/00/1963')).to eq(1963)
     end
 
-    it 'yields nil for a year range — range handling is a separate concern' do
+    it 'yields nil for a year range — a span names no single year' do
       expect(transformer.send(:extract_birth_year, '1962 to 1964')).to be_nil
     end
 
@@ -127,6 +336,13 @@ RSpec.describe Ammitto::Transformers::BaseTransformer do
         expect(transformer.send(:extract_birth_year, range))
           .to(be_nil, "expected #{range.inspect} to name no single year")
       end
+    end
+
+    # The uniqueness test cannot see this one: it names 1973 twice. The
+    # year is nevertheless not a stated year but the endpoint of a span.
+    it 'yields nil for a span that repeats one year' do
+      expect(transformer.send(:extract_birth_year, '01 Jan 1973 to 31 Dec 1973'))
+        .to be_nil
     end
 
     it 'yields nil for non-strings' do

--- a/spec/ammitto/transformers/base_transformer_spec.rb
+++ b/spec/ammitto/transformers/base_transformer_spec.rb
@@ -209,6 +209,41 @@ RSpec.describe Ammitto::Transformers::BaseTransformer do
     end
   end
 
+  # Presence is decided before normalization. Deciding it after would
+  # turn a stated-but-unusable bound into "no bound stated", which hands
+  # authority back to the date string: the record would then publish a
+  # span read out of its text while the bounds the source actually
+  # stated were dropped without a word.
+  describe 'a stated bound that is not a year' do
+    it 'is rejected rather than falling back to the date string' do
+      expect do
+        transformer.send(:create_birth_info, date: '1962 to 1964',
+                                             year_range_from: 'unknown')
+      end.to raise_error(Ammitto::Transformers::InvalidYearRangeError,
+                         /not a year/)
+    end
+
+    it 'is rejected on the upper bound too' do
+      expect do
+        transformer.send(:create_birth_info, year_range_to: 'n/a')
+      end.to raise_error(Ammitto::Transformers::InvalidYearRangeError)
+    end
+
+    it 'is rejected when the bound is a non-positive number' do
+      expect do
+        transformer.send(:create_birth_info, year_range_from: 0)
+      end.to raise_error(Ammitto::Transformers::InvalidYearRangeError)
+    end
+
+    # Absent is not malformed: no bound at all still lets the date
+    # string speak.
+    it 'still reads the date string when no bound is stated at all' do
+      info = transformer.send(:create_birth_info, date: '1962 to 1964')
+
+      expect(info.year_range_from).to eq(1962)
+    end
+  end
+
   describe '#extract_year_range' do
     it 'accepts only a value that is wholly a year span' do
       expect(transformer.send(:extract_year_range, '1962 to 1964'))
@@ -270,6 +305,21 @@ RSpec.describe Ammitto::Transformers::BaseTransformer do
 
     it 'needs a year on both sides of the connector' do
       expect(transformer.send(:date_span?, 'Jan and Feb 1970')).to be false
+    end
+
+    # Every connector is tried, not only the first, so a value whose
+    # opening connector is not the span connector still reads correctly.
+    it 'finds the span even when an earlier connector is not the span' do
+      expect(transformer.send(:date_span?, 'Jan and Feb 1970 to 1972'))
+        .to be true
+    end
+
+    # KNOWN BOUNDARY, stated rather than discovered later: an
+    # abbreviated span whose second half omits the year is not
+    # recognised. No corpus states one, so the shape is left unhandled
+    # rather than guessed at.
+    it 'does not recognise a span whose second half omits the year' do
+      expect(transformer.send(:date_span?, '01 Jan 1973 to 31 Dec')).to be false
     end
   end
 

--- a/spec/integration/harmonize_pipeline_spec.rb
+++ b/spec/integration/harmonize_pipeline_spec.rb
@@ -78,6 +78,65 @@ RSpec.describe 'harmonize pipeline (integration)' do
     expect(stats['total_entities']).to eq(2)
   end
 
+  # A span has to survive every hop the website depends on: the fetch
+  # YAML, the entity node, the search index, and the context artifact
+  # that types the two new keys. Checking the models alone would prove
+  # only that the fields exist, not that they are published.
+  it 'publishes a stated span of birth years end to end' do
+    processed = File.join(@workdir, 'data-eu', 'processed')
+    FileUtils.mkdir_p(processed)
+
+    # Attributes copied from logicalId 1865 of the live EU export.
+    span = Ammitto::Sources::Eu::SanctionEntity.from_yaml({
+      'logical_id' => '1865', 'eu_reference_number' => 'EU.1865',
+      'subject_type' => { 'code' => 'person' },
+      'name_aliases' => [{ 'whole_name' => 'Abdul Ghani' }],
+      'birthdates' => [{ 'year_range_from' => 1953, 'year_range_to' => 1958,
+                         'circa' => true, 'city' => 'Tirin Kot District' }]
+    }.to_yaml)
+    File.write(File.join(processed, 'eu-1865.yaml'), span.to_yaml)
+
+    # logicalId 117055: the one export record with an upper bound only.
+    open_below = Ammitto::Sources::Eu::SanctionEntity.from_yaml({
+      'logical_id' => '117055', 'eu_reference_number' => 'EU.117055',
+      'subject_type' => { 'code' => 'person' },
+      'name_aliases' => [{ 'whole_name' => 'Eritrea Person' }],
+      'birthdates' => [{ 'year_range_to' => 1980, 'circa' => false }]
+    }.to_yaml)
+    File.write(File.join(processed, 'eu-117055.yaml'), open_below.to_yaml)
+
+    run_harmonize(['eu'], @workdir)
+    api = File.join(@workdir, 'api', 'v1')
+
+    graph = JSON.parse(File.read(File.join(api, 'sources', 'eu.jsonld')))['@graph']
+    node = graph.find { |n| n['@id'] == 'https://www.ammitto.org/entity/eu/eu1865' }
+    birth = node['birthInfo'].first
+
+    expect(birth['yearRangeFrom']).to eq(1953)
+    expect(birth['yearRangeTo']).to eq(1958)
+    expect(birth['circa']).to be true
+    # Neither bound is the birth year, so neither scalar is published
+    expect(birth).not_to have_key('year')
+    expect(birth).not_to have_key('date')
+
+    open_node = graph.find { |n| n['@id'] == 'https://www.ammitto.org/entity/eu/eu117055' }
+    open_birth = open_node['birthInfo'].first
+    expect(open_birth['yearRangeTo']).to eq(1980)
+    expect(open_birth).not_to have_key('yearRangeFrom')
+
+    index = JSON.parse(File.read(File.join(api, 'search-index.json')))
+    row = index['entities'].find { |e| e['ref'] == 'eu/eu1865' }
+    expect(row['birthYearFrom']).to eq('1953')
+    expect(row['birthYearTo']).to eq('1958')
+    expect(row).not_to have_key('birthYear')
+
+    # The context artifact the website loads must type the new keys, or
+    # a consumer expanding the graph gets untyped strings
+    context = JSON.parse(File.read(File.join(api, 'context.jsonld')))['@context']
+    expect(context['yearRangeFrom']['@type']).to eq('xsd:gYear')
+    expect(context['yearRangeTo']['@type']).to eq('xsd:gYear')
+  end
+
   it 'harmonizes CH identities and AU vessels into correctly-typed entities' do
     ch_dir = File.join(@workdir, 'data-ch', 'processed')
     FileUtils.mkdir_p(ch_dir)


### PR DESCRIPTION
This PR represents source-stated birth-year spans with explicit bounds
instead of silently publishing one endpoint as if the source had asserted
it alone.

Three defects, all live today. The EU XML carries
`yearRangeFrom`/`yearRangeTo` that nothing modelled, so **55 records lost
their only date entirely**. Australia's "Approximately: Between 1959 and
1965" published as **1959**, an exact year the source never stated. And
OFAC writes "01 Jan YYYY to 31 Dec YYYY" in 37 distinct spellings to mean
"some day that year" — every one of them became **1 January**, the
invented date this gem set out to stop inventing.

## Changes

- Add `year_range_from` / `year_range_to`, published as `yearRangeFrom` /
  `yearRangeTo`, through the model, the parallel ontology value object,
  the JSON-LD serializer, the ontology exporter and the search index
  (`birthYearFrom` / `birthYearTo`).
- Declare both in the published context as `xsd:gYear`, and add the
  missing `year` declaration the serializer was already emitting without.
- A range never populates `year` or `date` with an endpoint. Either bound
  may stand alone — one EU record states only an upper bound. A reversed
  closed range raises rather than being silently reordered.
- `circa` stays independent: the EU emits it alongside a range, so it is
  carried from the source and never inferred from a range's presence.
- Full-date spans stop resolving to their opening date.

## The one case where a span still yields a year

`01 Jan 1962 to 31 Dec 1962` publishes `year: 1962`.

An earlier revision published nothing at all here, on the principle that
`year` means stated rather than entailed. That was wrong for this shape:
the year is stated outright, twice, and the whole interval lies inside
it, so reading it out is parsing rather than inference. Publishing
nothing discarded a certainly-true fact about a sanctioned person in
order to avoid a false one that was not on offer.

The rule is narrow and anchored — both endpoints must be complete and
name the same year. `01 Jan 1962 to 31 Dec 1963` still yields nothing,
because no single birth year is asserted and the model has no date-valued
range to hold what is. `01 Jan 1973 to 31 Dec` and
`circa 01 Jan 1962 to 31 Dec 1962` also yield nothing.

## Scope

Driven by corpus evidence, not by taste. All 5,795 distinct OFAC
`dateOfBirth` values were extracted from the live SDN file: `YYYY to
YYYY` appears in 52 distinct forms and is supported; `YYYY-YYYY` appears
**zero** times in OFAC, AU or EU and is deliberately not supported rather
than guessed at.

## Test plan

- `bundle exec rspec` — 1458 → **1549 examples**, 0 failures, 4 pending.
- `bundle exec rubocop` — **423 files**, no offenses.
- Proven red before the fix: 62 examples fail on base from the first
  commit, 30 from the second, 4 from the third. Some new examples pass on
  base by design — those are regression guards, and are labelled as
  guards rather than counted as proofs.
- Mutation-tested: dropping the same-year recovery fails 3 examples;
  removing the equality check so cross-year spans are accepted fails 2.
- A sweep over 43,294 files and 1,526,414 strings — every field, not just
  birth dates — found the span guard firing on exactly one birth field
  corpus-wide, with a positive control proving the sweep was reading data.

## What this costs, stated plainly

59 distinct OFAC values that previously produced a complete date now
produce a year or nothing. 19 of them repeat one year on both endpoints
and keep that year. The remainder cross years and are unrepresentable
until the model gains date-valued ranges — a documented gap, not an
oversight. 5,524 values still resolve to a complete date, unchanged.

## Website

The site needs a matching change to display `1953–1958`, `from 1953` or
`up to 1958`; without it those records show no birth year where some
previously showed a false one. Key casing is settled: the deployed API
serves camelCase (`birthInfo`, `entityType`), and the site's own
normalizer converts. The ontology browser's `year` datatype changes from
`xsd:integer` to `xsd:gYear` — the JSON shape is unchanged and only
datatype-specific RDF queries would notice.

## Known gaps

UK and CH pass a pre-parsed `Date` into birth-info construction, so a
string-stated range could never reach the extractor there. Latent, not
live — no such span exists in their corpus — and left alone because
changing their date path risks their existing parsing.
