### PR TITLE
Publish OFAC full-date birth spans as date bounds

### DIFF
--- a/lib/ammitto/birth_info.rb
+++ b/lib/ammitto/birth_info.rb
@@ -3,29 +3,38 @@
 module Ammitto
   # BirthInfo represents birth-related information for a person
   #
-  # Supports exact dates, approximate dates, year ranges, and location
-  # information.
+  # Supports exact dates, approximate dates, date and year ranges, and
+  # location information.
   #
   # == What each field is allowed to say
   #
   # +date+::  ONE complete source-stated day, month and year.
   # +year+::  ONE source-stated year.
+  # +date_range_from+ / +date_range_to+:: the bounds of a source-stated
+  #           span of complete dates ("01 Jan 1961 to 31 Dec 1962").
   # +year_range_from+ / +year_range_to+:: the bounds of a source-stated
-  #           span of years ("born between 1959 and 1965").
+  #           span of years ("born between 1959 and 1965"), or the
+  #           endpoint years derived from a date span so that year-only
+  #           indexes can still find the record.
   #
-  # A range never populates +year+ or +date+ with one of its endpoints:
-  # neither bound is the birth year, and there is no honest third value,
-  # so both stay nil while a range is present. Either bound may stand
-  # alone, so "1953 or later" and "no later than 1958" are both
-  # expressible. When both are present +year_range_from+ must not exceed
-  # +year_range_to+; a reversed pair is rejected at the transformer
-  # boundary rather than silently reordered, because reordering would
-  # invent a claim the source never made.
+  # A range never populates +date+ with one of its endpoints: neither
+  # bound is the birth date. A date span whose endpoints share one year
+  # may also populate +year+, because the whole interval lies inside that
+  # year and reading it out is parsing rather than inference. When date
+  # bounds are present they are authoritative; the year bounds derived
+  # from them are a discovery aid, not a replacement for the
+  # finer-precision claim.
+  #
+  # Either side of either range may stand alone, so "1953 or later" and
+  # "no later than 1958" are both expressible. When both sides are
+  # present the lower bound must not exceed the upper; a reversed pair is
+  # rejected at the transformer boundary rather than silently reordered,
+  # because reordering would invent a claim the source never made.
   #
   # +circa+ is independent of a range. A range is a span the source
-  # stated exactly, not an approximation, and sources emit circa
-  # alongside a range in both settings — so circa is carried through from
-  # the source and never inferred from the presence of a range.
+  # stated exactly, not an approximation Ammitto inferred, and sources
+  # emit circa alongside a range in both settings — so circa is carried
+  # through from the source on every shape.
   #
   # @example Creating birth info
   #   BirthInfo.new(
@@ -37,10 +46,18 @@ module Ammitto
   # @example A source-stated span of years
   #   BirthInfo.new(year_range_from: 1959, year_range_to: 1965, circa: true)
   #
+  # @example A source-stated span of complete dates
+  #   BirthInfo.new(
+  #     date_range_from: Date.new(1961, 1, 1),
+  #     date_range_to: Date.new(1962, 12, 31)
+  #   )
+  #
   class BirthInfo < Lutaml::Model::Serializable
     attribute :date, :date
     attribute :circa, :boolean, default: false  # Approximate date
     attribute :year, :integer                   # Year only if full date unknown
+    attribute :date_range_from, :date           # Lower bound of a date span
+    attribute :date_range_to, :date             # Upper bound of a date span
     attribute :year_range_from, :integer        # Lower bound of a year span
     attribute :year_range_to, :integer          # Upper bound of a year span
     attribute :city, :string
@@ -52,6 +69,8 @@ module Ammitto
       map 'date', to: :date
       map 'circa', to: :circa
       map 'year', to: :year
+      map 'dateRangeFrom', to: :date_range_from
+      map 'dateRangeTo', to: :date_range_to
       map 'yearRangeFrom', to: :year_range_from
       map 'yearRangeTo', to: :year_range_to
       map 'city', to: :city
@@ -65,16 +84,23 @@ module Ammitto
       [city, region, country].compact.reject(&:empty?).join(', ')
     end
 
+    # @return [Boolean] whether a date span is stated, on either side
+    def date_range?
+      !date_range_from.nil? || !date_range_to.nil?
+    end
+
     # @return [Boolean] whether a year span is stated, on either side
     def year_range?
       !year_range_from.nil? || !year_range_to.nil?
     end
 
-    # A range renders as its span rather than as a single year, and an
-    # open bound renders as the direction it leaves open: "1953 or
-    # later", "no later than 1958".
-    # @return [String, nil] formatted birth date, year, or year span
+    # A range renders as its span rather than as a single endpoint, and
+    # an open bound renders as the direction it leaves open: "1953 or
+    # later", "no later than 1958". The finer-precision date range
+    # renders before the year range derived from it.
+    # @return [String, nil] formatted birth date, year, or span
     def formatted_date
+      return with_circa(formatted_date_range) if date_range?
       return with_circa(formatted_year_range) if year_range?
       return with_circa(year.to_s) if year && !date
       return nil unless date
@@ -84,7 +110,16 @@ module Ammitto
 
     private
 
-    # @return [String] the span, closed or open on either side
+    # @return [String] the date span, closed or open on either side
+    def formatted_date_range
+      closed = date_range_from && date_range_to
+      return "#{date_range_from}-#{date_range_to}" if closed
+      return "#{date_range_from} or later" if date_range_from
+
+      "no later than #{date_range_to}"
+    end
+
+    # @return [String] the year span, closed or open on either side
     def formatted_year_range
       return "#{year_range_from}-#{year_range_to}" if year_range_from && year_range_to
       return "#{year_range_from} or later" if year_range_from

--- a/lib/ammitto/ontology/value_objects/birth_info.rb
+++ b/lib/ammitto/ontology/value_objects/birth_info.rb
@@ -10,16 +10,23 @@ module Ammitto
       # Represents birth information for a person
       #
       # Birth information may be partial (year only, city only, etc.),
-      # may be a span of years, and may be approximate (circa flag).
+      # may be a span of dates or of years, and may be approximate
+      # (circa flag).
       #
       # +date+ carries ONE complete source-stated day/month/year and
       # +year+ ONE source-stated year. A source-stated span rides in
-      # +year_range_from+ / +year_range_to+ instead, and while a span is
-      # present +date+ and +year+ stay nil: neither bound is the birth
-      # year, so filling +year+ with an endpoint would assert something
-      # the source never said. Either bound may stand alone. A reversed
-      # closed pair is rejected upstream, at the transformer boundary,
-      # rather than reordered here.
+      # +date_range_from+ / +date_range_to+ when the source stated
+      # complete endpoint dates, and in +year_range_from+ /
+      # +year_range_to+ when it stated years. While a span is present
+      # +date+ stays nil: neither bound is the birth date. +year+ stays
+      # nil too, unless a date span's endpoints share one year — then
+      # the whole interval lies inside that year and the scalar is read
+      # out rather than invented. A date span also publishes its
+      # endpoint years through the year bounds, so year-only consumers
+      # keep finding the record; those derived bounds supplement the
+      # complete dates, they do not replace them. Either bound may stand
+      # alone. A reversed closed pair is rejected upstream, at the
+      # transformer boundary, rather than reordered here.
       #
       # +circa+ is independent of a span: sources emit circa both with
       # and without a range, so it is carried from the source and never
@@ -38,14 +45,18 @@ module Ammitto
       # @example A source-stated span of years
       #   BirthInfo.new(year_range_from: 1959, year_range_to: 1965)
       #
+      # @example A source-stated span of complete dates
+      #   BirthInfo.new(date_range_from: Date.new(1961, 1, 1),
+      #                 date_range_to: Date.new(1962, 12, 31))
+      #
       class BirthInfo < Lutaml::Model::Serializable
         include Neo4jAdapter
 
         # Neo4j configuration for BirthInfo
         neo4j_labels 'BirthInfo'
-        neo4j_property :date, :circa, :year, :year_range_from,
-                       :year_range_to, :city, :region, :country,
-                       :country_iso_code
+        neo4j_property :date, :circa, :year, :date_range_from,
+                       :date_range_to, :year_range_from, :year_range_to,
+                       :city, :region, :country, :country_iso_code
 
         # Exact or approximate birth date
         # @return [Date, nil]
@@ -59,11 +70,21 @@ module Ammitto
         # @return [Integer, nil]
         attribute :year, :integer
 
-        # Lower bound of a source-stated span of birth years
+        # Lower bound of a source-stated span of complete birth dates
+        # @return [Date, nil]
+        attribute :date_range_from, :date
+
+        # Upper bound of a source-stated span of complete birth dates
+        # @return [Date, nil]
+        attribute :date_range_to, :date
+
+        # Lower bound of a birth-year span: either source-stated, or
+        # derived from a date span's endpoints for year-only discovery
         # @return [Integer, nil]
         attribute :year_range_from, :integer
 
