### PR TITLE
Load every source's supplement directories instead of the first

### DIFF
--- a/lib/ammitto/cli/harmonize_command.rb
+++ b/lib/ammitto/cli/harmonize_command.rb
@@ -113,8 +113,8 @@ module Ammitto
         @exporter = Serialization::JsonLdGraphExporter.new(
           output_dir: output_dir,
           combine: options[:combine] == true,
-          instruments_dir: find_instruments_dir,
-          supporting_dir: find_supporting_dir
+          instruments_dir: find_instruments_dirs,
+          supporting_dir: find_supporting_dirs
         )
         @search_indexer = Serialization::SearchIndexExporter.new
         @ontology_exporter = Serialization::OntologyExporter.new
@@ -745,39 +745,43 @@ module Ammitto
         File.join(base_dir, subdirs.first)
       end
 
-      # Find legal instruments directory
-      # @return [String, nil] path to instruments directory
-      def find_instruments_dir
-        find_supplement_dir('legal-instruments')
+      # Find legal instruments directories
+      # @return [Array<String>] instrument directories in requested-source order
+      def find_instruments_dirs
+        find_supplement_dirs('legal-instruments')
       end
 
-      # Find supporting data directory (document types, organizations)
-      # @return [String, nil] path to supporting directory
-      def find_supporting_dir
-        find_supplement_dir('supporting')
+      # Find supporting data directories (document types, organizations)
+      # @return [Array<String>] supporting directories in requested-source order
+      def find_supporting_dirs
+        find_supplement_dirs('supporting')
       end
 
-      # Resolve a supplement subtree (legal-instruments/, supporting/) for
-      # the requested sources. Supplements live inside a source's own data
-      # repository (currently only data-cn ships them), so they are looked
-      # up per requested source — a run that does not include a source must
-      # not inject that source's supplement nodes into its output tree.
-      # Known limitation: first match wins in requested-source order, because
-      # the exporter accepts a single directory per supplement kind; if a
-      # second repository ever ships supplements, the exporter API must grow
-      # union loading.
+      # Resolve every supplement subtree (legal-instruments/, supporting/)
+      # belonging to the requested sources. Supplements live inside a
+      # source's own data repository, so they are looked up per requested
+      # source — a run that does not include a source must not inject that
+      # source's supplement nodes into its output tree.
+      #
+      # Every match is returned rather than the first. Six data repositories
+      # ship supplements, and the exporter groups announcements and
+      # instruments by exact source-qualified identifier, so a vocabulary
+      # left unloaded is not a partial result: no slice exists for that
+      # source at all, and the ones that do exist belong to whichever source
+      # happened to sort first.
       # @param subdir [String] supplement directory name
-      # @return [String, nil] path to the supplement directory
-      def find_supplement_dir(subdir)
+      # @return [Array<String>] supplement directories in requested-source order
+      def find_supplement_dirs(subdir)
         sources_dir = options[:sources_dir]
         if sources_dir
-          @sources.each do |source|
+          paths = @sources.filter_map do |source|
             repo = Config::Defaults::DATA_REPO_TO_SOURCE.key(source)
             next unless repo
 
             path = File.join(sources_dir, repo, 'sources', subdir)
-            return path if Dir.exist?(path)
-          end
+            path if Dir.exist?(path)
+          end.uniq
+          return paths unless paths.empty?
         end
 
         # input_dir is already scoped to the repository the caller pointed
@@ -786,10 +790,10 @@ module Ammitto
         input_dir = options[:input_dir]
         if input_dir
           path = File.join(File.dirname(input_dir), subdir)
-          return path if Dir.exist?(path)
+          return [path] if Dir.exist?(path)
         end
 
-        nil
+        []
       end
 
       # Transform data using appropriate transformer

--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -91,13 +91,23 @@ module Ammitto
       # Initialize the graph exporter
       # @param output_dir [String] directory for output files
       # @param context_url [String] URL to the JSON-LD context