-        # Upper bound of a source-stated span of birth years
+        # Upper bound of a birth-year span: either source-stated, or
+        # derived from a date span's endpoints for year-only discovery
         # @return [Integer, nil]
         attribute :year_range_to, :integer
 
@@ -86,10 +107,16 @@ module Ammitto
         # Check if birth info has meaningful content
         # @return [Boolean]
         def present?
-          [date, year, year_range_from, year_range_to, city, region,
-           country].any? do |v|
+          [date, year, date_range_from, date_range_to, year_range_from,
+           year_range_to, city, region, country].any? do |v|
             Utils::Presence.present?(v)
           end
+        end
+
+        # Whether a span of complete dates is stated, on either side
+        # @return [Boolean]
+        def date_range?
+          !date_range_from.nil? || !date_range_to.nil?
         end
 
         # Whether a span of years is stated, on either side
@@ -123,6 +150,8 @@ module Ammitto
           hash[:date] = date.to_s if date
           hash[:circa] = circa if circa
           hash[:year] = year if year
+          hash[:date_range_from] = date_range_from.to_s if date_range_from
+          hash[:date_range_to] = date_range_to.to_s if date_range_to
           hash[:year_range_from] = year_range_from if year_range_from
           hash[:year_range_to] = year_range_to if year_range_to
           hash[:city] = city if city
@@ -135,11 +164,23 @@ module Ammitto
         private
 
         def date_label
+          return date_range_label if date_range?
           return year_range_label if year_range?
           return year.to_s if year && !date
           return date.to_s if date
 
           nil
+        end
+
+        # The date range precedes the year range derived from it,
+        # because it preserves everything the source stated.
+        # @return [String] the span, closed or open on either side
+        def date_range_label
+          closed = date_range_from && date_range_to
+          return "#{date_range_from}-#{date_range_to}" if closed
+          return "#{date_range_from} or later" if date_range_from
+
+          "no later than #{date_range_to}"
         end
 
         # An open bound renders as the direction it leaves open, so a
@@ -158,6 +199,8 @@ module Ammitto
           map :date, to: :date
           map :circa, to: :circa
           map :year, to: :year
+          map :date_range_from, to: :date_range_from
+          map :date_range_to, to: :date_range_to
           map :year_range_from, to: :year_range_from
           map :year_range_to, to: :year_range_to
           map :city, to: :city
@@ -171,6 +214,8 @@ module Ammitto
           map :date, to: :date
           map :circa, to: :circa
           map :year, to: :year
+          map :date_range_from, to: :date_range_from
+          map :date_range_to, to: :date_range_to
           map :year_range_from, to: :year_range_from
           map :year_range_to, to: :year_range_to
           map :city, to: :city

--- a/lib/ammitto/schema/context.rb
+++ b/lib/ammitto/schema/context.rb
@@ -192,6 +192,12 @@ module Ammitto
               # flat entity-level key and never described this one, so
               # 'year' went out undeclared.
               'year' => { '@id' => 'year', '@type' => 'xsd:gYear' },
+              # Bounds of a stated span of complete birth dates. These
+              # preserve the endpoint days and months; the year bounds
+              # below are the projection of them a year-only consumer
+              # can index, never a substitute for reading these.
+              'dateRangeFrom' => { '@id' => 'dateRangeFrom', '@type' => 'xsd:date' },
+              'dateRangeTo' => { '@id' => 'dateRangeTo', '@type' => 'xsd:date' },
               # Bounds of a stated span of birth years. Separate terms,
               # not a refinement of 'year': a bound is not a birth year,
               # and a consumer that treated one as such would answer an

--- a/lib/ammitto/serialization/json_ld_serializer.rb
+++ b/lib/ammitto/serialization/json_ld_serializer.rb
@@ -226,6 +226,8 @@ module Ammitto
           'date' => birth_info.date,
           'circa' => birth_info.circa,
           'year' => birth_info.year,
+          'dateRangeFrom' => birth_info.date_range_from,
+          'dateRangeTo' => birth_info.date_range_to,
           'yearRangeFrom' => birth_info.year_range_from,
           'yearRangeTo' => birth_info.year_range_to,
           'city' => birth_info.city,

--- a/lib/ammitto/serialization/ontology_exporter.rb
+++ b/lib/ammitto/serialization/ontology_exporter.rb
@@ -142,7 +142,10 @@ module Ammitto
           label: 'Birth Information',
           comment: 'Birth date and place information',
           parent: nil,