+      # @param instruments_dir [String, Array<String>, nil] legal instrument
+      #   directories, in precedence order
+      # @param supporting_dir [String, Array<String>, nil] supporting data
+      #   directories, in precedence order
       def initialize(output_dir:, context_url: nil, combine: true,
                      instruments_dir: nil, supporting_dir: nil)
         @output_dir = output_dir
         @context_url = context_url || Ammitto::Schema::Context.context_url
         @combine = combine
-        @instruments_dir = instruments_dir
-        @supporting_dir = supporting_dir
+        # Every supplied repository contributes. Supplement identifiers are
+        # source-qualified ('cn/act', 'uk/regulation'), so the vocabularies
+        # union rather than compete, and the grouping the slices depend on is
+        # an exact identifier match: a source whose vocabulary never loads can
+        # never be grouped, and its announcements and instruments go
+        # unreachable however complete the rest of the graph is.
+        @instruments_dirs = Array(instruments_dir).compact.uniq
+        @supporting_dirs = Array(supporting_dir).compact.uniq
 
         # Node collectors
         @entities = {}
@@ -128,24 +138,30 @@ module Ammitto
         # Serializer for generating node data
         @serializer = JsonLdSerializer.new
 
-        # Load legal instruments if directory provided
-        load_legal_instruments if @instruments_dir
-
-        # Load supporting data if directory provided
-        load_supporting_data if @supporting_dir
+        load_legal_instruments
+        load_supporting_data
       end
 
-      # Load legal instruments from YAML files
+      # Load legal instruments from every supplied directory
       # @return [void]
       def load_legal_instruments
-        return unless @instruments_dir && Dir.exist?(@instruments_dir)
+        @instruments_dirs.each do |dir|
+          next unless Dir.exist?(dir)
 
-        Dir.glob(File.join(@instruments_dir, '**', '*.yml')).each do |file|
-          load_instrument_file(file)
+          instrument_files(dir).each { |file| load_instrument_file(file) }
         end
-        Dir.glob(File.join(@instruments_dir, '**', '*.yaml')).each do |file|
-          load_instrument_file(file)
-        end
+      end
+
+      # Instrument YAML files under one directory.
+      #
+      # Order is load-bearing now that the first claimant of an identifier
+      # keeps it, and Dir.glob supplies it: it sorts its results, so two
+      # machines resolve the same duplicate the same way.
+      # @param dir [String] instrument directory
+      # @return [Array<String>] YAML file paths
+      def instrument_files(dir)
+        Dir.glob(File.join(dir, '**', '*.yml')) +
+          Dir.glob(File.join(dir, '**', '*.yaml'))
       end
 
       # Load a single legal instrument YAML file
@@ -156,23 +172,55 @@ module Ammitto
         return unless data && data['id']
 
         # Store by the ID (e.g., "cn/mofcom-unreliable-entity-list-provisions")
-        @loaded_instruments[data['id']] = data
+        claim(@loaded_instruments, data['id'], data, 'Legal instrument', file)
       rescue StandardError => e
         puts "Warning: Could not load instrument #{file}: #{e.message}" if ENV['VERBOSE']
       end
 
-      # Load supporting data (document types, organizations) from YAML files
+      # Load supporting data (document types, organizations) from every
+      # supplied directory
       # @return [void]
       def load_supporting_data
-        return unless @supporting_dir && Dir.exist?(@supporting_dir)
+        @supporting_dirs.each do |dir|
+          next unless Dir.exist?(dir)
 
-        # Load document types
-        doc_types_file = File.join(@supporting_dir, 'document-types.yml')
-        load_document_types_file(doc_types_file) if File.exist?(doc_types_file)
+          # Load document types
+          doc_types_file = File.join(dir, 'document-types.yml')
+          load_document_types_file(doc_types_file) if File.exist?(doc_types_file)
 