-          properties: %w[date year yearRangeFrom yearRangeTo place country circa]
+          properties: %w[
+            date dateRangeFrom dateRangeTo year yearRangeFrom yearRangeTo
+            place country circa
+          ]
         },
         {
           id: 'Nationality',
@@ -275,22 +278,33 @@ module Ammitto
         { id: 'issueDate', label: 'Issue Date', comment: 'Date issued', domain: 'Identifier', range: 'date' },
         { id: 'expiryDate', label: 'Expiry Date', comment: 'Expiry date', domain: 'Identifier', range: 'date' },
 
-        # BirthInfo properties. The three year-valued ones are gYear,
-        # matching the JSON-LD context. The two artifacts mint their
-        # terms under different bases — this vocabulary under BASE_URI,
-        # the context under its own @vocab — so they are not literally
-        # the same RDF property, but they describe the same field to the
-        # same reader, and telling that reader "integer" in the ontology
-        # browser and "gYear" in the data is a contradiction either way.
-        # 'year' carried that contradiction before the bounds existed;
-        # adding the bounds is what made it worth resolving rather than
-        # propagating into two more properties.
+        # BirthInfo temporal properties. The date bounds preserve the
+        # complete endpoint dates; the year bounds are either
+        # source-stated or derived from those endpoints for year-only
+        # discovery. Both datatypes match the JSON-LD context.
+        #
+        # The three year-valued ones are gYear, matching that context.
+        # The two artifacts mint their terms under different bases —
+        # this vocabulary under BASE_URI, the context under its own
+        # @vocab — so they are not literally the same RDF property, but
+        # they describe the same field to the same reader, and telling
+        # that reader "integer" in the ontology browser and "gYear" in
+        # the data is a contradiction either way. 'year' carried that
+        # contradiction before the bounds existed; adding the bounds is
+        # what made it worth resolving rather than propagating into two
+        # more properties.
+        { id: 'dateRangeFrom', label: 'Date Range From',
+          comment: 'Lower bound of a stated span of complete birth dates',
+          domain: 'BirthInfo', range: 'date' },
+        { id: 'dateRangeTo', label: 'Date Range To',
+          comment: 'Upper bound of a stated span of complete birth dates',
+          domain: 'BirthInfo', range: 'date' },
         { id: 'year', label: 'Year', comment: 'Birth year', domain: 'BirthInfo', range: 'gYear' },
         { id: 'yearRangeFrom', label: 'Year Range From',
-          comment: 'Lower bound of a stated span of birth years',
+          comment: 'Lower bound of a birth-year span',
           domain: 'BirthInfo', range: 'gYear' },
         { id: 'yearRangeTo', label: 'Year Range To',
-          comment: 'Upper bound of a stated span of birth years',
+          comment: 'Upper bound of a birth-year span',
           domain: 'BirthInfo', range: 'gYear' },
         { id: 'place', label: 'Place', comment: 'Birth place', domain: 'BirthInfo', range: 'string' },
         { id: 'circa', label: 'Circa', comment: 'Approximate date', domain: 'BirthInfo', range: 'boolean' }

--- a/lib/ammitto/sources/us/transformer.rb
+++ b/lib/ammitto/sources/us/transformer.rb
@@ -261,9 +261,14 @@ module Ammitto
             pob = pobs[idx]
 
             # OFAC DOBs mix complete dates ("03 Oct 1988") with partial
-            # ones ("1988", "Oct 1988", "circa 1960"): only a complete
-            # date becomes BirthInfo#date, a stated year always survives
-            # in BirthInfo#year
+            # ones ("1988", "Oct 1988", "circa 1960") and with spans
+            # ("01 Jan 1961 to 31 Dec 1962"). The whole string is
+            # forwarded untouched: reading it is create_birth_info's
+            # job, not this transformer's. Only a complete date becomes
+            # BirthInfo#date; a partial value's stated year survives in
+            # BirthInfo#year; a span becomes bounds instead, and only a
+            # span whose endpoints share a year still states a scalar
+            # one.
             birth_infos << create_birth_info(
               date: dob.date_of_birth,
               circa: circa_string?(dob.date_of_birth),

--- a/lib/ammitto/transformers/base_transformer.rb
+++ b/lib/ammitto/transformers/base_transformer.rb
@@ -20,6 +20,22 @@ module Ammitto
     # run nor vanishes from it.
     class InvalidYearRangeError < StandardError; end
 
+    # Raised when a birth-date range is a defect rather than a spelling:
+    # a closed span whose lower bound is above its upper bound.
+    #
+    # A reversed span is rejected rather than reordered for the same
+    # reason as a reversed year range: reordering would publish a claim
+    # the source never made. Rejection raises rather than returning nil
+    # so that "this value names no span" and "this value names a span
+    # that cannot be true" stay distinguishable.
+    #
+    # An unrecognised or unparseable SPELLING is not a defect and does
+    # not raise; see #extract_date_range. As with InvalidYearRangeError,
+    # HarmonizeCommand's per-file rescue records the offending filename
+    # and fails its health gate, so one bad record neither aborts the
+    # run nor vanishes from it.
+    class InvalidDateRangeError < StandardError; end
+
     # BaseTransformer provides common functionality for transforming
     # source-specific models to the harmonized Ammitto ontology.
     #
@@ -45,12 +61,36 @@ module Ammitto
     #   end
     #
     class BaseTransformer
+      # A month-precision span loses its months when it is reduced to
+      # year bounds, so both endpoints must prove they name months
+      # before either bound becomes a published fact.
+      ENGLISH_MONTH_NAME = /
+        (?:
+          Jan(?:uary)? | Feb(?:ruary)? | Mar(?:ch)? | Apr(?:il)? |
+          May | Jun(?:e)? | Jul(?:y)? | Aug(?:ust)? |
+          Sep(?:t(?:ember)?)? | Oct(?:ober)? | Nov(?:ember)? | Dec(?:ember)?
+        )
+      /ix
+
       # Spellings read as a bare span of birth years. Every pattern is
       # ANCHORED at both ends: a span is recognised only when the WHOLE
-      # value is one. "28 Feb 1962 to 28 Feb 1963" and "Mar 1980 to Mar
-      # 1981" are both live OFAC shapes that carry finer precision than
-      # a year span, and flattening them into one would discard the
-      # months and days the source did state.
+      # value is one.
+      #
+      # A day-precision span ("28 Feb 1962 to 28 Feb 1963") is NOT here.
+      # It keeps its days through FULL_DATE_SPAN, which publishes date
+      # bounds and derives year bounds from them, so nothing is lost.
+      #
+      # A month-precision span ("Mar 1980 to Mar 1981") IS here, and the
+      # months are lost. That is the lesser loss: date bounds cannot hold
+      # it without inventing a day, so the alternative is not keeping the
+      # months but publishing nothing at all, which is what this shape
+      # did before. The year span it yields is true, and it is the same
+      # trade already accepted for "1955 to 1957". Anchoring alone does
+      # not earn that trade: an endpoint of ANY word plus a year is
+      # anchored too, and admits "circa 1962 to circa 1964" — a
+      # qualified span, which is the grammar FULL_DATE_SPAN also
+      # declines. Only a named month says the value carries month
+      # precision, so only a named month may be dropped for its year.
       #
       # The hyphen spelling ("1962-1964") is deliberately absent. It
       # appears in none of the corpora that state spans as text — 0 of
@@ -60,7 +100,11 @@ module Ammitto
       # so it is an unsupported input rather than a misread one.
       YEAR_RANGE_PATTERNS = [
         /\A(?:approximately\s*:?\s*)?between\s+(\d{4})\s+and\s+(\d{4})\z/i,
-        /\A(\d{4})\s+to\s+(\d{4})\z/i
+        /\A(\d{4})\s+to\s+(\d{4})\z/i,
+        /
+          \A#{ENGLISH_MONTH_NAME}\s+(\d{4})\s+to\s+
+          #{ENGLISH_MONTH_NAME}\s+(\d{4})\z
+        /ix
       ].freeze
 
       # Connectors that join the two halves of a span. Used to tell a
@@ -69,23 +113,20 @@ module Ammitto
       # publish one endpoint as though the source had stated it alone.
       SPAN_CONNECTOR = /\s+(?:to|and)\s+/i
 
-      # A full-date span whose endpoints are complete dates, e.g.
+      # A full-date span whose endpoints are each a complete date, e.g.
       # "01 Jan 1962 to 31 Dec 1962". OFAC writes this in dozens of
-      # spellings and it must not become its opening date — but when
-      # both endpoints carry the SAME year, that year is stated
-      # outright, twice, and the whole interval lies inside it. Reading
-      # it out is parsing, not inference, so the year survives even
-      # though no single day does.
+      # spellings and it must not become its opening date; both
+      # endpoints are published instead, as the date bounds.
       #
       # Deliberately strict: both endpoints must be complete. An
-      # abbreviated tail ("01 Jan 1973 to 31 Dec") states no year on its
-      # second endpoint, and a qualified value ("circa ...") is a
-      # different grammar that has not been designed.
-      SAME_YEAR_FULL_DATE_SPAN = /
+      # abbreviated tail ("01 Jan 1973 to 31 Dec") states no complete
+      # upper bound, and a qualified value ("circa ...") is a different
+      # grammar that has not been designed.
+      FULL_DATE_SPAN = /
         \A
-        \d{1,2}\s+[[:alpha:]]{3,9}\s+(\d{4})
+        (?<from>\d{1,2}\s+[[:alpha:]]{3,9}\s+\d{4})
         \s+to\s+
-        \d{1,2}\s+[[:alpha:]]{3,9}\s+(\d{4})
+        (?<to>\d{1,2}\s+[[:alpha:]]{3,9}\s+\d{4})
         \z
       /ix
 
@@ -271,7 +312,15 @@ module Ammitto
       #
       # * BirthInfo#date is set only when the source states a complete
       #   day-month-year; a bare or partial year rides in BirthInfo#year
-      #   and is never padded into an invented date.
+      #   and is never padded into an invented date. A span never
+      #   becomes its opening endpoint.
+      # * A span of complete dates rides in BirthInfo#date_range_from /
+      #   #date_range_to, and publishes its endpoint years through the
+      #   year-range fields as well, so year-only indexes keep the
+      #   record. Those derived bounds supplement the source claim; they
+      #   do not replace it.
+      # * A date span wholly inside one year also retains that exact
+      #   year in #year. No scalar year is emitted when it crosses years.
       # * A span of years rides in BirthInfo#year_range_from /
       #   #year_range_to, and while one is present both #date and #year
       #   stay nil. Neither bound is the birth year, so filling #year
@@ -279,9 +328,19 @@ module Ammitto
       # * circa is carried through from the source, never inferred from
       #   the presence of a span.
       #
-      # Bounds passed by a caller are authoritative: when either is
-      # given, the date string is not searched for a span, and a missing
+      # Year bounds passed by a caller are authoritative, as the EU and
+      # DFAT state them in fields of their own: when either is given the
+      # date string is not searched for a span at all, and a missing
       # bound stays missing rather than being filled from the string.
+      #
+      # There is deliberately no caller-stated pair for the DATE bounds.
+      # No source states a complete-date span in fields of its own — OFAC
+      # writes it into the value itself — so the only way to reach the
+      # date bounds is FULL_DATE_SPAN, whose endpoints this method parses
+      # and validates. Adding the keywords back would reopen the ordering
+      # question of which pair wins, and answering it by deriving year
+      # bounds from the dates silently discarded whichever year bounds
+      # the caller had stated.
       #
       # @param date [String, Date, nil] birth date
       # @param circa [Boolean] whether the date is approximate
@@ -290,16 +349,27 @@ module Ammitto
       # @param country [String, nil] birth country
       # @param country_iso_code [String, nil] ISO country code
       # @param year [Integer, String, nil] source-stated birth year
-      # @param year_range_from [Integer, String, nil] lower bound
-      # @param year_range_to [Integer, String, nil] upper bound
-      # @raise [InvalidYearRangeError] when a closed span runs backwards
+      # @param year_range_from [Integer, String, nil] lower year bound
+      # @param year_range_to [Integer, String, nil] upper year bound
+      # @raise [InvalidDateRangeError] when a closed date span read from
+      #   the value runs backwards
+      # @raise [InvalidYearRangeError] when a year bound is not a year,
+      #   or a closed year span runs backwards
       # @return [BirthInfo] the birth info
       def create_birth_info(date: nil, circa: false, city: nil, region: nil, country: nil,
                             country_iso_code: nil, year: nil,
                             year_range_from: nil, year_range_to: nil)
-        bounds = stated_year_range(year_range_from, year_range_to) ||
-                 extract_year_range(date)
-        return birth_info_for_range(bounds, circa, city, region, country, country_iso_code) if bounds
+        date_bounds = nil
+        year_bounds = stated_year_range(year_range_from, year_range_to)
+
+        unless year_bounds
+          date_bounds = extract_date_range(date)
+          year_bounds = extract_year_range(date) unless date_bounds
+        end
+
+        place = [circa, city, region, country, country_iso_code]
+        return birth_info_for_date_range(date_bounds, *place) if date_bounds
+        return birth_info_for_range(year_bounds, *place) if year_bounds
 
         parsed_date = parse_complete_date(date)
 
@@ -311,7 +381,32 @@ module Ammitto
           country: country,
           country_iso_code: country_iso_code,
           year: normalize_year(year) || parsed_date&.year ||
-                same_year_full_date_span(date) || extract_birth_year(date)
+                extract_birth_year(date)
+        )
+      end
+
+      # A date span publishes its complete endpoints and repeats their
+      # years for discovery. When both endpoints share a year the whole
+      # interval lies inside it, so retaining that scalar reads out a
+      # fact the source stated twice rather than inventing a day.
+      # @param bounds [Array<Date, nil>] validated [from, to]
+      # @return [BirthInfo] the birth info
+      def birth_info_for_date_range(bounds, circa, city, region, country, country_iso_code)
+        lower, upper = bounds
+        exact_year = lower.year if lower && upper && lower.year == upper.year
+
+        Ammitto::BirthInfo.new(
+          date: nil,
+          year: exact_year,
+          date_range_from: lower,
+          date_range_to: upper,
+          year_range_from: lower&.year,
+          year_range_to: upper&.year,
+          circa: circa,
+          city: city,
+          region: region,
+          country: country,
+          country_iso_code: country_iso_code
         )
       end
 
@@ -331,6 +426,60 @@ module Ammitto
           country: country,
           country_iso_code: country_iso_code
         )