-        # Load organizations
-        orgs_file = File.join(@supporting_dir, 'organizations.yml')
-        load_organizations_file(orgs_file) if File.exist?(orgs_file)
+          # Load organizations
+          orgs_file = File.join(dir, 'organizations.yml')
+          load_organizations_file(orgs_file) if File.exist?(orgs_file)
+        end
+      end
+
+      # Record the first claimant of a supplement identifier.
+      #
+      # Directories arrive in requested-source order, so keeping the earliest
+      # claim makes the result independent of what is added later: a new
+      # repository can extend a vocabulary but never silently re-point a row
+      # already published under someone else's definition.
+      #
+      # Identifiers are source-qualified, so a clash means two repositories
+      # claim one source's row — a data defect, not a merge to resolve, hence
+      # an unconditional warning rather than the VERBOSE-gated ones nearby
+      # that report unreadable files. It is deliberately not fatal: the
+      # unattended publish spans fifteen repositories, and losing the whole
+      # graph over one duplicated row is the worse outcome.
+      # @param collection [Hash] collection claiming into
+      # @param key [String] identifier being claimed
+      # @param value [Object] node to store
+      # @param kind [String] human-readable node kind
+      # @param origin [String] file the duplicate claim came from
+      # @return [void]
+      def claim(collection, key, value, kind, origin)
+        if collection.key?(key)
+          warn "Warning: #{kind} #{key.inspect} is already defined; " \
+               "ignoring the duplicate declared in #{origin}"
+          return
+        end
+
+        collection[key] = value
       end
 
       # Load document types from YAML file
@@ -209,13 +257,13 @@ module Ammitto
             end
           end
 
-          @document_types[iri] = {
+          claim(@document_types, iri, {
             '@context' => @context_url,
             '@id' => iri,
             '@type' => 'DocumentType',
             'identifier' => type_id,
             'name' => names
-          }.compact
+          }.compact, 'Document type', file)
         end
 
         @stats[:total_document_types] = @document_types.length
@@ -257,7 +305,7 @@ module Ammitto
             end
           end
 
-          @organizations[iri] = {
+          claim(@organizations, iri, {
             '@context' => @context_url,
             '@id' => iri,
             '@type' => 'Organization',
@@ -266,7 +314,7 @@ module Ammitto
             'type' => org_data['type'],
             'parentId' => org_data['parent_id'],
             'url' => org_data['url']
-          }.compact
+          }.compact, 'Organization', file)
         end
 
         @stats[:total_organizations] = @organizations.length

--- a/spec/ammitto/cli/harmonize_command_spec.rb
+++ b/spec/ammitto/cli/harmonize_command_spec.rb
@@ -381,30 +381,47 @@ RSpec.describe Ammitto::Cmd::HarmonizeCommand do
       supporting = make_dir('data-cn', 'sources', 'supporting')
       cn = described_class.new(options, ['cn'])
 
-      expect(cn.send(:find_instruments_dir)).to eq(instruments)
-      expect(cn.send(:find_supporting_dir)).to eq(supporting)
+      expect(cn.send(:find_instruments_dirs)).to eq([instruments])
+      expect(cn.send(:find_supporting_dirs)).to eq([supporting])
     end
 
     it 'does not leak cn supplements into other sources' do
       make_dir('data-cn', 'sources', 'legal-instruments')
       make_dir('data-cn', 'sources', 'supporting')
 
-      expect(command.send(:find_instruments_dir)).to be_nil
-      expect(command.send(:find_supporting_dir)).to be_nil
+      expect(command.send(:find_instruments_dirs)).to eq([])
+      expect(command.send(:find_supporting_dirs)).to eq([])
     end
 
     it 'resolves a requested source from its own data repository' do
       instruments = make_dir('data-us', 'sources', 'legal-instruments')
       make_dir('data-cn', 'sources', 'legal-instruments')
 
-      expect(command.send(:find_instruments_dir)).to eq(instruments)
+      expect(command.send(:find_instruments_dirs)).to eq([instruments])
     end
 
     it 'reaches cn supplements in a multi-source run without us ones' do
       instruments = make_dir('data-cn', 'sources', 'legal-instruments')
       multi = described_class.new(options, %w[us cn])
 
-      expect(multi.send(:find_instruments_dir)).to eq(instruments)
+      expect(multi.send(:find_instruments_dirs)).to eq([instruments])
+    end
+
+    it 'returns every requested source in requested order' do
+      us = make_dir('data-us', 'sources', 'supporting')
+      cn = make_dir('data-cn', 'sources', 'supporting')
+
+      expect(described_class.new(options, %w[us cn])
+                            .send(:find_supporting_dirs)).to eq([us, cn])
+      expect(described_class.new(options, %w[cn us])
+                            .send(:find_supporting_dirs)).to eq([cn, us])
+    end
+
+    it 'names a repeated source once' do
+      us = make_dir('data-us', 'sources', 'supporting')
+      repeated = described_class.new(options, %w[us us])
+
+      expect(repeated.send(:find_supporting_dirs)).to eq([us])
     end
 
     it 'falls back to siblings of an explicit input_dir' do