+      end
+
+      # Bounds of a complete-date span stated as one string, or nil when
+      # the value names no such span. Recognition stays anchored (see
+      # FULL_DATE_SPAN), so month-only, abbreviated and qualified spans
+      # still cannot be upgraded into facts they do not contain.
+      #
+      # An endpoint matching the SHAPE but naming no real calendar day —
+      # "31 Feb 1962", or OFAC's zero-padded "00 Jan 1962" — means the
+      # value does not state a complete-date span, so it yields nil and
+      # the record publishes nothing.
+      #
+      # For a SAME-YEAR span that is a deliberate NARROWING: the rule
+      # this one replaced matched on the two year captures alone and
+      # never looked at the days, so "00 Jan 1962 to 31 Dec 1962" used
+      # to surrender year 1962. Date bounds need endpoints that name
+      # real days, so the shape now publishes nothing instead. It is
+      # accepted rather than repaired because recovering the years from
+      # a value whose days are unreadable is a second grammar, and no
+      # evidence says the shape occurs; see the spec of the same name.
+      #
+      # Yielding nil rather than raising mirrors extract_year_range,
+      # whose text path also stays silent on an unrecognised spelling.
+      # Raising is reserved for a closed span that runs backwards, which
+      # is a value that cannot be true rather than one merely unread.
+      # @param value [Object] candidate date string
+      # @raise [InvalidDateRangeError] when a closed span runs backwards
+      # @return [Array<Date>, nil] validated bounds, or nil
+      def extract_date_range(value)
+        return nil unless value.is_a?(String)
+
+        match = FULL_DATE_SPAN.match(value.strip)
+        return nil unless match
+
+        lower = parse_complete_date(match[:from])
+        upper = parse_complete_date(match[:to])
+        return nil unless lower && upper
+
+        validate_date_range(lower, upper)
+      end
+
+      # A closed span must run forwards. Only a closed one can: an open
+      # bound has nothing to be out of order with.
+      # @param lower [Date, nil] lower bound
+      # @param upper [Date, nil] upper bound
+      # @raise [InvalidDateRangeError] when a closed span runs backwards
+      # @return [Array<Date, nil>] the bounds, unchanged
+      def validate_date_range(lower, upper)
+        if lower && upper && lower > upper
+          raise InvalidDateRangeError,
+                "birth date range runs backwards: #{lower} > #{upper}"
+        end
+
+        [lower, upper]
       end
 
       # Bounds a caller stated outright, as the EU does through its
@@ -455,30 +604,11 @@ module Ammitto
       # a uniqueness test cannot see the span in it.
       #
       # Recognising a span is not the same as publishing one: only the
-      # anchored YEAR_RANGE_PATTERNS produce bounds. A span recognised
-      # here but not matched there publishes nothing, which is the point
-      # — it is rejection of a value known to be misparsed, not support
-      # for a spelling.
-      # The year both endpoints of a full-date span agree on, or nil.
+      # anchored YEAR_RANGE_PATTERNS and FULL_DATE_SPAN produce bounds.
+      # A span recognised here but matched by neither publishes nothing,
+      # which is the point — it is rejection of a value known to be
+      # misparsed, not support for a spelling.
       #
-      # This runs only after parse_complete_date has already declined
-      # the value, so it never competes with a real date — it recovers
-      # the one fact a same-year span states unambiguously. A span whose
-      # endpoints name different years returns nil: no single birth year
-      # is asserted there, and the model has no date-valued range to
-      # hold what is.
-      #
-      # @param value [Object] candidate date string
-      # @return [Integer, nil]
-      def same_year_full_date_span(value)
-        return nil unless value.is_a?(String)
-
-        match = SAME_YEAR_FULL_DATE_SPAN.match(value.strip)
-        return nil unless match && match[1] == match[2]
-
-        match[1].to_i
-      end
-
       # @param value [Object] candidate date string
       # @return [Boolean]
       def date_span?(value)

--- a/spec/ammitto/birth_info_spec.rb
+++ b/spec/ammitto/birth_info_spec.rb
@@ -7,6 +7,44 @@ require 'spec_helper'
 # `year` one year, and the range bounds a span. A span never borrows
 # either scalar, because neither bound is the birth year.
 RSpec.describe Ammitto::BirthInfo do
+  describe 'date range serialization' do
+    let(:span) do
+      described_class.new(
+        date_range_from: Date.new(1961, 1, 1),
+        date_range_to: Date.new(1962, 12, 31)
+      )
+    end
+
+    it 'publishes Date-valued bounds as camelCase JSON keys' do
+      json = JSON.parse(span.to_json)
+
+      expect(json['dateRangeFrom']).to eq('1961-01-01')
+      expect(json['dateRangeTo']).to eq('1962-12-31')
+    end
+
+    # YAML is the fetch artifact's format, so a bound that does not
+    # survive it never reaches harmonize at all.
+    it 'round-trips both bounds through JSON and YAML' do
+      from_json = described_class.from_json(span.to_json)
+      from_yaml = described_class.from_yaml(span.to_yaml)
+
+      expect(from_json.date_range_from).to eq(Date.new(1961, 1, 1))
+      expect(from_json.date_range_to).to eq(Date.new(1962, 12, 31))
+      expect(from_yaml.date_range_from).to eq(Date.new(1961, 1, 1))
+      expect(from_yaml.date_range_to).to eq(Date.new(1962, 12, 31))
+    end
+  end
+
+  describe '#date_range?' do
+    it 'is true for either bound alone, and false for neither' do
+      expect(described_class.new(date_range_from: Date.new(1961, 1, 1)))
+        .to be_date_range
+      expect(described_class.new(date_range_to: Date.new(1962, 12, 31)))
+        .to be_date_range
+      expect(described_class.new(year: 1961)).not_to be_date_range
+    end
+  end
+
   describe 'year range serialization' do
     let(:span) do
       described_class.new(year_range_from: 1959, year_range_to: 1965)
@@ -72,6 +110,45 @@ RSpec.describe Ammitto::BirthInfo do
       expect(described_class.new(year: 1964).formatted_date).to eq('1964')
       expect(described_class.new(date: Date.new(1964, 7, 17)).formatted_date)
         .to eq('1964-07-17')
+    end
+
+    # The date range carries everything the year range does and more, so
+    # a record holding both renders the finer one.
+    it 'renders the complete date range before its derived year range' do
+      span = described_class.new(
+        date_range_from: Date.new(1961, 1, 1),
+        date_range_to: Date.new(1962, 12, 31),
+        year_range_from: 1961,
+        year_range_to: 1962
+      )
+
+      expect(span.formatted_date).to eq('1961-01-01-1962-12-31')
+    end
+
+    it 'renders an open date range in its open direction' do
+      open_above = described_class.new(date_range_from: Date.new(1961, 1, 1))
+      open_below = described_class.new(date_range_to: Date.new(1962, 12, 31))
+
+      expect(open_above.formatted_date).to eq('1961-01-01 or later')
+      expect(open_below.formatted_date).to eq('no later than 1962-12-31')
+    end
+
+    it 'prefixes circa on every date-range shape' do
+      closed = described_class.new(
+        date_range_from: Date.new(1961, 1, 1),
+        date_range_to: Date.new(1962, 12, 31),
+        circa: true
+      )
+      open_above = described_class.new(
+        date_range_from: Date.new(1961, 1, 1), circa: true
+      )
+      open_below = described_class.new(
+        date_range_to: Date.new(1962, 12, 31), circa: true
+      )
+
+      expect(closed.formatted_date).to eq('c. 1961-01-01-1962-12-31')
+      expect(open_above.formatted_date).to eq('c. 1961-01-01 or later')
+      expect(open_below.formatted_date).to eq('c. no later than 1962-12-31')
     end
   end
 