@@ -412,12 +429,45 @@ RSpec.describe Ammitto::Cmd::HarmonizeCommand do
       supporting = make_dir('repo', 'sources', 'supporting')
       options[:input_dir] = input_dir
 
-      expect(command.send(:find_supporting_dir)).to eq(supporting)
+      expect(command.send(:find_supporting_dirs)).to eq([supporting])
     end
 
-    it 'returns nil when no supplement directories exist' do
-      expect(command.send(:find_instruments_dir)).to be_nil
-      expect(command.send(:find_supporting_dir)).to be_nil
+    it 'returns an empty array when no supplement directories exist' do
+      expect(command.send(:find_instruments_dirs)).to eq([])
+      expect(command.send(:find_supporting_dirs)).to eq([])
+    end
+  end
+
+  describe 'supplement wiring' do
+    # Reached through harmonize_all rather than the finders directly: the
+    # defect was that only one directory ever arrived at the exporter, and
+    # the finders were only half of that path. Construction is the first
+    # thing harmonize_all does, so raising from the stub captures the real
+    # arguments without needing a source's worth of data behind it.
+    def exporter_kwargs(sources)
+      captured = nil
+      stop = Class.new(StandardError)
+      allow(Ammitto::Serialization::JsonLdGraphExporter)
+        .to receive(:new) do |**kwargs|
+          captured = kwargs
+          raise stop
+        end
+
+      expect { described_class.new(options, sources).send(:harmonize_all) }
+        .to raise_error(stop)
+      captured
+    end
+
+    it 'hands every requested source\'s supplements to the exporter' do
+      us_supporting = make_dir('data-us', 'sources', 'supporting')
+      cn_supporting = make_dir('data-cn', 'sources', 'supporting')
+      cn_instruments = make_dir('data-cn', 'sources', 'legal-instruments')
+      jp_instruments = make_dir('data-jp', 'sources', 'legal-instruments')
+
+      kwargs = exporter_kwargs(%w[us cn jp])
+
+      expect(kwargs[:supporting_dir]).to eq([us_supporting, cn_supporting])
+      expect(kwargs[:instruments_dir]).to eq([cn_instruments, jp_instruments])
     end
   end
 

--- a/spec/ammitto/serialization/json_ld_graph_exporter_spec.rb
+++ b/spec/ammitto/serialization/json_ld_graph_exporter_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 require 'fileutils'
 require 'json'
 require 'tmpdir'
+require 'yaml'
 require 'ammitto/serialization/json_ld_graph_exporter'
 require 'ammitto/serialization/turtle_exporter'
 
@@ -430,6 +431,151 @@ RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
 
         expect(entry['legalCitations'].first['citationType']).to eq('canonical')
       end
+    end
+  end
+
+  describe 'supplement loading' do
+    let(:supplements_root) { Dir.mktmpdir('ammitto_supplements') }
+
+    after do
+      FileUtils.rm_rf(supplements_root)
+    end
+
+    def write_yaml(path, data)
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, YAML.dump(data))
+      path
+    end
+
+    def write_document_types(repo, id, name)
+      write_yaml(
+        File.join(supplements_root, repo, 'supporting', 'document-types.yml'),
+        'document_types' => [{ 'id' => id, 'name' => { 'en' => name } }]
+      )
+      File.join(supplements_root, repo, 'supporting')
+    end
+
+    def english_name(node)
+      node['name'].find { |n| n['lang'] == 'en' }['value']
+    end
+
+    it 'combines every directory into populated page slices' do
+      us_supporting = File.join(supplements_root, 'data-us', 'supporting')
+      cn_supporting = File.join(supplements_root, 'data-cn', 'supporting')
+      us_instruments = File.join(supplements_root, 'data-us',
+                                 'legal-instruments')
+      cn_instruments = File.join(supplements_root, 'data-cn',
+                                 'legal-instruments')
+
+      write_yaml(
+        File.join(us_supporting, 'document-types.yml'),
+        'document_types' => [
+          { 'id' => 'us/designation', 'name' => { 'en' => 'Designation' } }
+        ]
+      )
+      write_yaml(
+        File.join(us_supporting, 'organizations.yml'),
+        'organizations' => [{ 'id' => 'us/ofac', 'name' => { 'en' => 'OFAC' } }]
+      )
+      write_yaml(
+        File.join(cn_supporting, 'document-types.yml'),
+        'document_types' => [{ 'id' => 'cn/act', 'name' => { 'en' => 'Act' } }]
+      )
+      write_yaml(
+        File.join(cn_supporting, 'organizations.yml'),
+        'organizations' => [
+          { 'id' => 'cn/ministry', 'name' => { 'en' => 'Ministry' } }
+        ]
+      )
+      write_yaml(File.join(us_instruments, 'law.yml'),
+                 'id' => 'us/law', 'type' => 'us/designation',
+                 'title' => 'US law')
+      write_yaml(File.join(cn_instruments, 'law.yml'),
+                 'id' => 'cn/law', 'type' => 'cn/act', 'title' => 'CN law')
+
+      merged = described_class.new(
+        output_dir: output_dir,
+        context_url: context_url,
+        combine: false,
+        supporting_dir: [us_supporting, cn_supporting],
+        instruments_dir: [us_instruments, cn_instruments]
+      )
+
+      expect(merged.document_types.keys).to contain_exactly(
+        'https://www.ammitto.org/document-type/us/designation',
+        'https://www.ammitto.org/document-type/cn/act'
+      )
+      expect(merged.organizations.keys).to contain_exactly(
+        'https://www.ammitto.org/organization/us/ofac',
+        'https://www.ammitto.org/organization/cn/ministry'
+      )
+      expect(merged.loaded_instruments.keys)
+        .to contain_exactly('us/law', 'cn/law')
+
+      merged.add_node(
+        entity: { '@id' => 'https://www.ammitto.org/entity/cn/1' },
+        entry: {
+          '@id' => 'https://www.ammitto.org/entry/cn/list/1',
+          'announcement' => {
+            'documentType' => 'cn/act',
+            'documentId' => 'CN-1',
+            'publisher' => 'cn/ministry'
+          },
+          'legalCitations' => [{
+            'legalInstrumentId' =>
+              'https://www.ammitto.org/legal_instrument/cn/law'
+          }]
+        },
+        source: :cn
+      )
+      merged.export
+
+      document_slice = JSON.parse(File.read(File.join(
+                                              output_dir, 'by-document-type',
+                                              'cn', 'act.jsonld'
+                                            )))
+      organization_slice = JSON.parse(File.read(File.join(
+                                                  output_dir,
+                                                  'by-organization', 'cn',
+                                                  'ministry.jsonld'
+                                                )))
+
+      expect(document_slice['announcements'])
+        .to match([a_hash_including('documentId' => 'CN-1')])
+      expect(document_slice['legalInstruments'])
+        .to match([a_hash_including('identifier' => 'law')])
+      expect(organization_slice['published'])
+        .to match([a_hash_including('documentId' => 'CN-1')])
+    end
+
+    it 'keeps the first claim on an identifier and reports the duplicate' do
+      first = write_document_types('data-cn', 'cn/act', 'Claimed first')
+      second = write_document_types('data-jp', 'cn/act', 'Claimed second')
+
+      merged = nil
+      expect do
+        merged = described_class.new(
+          output_dir: output_dir, context_url: context_url,
+          supporting_dir: [first, second]
+        )
+      end.to output(%r{Document type .*cn/act.* is already defined})
+        .to_stderr
+
+      expect(merged.document_types.size).to eq(1)
+      expect(english_name(merged.document_types.values.first))
+        .to eq('Claimed first')
+    end
+
+    it 'still accepts a single directory as a bare string' do
+      supporting = write_document_types('data-cn', 'cn/act', 'Act')
+
+      single = described_class.new(
+        output_dir: output_dir, context_url: context_url,
+        supporting_dir: supporting
+      )
+
+      expect(single.document_types.keys)
+        .to eq(['https://www.ammitto.org/document-type/cn/act'])
     end
   end
 end