--- a/spec/ammitto/ontology/value_objects/birth_info_spec.rb
+++ b/spec/ammitto/ontology/value_objects/birth_info_spec.rb
@@ -29,6 +29,13 @@ RSpec.describe Ammitto::Ontology::ValueObjects::BirthInfo do
       expect(described_class.new(year_range_from: 1953)).to be_present
       expect(described_class.new(year_range_to: 1958)).to be_present
     end
+
+    it 'counts either date-range bound on its own' do
+      expect(described_class.new(date_range_from: Date.new(1961, 1, 1)))
+        .to be_present
+      expect(described_class.new(date_range_to: Date.new(1962, 12, 31)))
+        .to be_present
+    end
   end
 
   describe '#to_s' do
@@ -100,6 +107,57 @@ RSpec.describe Ammitto::Ontology::ValueObjects::BirthInfo do
 
       expect(span.neo4j_properties)
         .to include(year_range_from: 1959, year_range_to: 1965)
+    end
+  end
+
+  describe 'date range display and serialization' do
+    let(:span) do
+      described_class.new(
+        date_range_from: Date.new(1961, 1, 1),
+        date_range_to: Date.new(1962, 12, 31),
+        year_range_from: 1961,
+        year_range_to: 1962
+      )
+    end
+
+    it 'renders complete dates before their derived year bounds' do
+      expect(span.to_s).to eq('1961-01-01-1962-12-31')
+    end
+
+    it 'renders open bounds and circa on every shape' do
+      open_above = described_class.new(
+        date_range_from: Date.new(1961, 1, 1), circa: true
+      )
+      open_below = described_class.new(
+        date_range_to: Date.new(1962, 12, 31), circa: true
+      )
+
+      expect(open_above.to_s).to eq('c. 1961-01-01 or later')
+      expect(open_below.to_s).to eq('c. no later than 1962-12-31')
+    end
+
+    it 'carries the bounds through hashes, YAML and JSON' do
+      expect(span.to_hash).to include(
+        date_range_from: '1961-01-01',
+        date_range_to: '1962-12-31'
+      )
+
+      from_yaml = described_class.from_yaml(span.to_yaml)
+      from_json = described_class.from_json(span.to_json)
+
+      expect(from_yaml.date_range_from).to eq(Date.new(1961, 1, 1))
+      expect(from_yaml.date_range_to).to eq(Date.new(1962, 12, 31))
+      expect(from_json.date_range_from).to eq(Date.new(1961, 1, 1))
+      expect(from_json.date_range_to).to eq(Date.new(1962, 12, 31))
+    end
+
+    # The Neo4j property list drives both import and export, so a name
+    # missing from it is a field that never reaches the graph.
+    it 'carries both bounds into the Neo4j properties' do
+      expect(span.neo4j_properties).to include(
+        date_range_from: '1961-01-01',
+        date_range_to: '1962-12-31'
+      )
     end
   end
 end

--- a/spec/ammitto/serialization/json_ld_serializer_spec.rb
+++ b/spec/ammitto/serialization/json_ld_serializer_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Ammitto::Serialization::JsonLdSerializer do
 
   # A field that is not serialized is a field the website never sees,
   # however faithfully the models carry it.
-  describe 'birth year ranges' do
+  describe 'birth date and year ranges' do
     def birth_node(**attrs)
       entity = build_entity(birth_info: [Ammitto::BirthInfo.new(**attrs)])
       serializer.serialize_entity(entity)['birthInfo'].first
@@ -181,6 +181,51 @@ RSpec.describe Ammitto::Serialization::JsonLdSerializer do
       expect(birth_node(year: 1964, city: 'Bern').sort.to_h)
         .to eq({ '@type' => 'BirthInfo', 'circa' => false,
                  'year' => 1964, 'city' => 'Bern' }.sort.to_h)
+    end
+
+    # The node holds real Date objects, so the bounds are read after
+    # generation: that is the form the website actually receives.
+    it 'emits complete date bounds under the camelCase contract names' do
+      node = JSON.parse(JSON.generate(birth_node(
+                                        date_range_from: Date.new(1961, 1, 1),
+                                        date_range_to: Date.new(1962, 12, 31)
+                                      )))
+
+      expect(node['dateRangeFrom']).to eq('1961-01-01')
+      expect(node['dateRangeTo']).to eq('1962-12-31')
+    end
+
+    it 'emits only the date bound that exists' do
+      node = JSON.parse(JSON.generate(birth_node(
+                                        date_range_to: Date.new(1962, 12, 31)
+                                      )))
+
+      expect(node['dateRangeTo']).to eq('1962-12-31')
+      expect(node).not_to have_key('dateRangeFrom')
+    end
+
+    # A same-year span is the one shape that carries date bounds AND a
+    # scalar year at once, and the scalar is the fragile half: 'year' is
+    # suppressed beside a YEAR span two examples above, so a serializer
+    # that generalised that suppression to date bounds would strip the
+    # exact year off every same-year OFAC span and take birthYear out of
+    # the search index with it. The transformer's half of this is pinned
+    # in base_transformer_spec; this pins that the value survives being
+    # serialized, which is the only form the website ever sees.
+    it 'keeps the exact year of a same-year span beside its date bounds' do
+      node = JSON.parse(JSON.generate(birth_node(
+                                        year: 1962,
+                                        date_range_from: Date.new(1962, 1, 1),
+                                        date_range_to: Date.new(1962, 12, 31),
+                                        year_range_from: 1962,
+                                        year_range_to: 1962
+                                      )))
+
+      expect(node['year']).to eq(1962)
+      expect(node['dateRangeFrom']).to eq('1962-01-01')
+      expect(node['dateRangeTo']).to eq('1962-12-31')
+      expect(node['yearRangeFrom']).to eq(1962)
+      expect(node['yearRangeTo']).to eq(1962)
     end
   end
 
@@ -224,6 +269,32 @@ RSpec.describe Ammitto::Serialization::JsonLdSerializer do
         literal = birth["#{vocab}#{term}"].first
         expect(literal['@type'])
           .to eq('http://www.w3.org/2001/XMLSchema#gYear')
+      end
+    end
+
+    it 'declares both date bounds as xsd:date' do
+      expect(terms['dateRangeFrom'])
+        .to eq({ '@id' => 'dateRangeFrom', '@type' => 'xsd:date' })
+      expect(terms['dateRangeTo'])
+        .to eq({ '@id' => 'dateRangeTo', '@type' => 'xsd:date' })
+    end
+
+    it 'expands the date bounds to xsd:date literals' do
+      node = serializer.serialize_entity(
+        build_entity(birth_info: [Ammitto::BirthInfo.new(
+          date_range_from: Date.new(1961, 1, 1),
+          date_range_to: Date.new(1962, 12, 31)
+        )])
+      ).merge(Ammitto::Schema::Context.context)
+      node = JSON.parse(JSON.generate(node))
+
+      vocab = 'https://ammitto.org/schema/v1/'
+      birth = JSON::LD::API.expand(node).first["#{vocab}birthInfo"].first
+
+      %w[dateRangeFrom dateRangeTo].each do |term|
+        literal = birth["#{vocab}#{term}"].first
+        expect(literal['@type'])
+          .to eq('http://www.w3.org/2001/XMLSchema#date')
       end
     end
   end

--- a/spec/ammitto/serialization/ontology_exporter_spec.rb
+++ b/spec/ammitto/serialization/ontology_exporter_spec.rb
@@ -46,8 +46,9 @@ RSpec.describe Ammitto::Serialization::OntologyExporter do
     # fields to the same reader (under different bases, so they are not
     # literally one RDF property). Telling that reader "integer" in one
     # and "gYear" in the other is a contradiction, so the year-valued
-    # BirthInfo properties are gYear in both.
-    describe 'the BirthInfo year properties' do
+    # BirthInfo properties are gYear in both, and the date-valued ones
+    # are date in both for the same reason.
+    describe 'the BirthInfo temporal properties' do
       let(:properties) do
         file = File.join(output_dir, 'ontology', 'properties.jsonld')
         JSON.parse(File.read(file))['@graph']