### PR DESCRIPTION
`harmonize` loaded supporting data from the FIRST source directory it
found and stopped. Six data repositories ship one — ch, cn, jp, ru, uk and
us — so five vocabularies were unreachable, and the published graph has
been one repo's supplement and nothing else.

Live `stats.json` says it plainly: `total_document_types: 6`,
`total_organizations: 5`, across thirteen harmonized sources. All eleven
are `uk/`-prefixed, and `data-uk/sources/supporting/` contains exactly
those six document types and five organizations.

`find_supplement_dir` documented the behaviour as a known limitation
needing union loading. This is that union.

## Changes

- `find_supplement_dir` becomes `find_supplement_dirs`, returning every
  matching directory in requested-source order. The `input_dir` fallback
  and the rule against leaking another source's supplements are unchanged.
- Both exporter loaders iterate. `instruments_dir:` and `supporting_dir:`
  accept a String, an Array or nil, so the existing single-directory call
  style still works.
- **Collisions are first-wins and loud.** Directories arrive in source
  order, so first-wins means adding a repository can never silently
  re-point a row that is already published. A duplicate identifier emits a
  warning naming the kind, the identifier and the file. It is deliberately
  non-fatal: an unattended publish spans fifteen repositories, and losing
  the whole graph over one duplicated row is worse than publishing it with
  a warning. This also covers duplicates within a single file, which
  previously last-won in silence.
- The "first match wins" comment is gone, since it is no longer true.

## What this does and does not fix

It makes the CN corpus reachable. `data-cn/sources/supporting/` defines
`cn/ministry-of-commerce-announcement`, `cn/state-council-order` and
`cn/ministry-of-commerce` — exactly the values live CN entries and
instruments carry. Those slices populate once that vocabulary loads.

**The six UK slices stay empty, and not because of this bug.** UK entries
carry no `announcement` field at all, and `data-uk` ships no
`legal-instruments/`. The vocabulary that loads today belongs to the one
source with nothing to group — which is why *every* slice is empty rather
than merely most of them.

Sampled US, CH and JP entries also carry no announcements, so their
newly-loaded vocabularies will still yield slices empty of announcements.
And 811 of the 817 live instrument nodes are `eu` or `au`, whose repos
ship no supporting taxonomy at all, so no slice key exists for them.

That is a data gap in those repositories, not something this change can
reach. Worth deciding separately whether an empty slice should be written
at all.

## A correction to the diagnosis this started from

The reported cause was an identifier-namespace mismatch — bare
`"regulation"` against namespaced `"uk/regulation"`. That is wrong, and
the comparisons are left untouched. Verified against the live API:
`document-type/uk/regulation` carries `identifier: "uk/regulation"`, and
`legal-instrument/cn/mofcom-…` carries `type: "cn/state-council-order"`.
Both sides are already qualified, and loosening the comparison would have
crossed source boundaries — AU's bare `"regulation"` would have grouped
under UK's taxonomy.

## Test plan

- `bundle exec rake` — 1610 → **1616 examples, 0 failures, 4 pending**, exit 0.
- `bundle exec rubocop` — **427 files, no offenses**, exit 0.
- **Red proof:** a wiring spec drives the real `harmonize_all` path and
  captures the exporter's constructor arguments. Against unmodified main
  it fails with a value mismatch — one directory where two were requested:
  `expected: [".../data-us/sources/supporting", ".../data-cn/sources/supporting"]`,
  `got: ".../data-us/sources/supporting"`. 11 examples fail in total.
- Specs cover order sensitivity, repeated-source dedup, bare-String
  backward compatibility, and the collision warning.

## Not verified

The slice endpoints 404 in production — the deployed gem predates them —
so the empty-slice finding is inferred from the loaded vocabularies and
the exporter's grouping code, not read off a published artifact. Repo
contents were checked through the GitHub API rather than local clones,
and the announcement check sampled one entry per source.