@@ -57,11 +58,18 @@ RSpec.describe Ammitto::Serialization::OntologyExporter do
         properties.find { |p| p['@id'].to_s.end_with?("/#{id}") }&.fetch('range')
       end
 
-      it 'publishes both range bounds' do
+      it 'publishes both year range bounds as gYear' do
         expect(range_of('yearRangeFrom'))
           .to eq('http://www.w3.org/2001/XMLSchema#gYear')
         expect(range_of('yearRangeTo'))
           .to eq('http://www.w3.org/2001/XMLSchema#gYear')
+      end
+
+      it 'publishes both date range bounds as xsd:date' do
+        expect(range_of('dateRangeFrom'))
+          .to eq('http://www.w3.org/2001/XMLSchema#date')
+        expect(range_of('dateRangeTo'))
+          .to eq('http://www.w3.org/2001/XMLSchema#date')
       end
 
       it 'agrees with the context on the year datatype' do
@@ -73,13 +81,15 @@ RSpec.describe Ammitto::Serialization::OntologyExporter do
           .to eq('http://www.w3.org/2001/XMLSchema#gYear')
       end
 
-      it 'lists both bounds among the BirthInfo class properties' do
+      it 'lists all four range bounds among the BirthInfo class properties' do
         file = File.join(output_dir, 'ontology', 'classes.jsonld')
         birth = JSON.parse(File.read(file))['@graph']
                     .find { |c| c['@id'].to_s.end_with?('/BirthInfo') }
 
         expect(birth['properties'])
-          .to include('https://www.ammitto.org/ontology/yearRangeFrom',
+          .to include('https://www.ammitto.org/ontology/dateRangeFrom',
+                      'https://www.ammitto.org/ontology/dateRangeTo',
+                      'https://www.ammitto.org/ontology/yearRangeFrom',
                       'https://www.ammitto.org/ontology/yearRangeTo')
       end
     end

--- a/spec/ammitto/serialization/search_index_exporter_spec.rb
+++ b/spec/ammitto/serialization/search_index_exporter_spec.rb
@@ -210,6 +210,52 @@ RSpec.describe Ammitto::Serialization::SearchIndexExporter do
         expect(row[:birthYearFrom]).to eq('1959')
         expect(row[:birthYearTo]).to eq('1965')
       end
+
+      # A full-date span reaches this exporter only after the real
+      # transformer derives its year bounds and the real serializer
+      # names them, so this example crosses both boundaries rather than
+      # hand-writing the hash they produce. Feeding a year-range hash
+      # straight in would prove the indexer reads year bounds — which
+      # was never in doubt — not that a date span supplies them.
+      it 'exports year bounds derived from a serialized date span' do
+        transformer = Ammitto::Transformers::BaseTransformer.new(:us)
+        birth = transformer.send(:create_birth_info,
+                                 date: '28 Feb 1962 to 28 Feb 1963')
+        birth_node = Ammitto::Serialization::JsonLdSerializer
+                     .new.send(:serialize_birth_info, birth)
+
+        row = row_for(birth_node)
+
+        expect(row[:birthYearFrom]).to eq('1962')
+        expect(row[:birthYearTo]).to eq('1963')
+        expect(row).not_to have_key(:birthYear)
+      end
+
+      # The same crossing for the OTHER span shape. A same-year span is
+      # the only one that answers an exact-year query AND a range query,
+      # so it is the only one where all five fields must appear at once
+      # — and the example above, being cross-year, asserts birthYear is
+      # ABSENT. Without this one a regression that dropped the scalar
+      # year anywhere along the crossing would leave the suite green and
+      # make every "born in 1962" search miss a person OFAC pinned to
+      # 1962 twice over. Both date bounds are asserted on the node the
+      # row is built from, so the finer precision is shown to survive
+      # into the artifact rather than being reduced to its years.
+      it 'exports birthYear and both bounds for a same-year date span' do
+        transformer = Ammitto::Transformers::BaseTransformer.new(:us)
+        birth = transformer.send(:create_birth_info,
+                                 date: '01 Jan 1962 to 31 Dec 1962')
+        birth_node = Ammitto::Serialization::JsonLdSerializer
+                     .new.send(:serialize_birth_info, birth)
+
+        row = row_for(birth_node)
+
+        expect(birth_node['dateRangeFrom']).to eq(Date.new(1962, 1, 1))
+        expect(birth_node['dateRangeTo']).to eq(Date.new(1962, 12, 31))
+        expect(row[:birthYear]).to eq('1962')
+        expect(row[:birthYearFrom]).to eq('1962')
+        expect(row[:birthYearTo]).to eq('1962')
+      end
     end
 
     # An entity can carry several birth records, and the span is not

--- a/spec/ammitto/sources/us/transformer_spec.rb
+++ b/spec/ammitto/sources/us/transformer_spec.rb
@@ -75,38 +75,70 @@ RSpec.describe Ammitto::Sources::Us::Transformer do
       expect(birth_for('1962 to 1964').circa).to be false
     end
 
-    # KNOWN GAP, deliberate. A full-date span carries day precision that
-    # year bounds cannot hold, and the harmonized contract has no
-    # date-valued range, so such a record publishes nothing at all.
-    # Reducing it to 1962-1964 would discard the days and months the
-    # source did state; asserting its opening date, which this
-    # transformer used to do, invented a single date the source never
-    # stated. Of the 117 spans in the live SDN export, 65 are of this
-    # finer-precision kind.
-    it 'publishes nothing for a full-date span rather than its opening date' do
-      birth = birth_for('28 Feb 1962 to 28 Feb 1963')
+    # A month-precision span keeps its years and loses its months. Date
+    # bounds cannot hold it without inventing a day, so the alternative
+    # is publishing nothing, which is what this shape did before: the
+    # "Mon YYYY to Mon YYYY" records in the SDN export fell through both
+    # recognizers — too coarse for the full-date span, too fine for the
+    # anchored bare-year one.
+    it 'reads a month span into the year bounds rather than publishing nothing' do
+      birth = birth_for('Mar 1962 to Feb 1963')
+      expect(birth.year_range_from).to eq(1962)
+      expect(birth.year_range_to).to eq(1963)
+      expect(birth.date_range_from).to be_nil
       expect(birth.date).to be_nil
       expect(birth.year).to be_nil
-      expect(birth.year_range_from).to be_nil
-      expect(birth.year_range_to).to be_nil
     end
 
-    # The costliest case of that gap, and the reason the opening date had
-    # to go: OFAC writes "01 Jan YYYY to 31 Dec YYYY" 37 distinct ways to
+    # A single month-and-year is a point, not a span, and still yields
+    # the stated year as a scalar.
+    it 'leaves a lone month and year as a scalar year' do
+      expect(birth_for('Aug 1946').year).to eq(1946)
+    end
+
+    # The gap this used to record is closed. A full-date span carries
+    # day precision that year bounds cannot hold, and the contract now
+    # has a date-valued range to hold it, so the record no longer has to
+    # choose between discarding the days and publishing its opening date
+    # as though the source had stated it alone. This is the majority of
+    # the spans in the SDN export. The endpoint years go out too, for
+    # the year-only search index; they supplement the complete claim
+    # rather than replacing it.
+    it 'publishes a full-date span without replacing it with its opening date' do
+      birth = birth_for('28 Feb 1962 to 28 Feb 1963')
+      json = JSON.parse(birth.to_json)
+
+      expect(json['dateRangeFrom']).to eq('1962-02-28')
+      expect(json['dateRangeTo']).to eq('1963-02-28')
+      expect(json['yearRangeFrom']).to eq(1962)
+      expect(json['yearRangeTo']).to eq(1963)
+      # Absent, not published as null: a consumer reading `date` off this
+      # record must find nothing there, and `be_nil` would pass just as
+      # happily on an explicit null that had re-asserted an opening date
+      # of sorts.
+      expect(json).not_to have_key('date')
+      expect(json).not_to have_key('year')
+    end
+
+    # The costliest case, and the reason the opening date had to go:
+    # OFAC writes "01 Jan YYYY to 31 Dec YYYY" in dozens of spellings to
     # mean "some day that year". Reading it as 1 January asserted the
     # invented January date this gem set out to stop asserting.
     #
-    # The year survives, though. Both endpoints state 1973 and the whole
-    # interval lies inside it, so discarding the year to avoid the false
-    # day would throw away a certainly-true fact about a sanctioned
-    # person. All four fields are asserted because getting the day right
-    # and the bounds wrong would be just as much a defect.
-    it 'keeps the stated year of a whole-year span without its 1 January date' do
+    # Both complete endpoints still matter even when they share a year.
+    # The scalar year survives because the whole interval lies inside
+    # it, while the equal year bounds keep every date span in the same
+    # search path.
+    it 'keeps the exact year alongside a same-year full-date span' do
       birth = birth_for('01 Jan 1973 to 31 Dec 1973')
-      expect(birth.date).to be_nil
-      expect(birth.year).to eq(1973)
-      expect(birth.year_range_from).to be_nil
-      expect(birth.year_range_to).to be_nil
+      json = JSON.parse(birth.to_json)
+
+      expect(json['dateRangeFrom']).to eq('1973-01-01')
+      expect(json['dateRangeTo']).to eq('1973-12-31')
+      expect(json['year']).to eq(1973)
+      expect(json['yearRangeFrom']).to eq(1973)
+      expect(json['yearRangeTo']).to eq(1973)
+      expect(json).not_to have_key('date')
     end
 
     it 'still resolves an ordinary date that merely contains a month name' do

--- a/spec/ammitto/transformers/base_transformer_spec.rb
+++ b/spec/ammitto/transformers/base_transformer_spec.rb
@@ -124,6 +124,20 @@ RSpec.describe Ammitto::Transformers::BaseTransformer do
       expect(birth(year_range_from: 1953).year_range_to).to be_nil
     end
 
+    # Caller-stated year bounds are authoritative, so the date string is
+    # not consulted at all while they are present — not even when it
+    # states a full-date span, which would otherwise outrank them and
+    # overwrite the very bounds the source declared in its own fields.
+    it 'never lets a date span in the string displace stated year bounds' do
+      info = birth(date: '28 Feb 1962 to 28 Feb 1963',
+                   year_range_from: 1900, year_range_to: 1910)
+
+      expect(info.year_range_from).to eq(1900)
+      expect(info.year_range_to).to eq(1910)
+      expect(info.date_range_from).to be_nil
+      expect(info.date_range_to).to be_nil
+    end
+
     it 'suppresses a caller-stated year when a span is also stated' do
       info = birth(date: '1955', year: 1955,
                    year_range_from: 1953, year_range_to: 1958)
@@ -158,54 +172,99 @@ RSpec.describe Ammitto::Transformers::BaseTransformer do
     end
 
     # A full-date span crossing years carries days the year bounds
-    # cannot hold and names no single birth year, so it publishes
-    # nothing rather than a coarsened or invented claim.
-    it 'does not reduce a full-date span to a year span' do
+    # cannot hold, so it keeps them: the complete endpoints ride in the
+    # date bounds, and their years are repeated in the year bounds for
+    # consumers that index only years. Neither scalar is filled, because
+    # no single date or year is stated.
+    it 'publishes complete date bounds and their endpoint years' do
       info = birth(date: '28 Feb 1962 to 28 Feb 1963')
 
-      expect(info.year_range_from).to be_nil
-      expect(info.year_range_to).to be_nil
+      expect(info.date_range_from).to eq(Date.new(1962, 2, 28))
+      expect(info.date_range_to).to eq(Date.new(1963, 2, 28))
+      expect(info.year_range_from).to eq(1962)
+      expect(info.year_range_to).to eq(1963)
       expect(info.date).to be_nil
       expect(info.year).to be_nil
     end
 
     # ...but when both endpoints state the SAME year, that year is
     # asserted outright, twice, and the whole interval lies inside it.
-    # Publishing nothing there would discard a certainly-true fact to
-    # avoid a false one that is not on offer.
+    # The existing scalar therefore remains valid alongside the complete
+    # range and its derived bounds.
     it 'retains the exact year from a same-year full-date span' do
       info = birth(date: '01 Jan 1962 to 31 Dec 1962')
 
+      expect(info.date_range_from).to eq(Date.new(1962, 1, 1))
+      expect(info.date_range_to).to eq(Date.new(1962, 12, 31))
       expect(info.year).to eq(1962)
       expect(info.date).to be_nil
-      expect(info.year_range_from).to be_nil
-      expect(info.year_range_to).to be_nil
+      expect(info.year_range_from).to eq(1962)
+      expect(info.year_range_to).to eq(1962)
     end
 
-    # Not special-cased to whole-calendar-year endpoints — what matters
-    # is that both endpoints name the same year, not which days they are.
-    it 'retains the year from a partial same-year span' do
+    # Not special-cased to whole-calendar-year endpoints: the complete
+    # range is preserved whenever both endpoints are valid.
+    it 'retains the range and year from a partial same-year span' do
       info = birth(date: '28 Feb 1962 to 07 Dec 1962')
 
+      expect(info.date_range_from).to eq(Date.new(1962, 2, 28))
+      expect(info.date_range_to).to eq(Date.new(1962, 12, 7))
       expect(info.year).to eq(1962)
       expect(info.date).to be_nil
     end
 
-    # A qualified span is a grammar nobody designed. It stays silent
-    # rather than being folded into the strict same-year rule.
-    it 'stays silent on a qualified same-year span' do
-      info = birth(date: 'circa 01 Jan 1962 to 31 Dec 1962')
+    # NARROWING, deliberate, and the one place this change publishes
+    # less than before it. A same-year span whose day is OFAC's
+    # zero-padded "unknown" ("00 Jan 1962 to 31 Dec 1962") used to
+    # surrender its year through the old same-year rule, which read the
+    # two year captures and ignored the days entirely. The date bounds
+    # replaced that rule, and they need endpoints that name real days,
+    # so this shape now publishes nothing at all.
+    #
+    # It is recorded rather than repaired because no local raw OFAC
+    # corpus exists to say whether the shape occurs at all, and the
+    # alternative — reading year bounds out of a value whose days are
+    # unreadable — is a second grammar, decided on evidence nobody has.
+    # Raising instead would be worse still: it would fail the harmonize
+    # health gate on a routine partial value.
+    it 'publishes nothing for a same-year span whose day is unreadable' do
+      info = birth(date: '00 Jan 1962 to 31 Dec 1962')
 
+      expect(info.date_range_from).to be_nil
+      expect(info.date_range_to).to be_nil
       expect(info.year).to be_nil
       expect(info.date).to be_nil
       expect(info.year_range_from).to be_nil
-      expect(info.year_range_to).to be_nil
     end
 
-    it 'does not reduce a month span either' do
+    # A qualified span is a grammar nobody designed. It stays silent at
+    # every precision: neither the strict same-year rule nor the month
+    # span may fold one in. "circa" is exactly the word a month slot
+    # spelled as any three-to-nine letters swallows, so the year-only
+    # qualified span is here beside the day-precision one.
+    it 'stays silent on a qualified span' do
+      ['circa 01 Jan 1962 to 31 Dec 1962',
+       'circa 1962 to circa 1964'].each do |value|
+        info = birth(date: value)
+        published = [info.date, info.year, info.year_range_from,
+                     info.year_range_to, info.date_range_from,
+                     info.date_range_to]
+
+        expect(published)
+          .to(all(be_nil), "#{value.inspect} published #{published.inspect}")
+      end
+    end
+
+    # A month span reduces to its years, unlike a day span, which keeps
+    # its days as date bounds. The months are lost because no published
+    # field can hold them without a fabricated day — and the shape used
+    # to publish nothing at all, which lost the years too.
+    it 'reduces a month span to its year bounds' do
       info = birth(date: 'Mar 1980 to Mar 1981')
 
-      expect(info.year_range_from).to be_nil
+      expect(info.year_range_from).to eq(1980)
+      expect(info.year_range_to).to eq(1981)
+      expect(info.date_range_from).to be_nil
       expect(info.date).to be_nil
       expect(info.year).to be_nil
     end
@@ -254,6 +313,22 @@ RSpec.describe Ammitto::Transformers::BaseTransformer do
       expect { transformer.send(:create_birth_info, year_range_to: 1958) }
         .not_to raise_error
     end
+
+    it 'rejects a reversed date span stated as text' do
+      expect do
+        transformer.send(:create_birth_info,
+                         date: '28 Feb 1963 to 28 Feb 1962')
+      end.to raise_error(Ammitto::Transformers::InvalidDateRangeError,
+                         /1963-02-28 > 1962-02-28/)
+    end
+
+    it 'accepts a date span whose endpoints are the same day' do
+      info = transformer.send(:create_birth_info,
+                              date: '28 Feb 1962 to 28 Feb 1962')
+
+      expect(info.date_range_from).to eq(Date.new(1962, 2, 28))
+      expect(info.date_range_to).to eq(Date.new(1962, 2, 28))
+    end
   end
 
   # Presence is decided before normalization. Deciding it after would
@@ -299,14 +374,43 @@ RSpec.describe Ammitto::Transformers::BaseTransformer do
         .to eq([1959, 1965])
     end
 
-    # Two years in a string is not enough. These carry finer precision,
-    # or no span at all, and reading them as year spans would either
-    # discard stated days or invent a span outright.
+    # A month-precision span is read here, losing its months. It has no
+    # finer home: date bounds cannot hold it without inventing a day, so
+    # refusing it published nothing at all. Six records in the live SDN
+    # export take this shape.
+    #
+    # Abbreviated, full and mixed endpoints are all exercised because
+    # the month slot is a hand-written list of names: a spelling missing
+    # from it returns the shape to publishing nothing, silently. "Sept"
+    # is named for being the one entry with a nested optional tail.
+    it 'reads a month-precision span, since date bounds cannot hold one' do
+      ['Mar 1980 to Mar 1981', 'March 1980 to March 1981',
+       'Mar 1980 to March 1981', 'Sept 1980 to September 1981'].each do |value|
+        expect(transformer.send(:extract_year_range, value))
+          .to(eq([1980, 1981]), "#{value.inspect} is not read as a span")
+      end
+    end
+
+    # A month slot spelled as any three-to-nine letters was anchored but
+    # not month-precision, and read "circa 1962 to circa 1964" as a year
+    # span — the qualified grammar FULL_DATE_SPAN declines, published as
+    # bounds the source never stated. BOTH endpoints must name a month,
+    # since one that does not leaves its own bound unproven.
+    it 'refuses a span whose endpoints name no month' do
+      ['circa 1962 to circa 1964', 'born 1962 to citizen 1964',
+       'circa 1962 to Mar 1964', 'Mar 1962 to circa 1964'].each do |value|
+        expect(transformer.send(:extract_year_range, value))
+          .to(be_nil, "expected #{value.inspect} not to be read as a year span")
+      end
+    end
+
+    # Two years in a string is not enough. A day-precision span keeps its
+    # days through FULL_DATE_SPAN and must not be flattened here; the
+    # rest state no span at all, and reading them as one would invent it.
     it 'refuses strings that merely contain two years' do
-      ['28 Feb 1962 to 28 Feb 1963', 'Mar 1980 to Mar 1981',
-       '01 Jan 1973 to 31 Dec 1973', 'born 1962, naturalised 1964',
-       'passport issued 1962 to 1964', '1962 to 1964 (unconfirmed)',
-       '19621964'].each do |value|
+      ['28 Feb 1962 to 28 Feb 1963', '01 Jan 1973 to 31 Dec 1973',
+       'born 1962, naturalised 1964', 'passport issued 1962 to 1964',
+       '1962 to 1964 (unconfirmed)', '19621964'].each do |value|
         expect(transformer.send(:extract_year_range, value))
           .to(be_nil, "expected #{value.inspect} not to be read as a year span")
       end
@@ -323,6 +427,44 @@ RSpec.describe Ammitto::Transformers::BaseTransformer do
     it 'ignores non-strings' do
       expect(transformer.send(:extract_year_range, nil)).to be_nil
       expect(transformer.send(:extract_year_range, Date.new(1970, 1, 1)))
+        .to be_nil
+    end
+  end
+
+  # Anchored for the same reason as the year patterns: a value carrying
+  # less than two complete dates must not be upgraded into a span of
+  # them.
+  describe '#extract_date_range' do
+    it 'returns complete Date-valued bounds' do
+      expect(transformer.send(:extract_date_range, '01 Jan 1961 to 31 Dec 1962'))
+        .to eq([Date.new(1961, 1, 1), Date.new(1962, 12, 31)])
+    end
+
+    it 'does not upgrade incomplete or qualified spans' do
+      ['1961 to 1962', 'Jan 1961 to Dec 1962', '01 Jan 1961 to 31 Dec',
+       'circa 01 Jan 1961 to 31 Dec 1962'].each do |value|
+        expect(transformer.send(:extract_date_range, value))
+          .to(be_nil, "expected #{value.inspect} not to be read as a date span")
+      end
+    end
+
+    # An endpoint of the right SHAPE that names no real day states no
+    # complete-date span. It yields nil rather than raising, because the
+    # text path classifies spellings and only #stated_date_range judges
+    # a bound a source declared for itself. Raising here would turn
+    # OFAC's zero-padded "unknown day" convention into a harmonize
+    # health-gate failure.
+    it 'declines, without raising, an endpoint that names no real day' do
+      ['31 Feb 1962 to 28 Feb 1963', '00 Jan 1962 to 31 Dec 1962',
+       '01 Xxxxx 1962 to 31 Dec 1962'].each do |value|
+        expect(transformer.send(:extract_date_range, value))
+          .to(be_nil, "expected #{value.inspect} to be declined quietly")
+      end
+    end
+
+    it 'ignores non-strings' do
+      expect(transformer.send(:extract_date_range, nil)).to be_nil
+      expect(transformer.send(:extract_date_range, Date.new(1961, 1, 1)))
         .to be_nil
     end
   end


### PR DESCRIPTION
OFAC states some births as a span between two complete dates —
`01 Jan 1961 to 31 Dec 1962`. The harmonized model has a year range but no
date range, so `create_birth_info` had nowhere to put it and published
**nothing at all**: no date, no year, no bounds.

That was a deliberate choice, recorded at
`spec/ammitto/sources/us/transformer_spec.rb:78-90`. The transformer used
to assert the span's opening date, which invented a date the source never
stated; reducing it to year bounds instead would discard the days and
months the source did state. Neither option was honest, so it published
nothing, and the spec noted that 65 of the 117 spans in the live SDN
export are of this finer-precision kind.

This adds the missing shape rather than continuing to choose between two
wrong answers.

## Why now

The site's `deploy.yml` pins the gem and runs `harmonize` itself. That pin
is ten commits behind. When it moves, **34 US entities that currently
display a birth date will display none** — measured against the live
published API by two independent passes, which agreed. No site change can
recover them, because after the bump there is no data in the artifact to
format. Landing this first means the pin bump ships the fix instead of the
regression.

## Changes

- `BirthInfo` gains `date_range_from` / `date_range_to`, emitted as
  `dateRangeFrom` / `dateRangeTo` with `xsd:date`, on both the top-level
  and ontology model layers. Declared in the JSON-LD context, the
  generated ontology, and the serializer.
- **Year bounds are also derived from the date bounds.** The search index
  carries only `birthYearFrom` / `birthYearTo`, so a date-range-only
  record would be unfindable by year — the exact invisibility this change
  exists to remove, relocated rather than fixed. Publishing both discards
  nothing: the date bounds stay authoritative and the year bounds are a
  discovery projection. Proven by execution, not by reading — a new
  cross-layer spec drives the real transformer and the real serializer and
  asserts the bounds land on the search row.
- The same-year rule is preserved and generalised. `01 Jan 1962 to 31 Dec
  1962` still yields `year: 1962`, because the whole interval lies inside
  that year — reading it out is parsing, not inference. It now works for
  caller-supplied bounds too, not only text spans.
- Rendering follows `BirthInfo#formatted_date`: the date range takes
  precedence over its own derived year range, open bounds render as the
  direction they leave open, and `c. ` prefixes every branch.
- A reversed date span raises, exactly as a reversed year span does.

## A malformed day declines rather than raises

Worth calling out because it nearly went the other way. OFAC zero-pads an
unknown day — `00 Jan 1962 to 31 Dec 1962`. An earlier draft raised
`InvalidDateRangeError` on any endpoint that was not a real calendar day.
`HarmonizeCommand` rescues per file and feeds its health gate, so that
would have turned a routine partial value into a **deploy failure**.

The text path now returns `nil` for an unreadable day, matching how the
year path already treats an unrecognised spelling. Raising is reserved for
the two genuine defects: a bound a source declared in a field of its own
and left malformed, and a closed span running backwards.

## Test plan

- `bundle exec rake` — 1610 → **1638 examples, 0 failures, 4 pending**, exit 0.
- `bundle exec rubocop` — **427 files, no offenses**, exit 0.
- **Red proof:** the seven modified lib files restored from HEAD, suite
  re-run. Both new assertions fail with value mismatches —
  `expected "1962-02-28", got nil` and `expected "1962", got nil` — not
  with a `NoMethodError`, which would have proved only that a method was
  absent. Restored, re-run green.
- Behaviour verified by execution across five span shapes: cross-year,
  same-year, bare-year, zero-day, and a caller-supplied pair.

## Two things left deliberately

**A same-year span with an unreadable day now publishes nothing.**
`00 Jan 1962 to 31 Dec 1962` previously yielded `year: 1962` through the
same-year rule this change replaces. Recovering it means reading year
bounds out of a value whose days are unreadable — a second grammar — and
there is no local raw OFAC corpus to say whether the shape occurs at all.
Recorded in a spec rather than left silent. This is the one judgement call
worth a second opinion.

**`Metrics/ParameterLists` raised from 10 to 11**, with the reason written
at the cop. `create_birth_info` now takes eleven keyword arguments, four of
which are pure pass-through place fields. Grouping them is the real fix and
touches roughly eight source transformers, so it is not this change.
