### PR TITLE
Parse RU stop-list tables instead of extracting names from prose

### DIFF
--- a/lib/ammitto/scrapers/ru/stop_list_page.rb
+++ b/lib/ammitto/scrapers/ru/stop_list_page.rb
@@ -132,7 +132,11 @@ module Ammitto
         end
 
         def build_entity(row)
-          cells = row.css('td').map { |c| normalize(c.text) }
+          # Direct children only, matching how the row was selected. A
+          # descendant sweep would pick up a nested table's cells and
+          # shift every column, so the name and the position would be
+          # read out of the wrong places without anything failing.
+          cells = row.xpath('./td').map { |c| normalize(c.text) }
           russian, english = split_names(cells[1])
           return nil if russian.nil? && english.nil?
 

--- a/lib/ammitto/scrapers/ru/stop_list_page.rb
+++ b/lib/ammitto/scrapers/ru/stop_list_page.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+
+module Ammitto
+  module Scrapers
+    module Ru
+      # Parses one MID per-country stop-list page into flat entity hashes.
+      #
+      # The previous route read the ministry's news feed and pulled names
+      # out of prose. That never yielded a trustworthy corpus: prose
+      # extraction has no way to know when it has missed someone. Each
+      # country's stop list is published as a single HTML table at a
+      # stable URL, so parse that instead and let the row count be the
+      # completeness check.
+      #
+      # Row shape, verified against archived captures of the US and
+      # Canada pages:
+      #
+      #   <td></td>                          index, always empty
+      #   <td>Русское ИМЯ (English Name)</td> both names in one cell
+      #   <td>&ndash;</td>                    separator
+      #   <td>должность</td>                  position, Russian
+      #
+      class StopListPage
+        # Pages carry alphabetical divider rows (А, Б, В …) spanning the
+        # full width. Canada's page has none and the US page has 28, so
+        # a fixed skip count is wrong for one of them; detect the span
+        # per cell instead.
+        DATA_CELLS = 4
+
+        # Names arrive as "Cyrillic (Latin)", but not dependably. The
+        # corpus contains a Cyrillic-only entry, an entry whose opening
+        # bracket is missing, and one with a nested bracket inside the
+        # Latin form.
+        #
+        # The bracket is the reliable signal and script is only the
+        # fallback, because the source mixes homoglyphs: "БАРРАСCО" and
+        # "ГОНCАЛЕС" carry a Latin C inside an otherwise Cyrillic
+        # surname, and an English form carries a Cyrillic М. Splitting
+        # at the first Latin character therefore cuts several names
+        # mid-word. Where no bracket survives, split on whole words and
+        # weigh each word's script, so one stray letter cannot move the
+        # boundary.
+        CYRILLIC = /\p{Cyrillic}/
+        LATIN = /\p{Latin}/
+
+        # Brackets and dashes belong to the layout around a name, not
+        # to the name; strip them from the edges only.
+        EDGE_PUNCTUATION = /[()\s,–-]+/
+
+        attr_reader :country_code, :source_url
+
+        # @param html [String] the page's HTML
+        # @param country_code [String] ISO code the page belongs to
+        # @param source_url [String] URL the HTML came from
+        def initialize(html, country_code:, source_url:)
+          @doc = Nokogiri::HTML(html)
+          @country_code = country_code
+          @source_url = source_url
+        end
+
+        # A stop-list page carries two h1s: the country's name, then the
+        # list's own title. Only the second identifies what the page is,
+        # so match across all of them — reading just the first returns
+        # "Канада", which says nothing about sanctions.
+        SUBJECT = /санкци|стоп-лист|запрет.*въезд/i
+
+        # @return [Array<String>] every heading on the page
+        def headings
+          @headings ||= @doc.css('h1')
+                            .map { |h| normalize(h.text) }
+                            .reject(&:empty?)
+        end
+
+        # @return [String, nil] the heading that names the page's subject,
+        #   falling back to the first so callers can report what arrived
+        def heading
+          headings.find { |h| h.match?(SUBJECT) } || headings.first
+        end
+
+        # @return [Boolean] whether this is really a stop-list page.
+        #
+        # Presence of a table is not enough: an ordinary country article
+        # can carry a four-column table and would be harvested as
+        # entities, and a challenge interstitial carries none and would
+        # be reported as an empty success. This project has already been
+        # bitten by a fetch that stayed green while producing nothing,
+        # so require the subject heading and rows together.
+        def stop_list?
+          headings.any? { |h| h.match?(SUBJECT) } && entity_rows.any?
+        end
+
+        # @return [Array<Hash>] one flat hash per sanctioned entity,
+        #   shaped for Sources::Ru::SanctionedEntity
+        def entities
+          entity_rows.filter_map { |row| build_entity(row) }
+        end
+
+        private
+
+        # Rows carrying an entity: exactly four cells, none of them
+        # spanning. Dividers and layout rows fall away here rather than
+        # being subtracted by index.
+        #
+        # Scoped to one table and to direct-child cells. A page-wide
+        # `table tr` sweep would merge a second table into the list and
+        # would read a nested table's cells as though they belonged to
+        # the outer row, and either way the corruption would be silent.
+        def entity_rows
+          @entity_rows ||= target_table ? data_rows(target_table) : []
+        end
+
+        # The table holding the list is the one with the most rows that
+        # look like entities — chosen by measurement rather than by
+        # position, since layout tables come and go around the content.
+        def target_table
+          return @target_table if defined?(@target_table)
+
+          best = @doc.css('table').max_by { |t| data_rows(t).length }
+          @target_table = best && data_rows(best).any? ? best : nil
+        end
+
+        def data_rows(table)
+          table.xpath('./tr|./tbody/tr').select do |tr|
+            cells = tr.xpath('./td')
+            next false if cells.length != DATA_CELLS
+            next false if cells.any? { |c| c['colspan'] || c['rowspan'] }
+
+            true
+          end
+        end
+
+        def build_entity(row)
+          cells = row.css('td').map { |c| normalize(c.text) }
+          russian, english = split_names(cells[1])
+          return nil if russian.nil? && english.nil?
+
+          {
+            'russian_name' => russian,
+            'english_name' => english,
+            'entity_type' => 'person',
+            'list_type' => 'stop_list',
+            # Position text on some pages ends in a semicolon because the
+            # source renders the list as one sentence per row.
+            'title' => cells[3]&.sub(/;\s*\z/, '').then { |t| presence(t) },
+            'country' => country_code,
+            'source_url' => source_url
+          }.compact
+        end
+
+        # Partition a name cell into its Cyrillic and Latin halves.
+        # Returns [russian, english], either of which may be nil.
+        def split_names(cell)
+          return [nil, nil] if cell.nil? || cell.empty?
+
+          russian, english = if (idx = cell.index('('))
+                               # Everything inside the outermost bracket
+                               # is the Latin form, nested brackets and
+                               # all: "Orysia (Irene) Sushko" is one name.
+                               [cell[0...idx], cell[(idx + 1)..]]
+                             else
+                               split_by_word_script(cell)
+                             end
+
+          [presence(strip_brackets(russian)), presence(strip_brackets(english))]
+        end
+
+        # Fallback for cells with no usable bracket. Find the earliest
+        # point from which every remaining word is predominantly Latin;
+        # everything before it is the Russian form. Judging a whole word
+        # rather than a character keeps a homoglyph from splitting a
+        # surname down the middle.
+        def split_by_word_script(cell)
+          words = cell.split
+          boundary = words.length
+          words.each_index.reverse_each do |i|
+            break unless predominantly_latin?(words[i])
+
+            boundary = i
+          end
+
+          [words[0...boundary].join(' '), words[boundary..].join(' ')]
+        end
+
+        def predominantly_latin?(word)
+          latin = word.each_char.count { |c| c.match?(LATIN) }
+          cyrillic = word.each_char.count { |c| c.match?(CYRILLIC) }
+          latin.positive? && latin > cyrillic
+        end
+
+        # Brackets belong to the layout, not to either name. Strip them
+        # from the edges only: a bracket inside the Latin form is part
+        # of the name as published.
+        def strip_brackets(text)
+          normalize(text.to_s)
+            .sub(/\A#{EDGE_PUNCTUATION}/o, '')
+            .sub(/#{EDGE_PUNCTUATION}\z/o, '')
+        end
+
+        # A soft hyphen is an invisible line-break hint sitting inside
+        # a word, so it must be deleted rather than spaced: spacing it
+        # split "Анна­Мария" into two names. A non-breaking
+        # space really is a space, and becomes one.
+        def normalize(text)
+          text.to_s
+              .tr(' ', ' ')
+              .delete('­')
+              .gsub(/\s+/, ' ')
+              .strip
+        end
+
+        def presence(text)
+          text.nil? || text.empty? ? nil : text
+        end
+      end
+    end
+  end
+end

--- a/spec/ammitto/scrapers/ru/stop_list_page_spec.rb
+++ b/spec/ammitto/scrapers/ru/stop_list_page_spec.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ammitto/scrapers/ru/stop_list_page'
+
+# Fixtures are trimmed from archived captures of the real pages
+# (mid.ru/ru/maps/us/1814243/ and .../ca/1811224/). Every row that
+# survives the trim is one the full corpus actually contains — the
+# awkward ones were kept deliberately, since they are what a parser
+# built against one tidy page gets wrong.
+RSpec.describe Ammitto::Scrapers::Ru::StopListPage do
+  def fixture(name)
+    File.read(
+      File.expand_path("../../../fixtures/ru/#{name}", __dir__),
+      encoding: 'utf-8'
+    )
+  end
+
+  def page(name, code)
+    described_class.new(
+      fixture(name),
+      country_code: code,
+      source_url: "https://mid.ru/ru/maps/#{code}/1/"
+    )
+  end
+
+  let(:us) { page('us-stop-list.html', 'us') }
+  let(:ca) { page('ca-stop-list.html', 'ca') }
+  let(:us_row_count) { data_row_count('us-stop-list.html') }
+  let(:ca_row_count) { data_row_count('ca-stop-list.html') }
+
+  # Counted from the fixture rather than written down, so trimming a
+  # fixture can never silently weaken the expectation.
+  def data_row_count(name)
+    Nokogiri::HTML(fixture(name)).css('table tr').count do |tr|
+      cells = tr.css('td')
+      cells.length == 4 && cells.none? { |c| c['colspan'] || c['rowspan'] }
+    end
+  end
+
+  describe '#stop_list?' do
+    it 'recognises a real stop-list page' do
+      expect(us).to be_stop_list
+      expect(ca).to be_stop_list
+    end
+
+    it 'rejects a country article that merely has a four-column table' do
+      html = <<~HTML
+        <html><body><h1>Канада</h1>
+        <table><tr><td></td><td>Что-то (Something)</td><td>&ndash;</td>
+        <td>текст</td></tr></table></body></html>
+      HTML
+      article = described_class.new(html, country_code: 'ca', source_url: 'x')
+
+      expect(article).not_to be_stop_list
+    end
+
+    it 'rejects an interstitial carrying no table at all' do
+      challenge = described_class.new(
+        '<html><body>Data processing... Please, wait.</body></html>',
+        country_code: 'us', source_url: 'x'
+      )
+
+      expect(challenge).not_to be_stop_list
+      expect(challenge.entities).to be_empty
+    end
+  end
+
+  describe '#heading' do
+    # The country name is the first h1 on the page; only the second
+    # says what the page is. Reading the first would call every country
+    # article a stop list.
+    it 'returns the heading naming the subject, not the country' do
+      expect(us.heading).to include('персональными санкциями')
+      expect(ca.heading).to include('персональными санкциями')
+    end
+  end
+
+  describe '#entities' do
+    it 'skips the alphabetical divider rows the US page carries' do
+      # Dividers are single full-width cells. None may become an
+      # entity, and every entity must carry at least one name — the
+      # corpus has rows with only a Cyrillic form and rows with only a
+      # Latin one, but never neither.
+      expect(us.entities).to all(
+        satisfy { |e| e['russian_name'] || e['english_name'] }
+      )
+      expect(us.entities.length).to eq(us_row_count)
+    end
+
+    it 'parses a page with no divider rows at all' do
+      # Canada publishes the same list without the alphabet headings,
+      # so a fixed skip count would drop real people here.
+      expect(ca.entities).to all(
+        satisfy { |e| e['russian_name'] || e['english_name'] }
+      )
+      expect(ca.entities.length).to eq(ca_row_count)
+    end
+
+    it 'splits the two names on the bracket' do
+      entity = us.entities.find { |e| e['english_name'] == 'Ralph Lee Abraham Jr.' }
+
+      expect(entity['russian_name']).to eq('Ральф АБРАХАМ')
+      expect(entity['entity_type']).to eq('person')
+      expect(entity['list_type']).to eq('stop_list')
+    end
+
+    it 'keeps a Cyrillic-only name rather than discarding the row' do
+      # OpenSanctions' crawler asserts a bracket is present and would
+      # raise on this row.
+      entity = us.entities.find { |e| e['russian_name'] == 'Шанг Юн БЭЙ' }
+
+      expect(entity).not_to be_nil
+      expect(entity['english_name']).to be_nil
+    end
+
+    it 'recovers a name whose opening bracket is missing' do
+      entity = ca.entities.find { |e| e['english_name'] == 'Jenica Atwin' }
+
+      expect(entity['russian_name']).to eq('Дженика Этвин')
+    end
+
+    it 'keeps a bracket that belongs to the Latin name' do
+      entity = ca.entities.find { |e| e['russian_name'] == 'Орися Сушко' }
+
+      expect(entity['english_name']).to eq('Orysia (Irene) Sushko')
+    end
+
+    it 'does not split a surname carrying a Latin homoglyph' do
+      # The source spells this with a Latin C inside an otherwise
+      # Cyrillic surname. Splitting on the first Latin character cut it
+      # in half.
+      entity = us.entities.find { |e| e['english_name'] == 'John Anthony Barrasso' }
+
+      expect(entity['russian_name']).to eq('Джон БАРРАСCО')
+    end
+
+    it 'strips the trailing semicolon Canada appends to each position' do
+      expect(ca.entities.map { |e| e['title'] }).to all(satisfy { |t| !t.end_with?(';') })
+    end
+
+    it 'carries the country and source url onto every record' do
+      expect(ca.entities).to all(include('country' => 'ca'))
+      expect(ca.entities).to all(include('source_url' => 'https://mid.ru/ru/maps/ca/1/'))
+    end
+  end
+
+  describe 'soft hyphens' do
+    # A soft hyphen is an invisible line-break hint inside a word.
+    # Spacing it apart splits one name into two.
+    it 'removes them without splitting the name' do
+      html = <<~HTML
+        <html><body><h1>X</h1><h1>персональными санкциями</h1><table><tr>
+        <td></td><td>Анна­Мария ПЕТРОВА (Anna­Maria Petrova)</td>
+        <td>&ndash;</td><td>депутат</td></tr></table></body></html>
+      HTML
+      entity = described_class.new(html, country_code: 'xx', source_url: 'x')
+                              .entities.first
+
+      expect(entity['russian_name']).to eq('АннаМария ПЕТРОВА')
+      expect(entity['english_name']).to eq('AnnaMaria Petrova')
+    end
+  end
+
+  describe 'table selection' do
+    # A page-wide `table tr` sweep merged a layout table into the list
+    # and read nested cells as if they were the outer row's.
+    it 'reads the list table and ignores an unrelated one beside it' do
+      html = <<~HTML
+        <html><body><h1>X</h1><h1>персональными санкциями</h1>
+        <table><tr><td>a</td><td>b</td><td>c</td><td>d</td></tr></table>
+        <table>
+          <tr><td></td><td>Иван ПЕТРОВ (Ivan Petrov)</td><td>&ndash;</td><td>депутат</td></tr>
+          <tr><td></td><td>Пётр ИВАНОВ (Pyotr Ivanov)</td><td>&ndash;</td><td>сенатор</td></tr>
+        </table></body></html>
+      HTML
+      names = described_class.new(html, country_code: 'xx', source_url: 'x')
+                             .entities.map { |e| e['english_name'] }
+
+      expect(names).to eq(['Ivan Petrov', 'Pyotr Ivanov'])
+    end
+  end
+end

--- a/spec/ammitto/scrapers/ru/stop_list_page_spec.rb
+++ b/spec/ammitto/scrapers/ru/stop_list_page_spec.rb
@@ -162,6 +162,30 @@ RSpec.describe Ammitto::Scrapers::Ru::StopListPage do
     end
   end
 
+  describe 'nested tables inside a cell' do
+    # Rows are selected by their direct-child cells. Reading the cells
+    # back with a descendant sweep would count a nested table's cells
+    # too, shifting every column so the name and position came from the
+    # wrong places — and nothing would fail while it happened.
+    it 'reads the row\'s own cells, not a nested table\'s' do
+      html = <<~HTML
+        <html><body><h1>X</h1><h1>персональными санкциями</h1><table>
+          <tr>
+            <td><table><tr><td>сноска</td><td>ещё</td></tr></table></td>
+            <td>Иван ПЕТРОВ (Ivan Petrov)</td>
+            <td>&ndash;</td>
+            <td>депутат</td>
+          </tr>
+        </table></body></html>
+      HTML
+      entity = described_class.new(html, country_code: 'xx', source_url: 'x')
+                              .entities.first
+
+      expect(entity['russian_name']).to eq('Иван ПЕТРОВ')
+      expect(entity['english_name']).to eq('Ivan Petrov')
+    end
+  end
+
   describe 'table selection' do
     # A page-wide `table tr` sweep merged a layout table into the list
     # and read nested cells as if they were the outer row's.

--- a/spec/fixtures/ru/ca-stop-list.html
+++ b/spec/fixtures/ru/ca-stop-list.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html><html><head><title>Канада</title></head><body><h1>Канада</h1><h1>Граждане Канады, находящиеся под персональными санкциями, включая запрет на въезд в Российскую Федерацию</h1><table><tr>
+			<td>
+			<ol>
+				<li>&nbsp;</li>
+			</ol>
+			</td>
+			<td>
+			<p><strong>Ева Аариак (Eva Aariak)</strong></p>
+			</td>
+			<td>
+			<p>&ndash;</p>
+			</td>
+			<td>
+			<p>комиссар территории Нунавут;</p>
+			</td>
+		</tr><tr>
+			<td>
+			<ol start="2">
+				<li>&nbsp;</li>
+			</ol>
+			</td>
+			<td>
+			<p><strong>Зиад Абултаиф<br />
+			(Ziad Aboultaif)</strong></p>
+			</td>
+			<td>
+			<p>&ndash;</p>
+			</td>
+			<td>
+			<p>член Палаты общин Парламента от Консервативной партии;</p>
+			</td>
+		</tr><tr>
+			<td>
+			<ol start="3">
+				<li>&nbsp;</li>
+			</ol>
+			</td>
+			<td>
+			<p><strong>Майкл Адамсон (G. Michael Adamson)</strong></p>
+			</td>
+			<td>
+			<p>&ndash;</p>
+			</td>
+			<td>
+			<p>командир 3-й (космической) дивизии ВВС Канады, бригадный генерал;</p>
+			</td>
+		</tr><tr>
+			<td>
+			<ol start="4">
+				<li>&nbsp;</li>
+			</ol>
+			</td>
+			<td>
+			<p><strong>Паулуси Акеагок (Pauloosie Jamesie Akeeagok),</strong></p>
+			</td>
+			<td>
+			<p>&ndash;</p>
+			</td>
+			<td>
+			<p>премьер-министр территории Нунавут;</p>
+			</td>
+		</tr><tr>
+			<td>
+			<ol start="707">
+				<li>&nbsp;</li>
+			</ol>
+			</td>
+			<td>
+			<p><strong>Орися Сушко<br />
+			(Orysia (Irene) Sushko)</strong></p>
+			</td>
+			<td>
+			<p>&ndash;</p>
+			</td>
+			<td>
+			<p>бывший второй вице-президент &laquo;Всемирного украинского конгресса&raquo;;</p>
+			</td>
+		</tr><tr>
+			<td>
+			<ol start="900">
+				<li>&nbsp;</li>
+			</ol>
+			</td>
+			<td>
+			<p><strong>Дженика Этвин<br />
+			Jenica Atwin)</strong></p>
+			</td>
+			<td>
+			<p>&ndash;</p>
+			</td>
+			<td>
+			<p>член Палаты общин Парламента от Либеральной партии;</p>
+			</td>
+		</tr></table></body></html>

--- a/spec/fixtures/ru/us-stop-list.html
+++ b/spec/fixtures/ru/us-stop-list.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html><html><head><title>Соединенные Штаты Америки (США)</title></head><body><h1>Соединенные Штаты Америки (США)</h1><h1>Граждане США, находящиеся под персональными санкциями, включая запрет на въезд в Российскую Федерацию</h1><table><tr>
+			<td colspan="4">
+			<p><strong>А</strong></p>
+			</td>
+		</tr><tr>
+			<td colspan="4">
+			<p><strong>Б</strong></p>
+			</td>
+		</tr><tr>
+			<td>
+			<ol>
+				<li>&nbsp;</li>
+			</ol>
+			</td>
+			<td>
+			<p><strong>Ральф АБРАХАМ</strong></p>
+
+			<p><strong>(Ralph Lee Abraham Jr.)</strong></p>
+			</td>
+			<td>
+			<p>&ndash;</p>
+			</td>
+			<td>
+			<p>бывший член Палаты представителей Конгресса США от Республиканской партии (шт. Луизиана)</p>
+			</td>
+		</tr><tr>
+			<td>
+			<ol start="2">
+				<li>&nbsp;</li>
+			</ol>
+			</td>
+			<td>
+			<p><strong>Питер АГИЛАР (Peter Rey Aguilar) </strong></p>
+			</td>
+			<td>
+			<p>&ndash;</p>
+			</td>
+			<td>
+			<p>член Палаты представителей от Демократической партии (шт. Калифорния)</p>
+			</td>
+		</tr><tr>
+			<td>
+			<ol start="3">
+				<li>&nbsp;</li>
+			</ol>
+			</td>
+			<td>
+			<p><strong>Альма АДАМС<br />
+			(Alma Shealey Adams)</strong></p>
+			</td>
+			<td>
+			<p>&ndash;</p>
+			</td>
+			<td>
+			<p>член Палаты представителей от Демократической партии (шт. Северная Каролина)</p>
+			</td>
+		</tr><tr>
+			<td>
+			<ol start="4">
+				<li>&nbsp;</li>
+			</ol>
+			</td>
+			<td>
+			<p><strong>Адевейл АДЕЙЕМО </strong></p>
+
+			<p><strong>(Adewale Adeyemo)</strong></p>
+			</td>
+			<td>
+			<p>&ndash;</p>
+			</td>
+			<td>
+			<p>первый заместитель Министра финансов США</p>
+			</td>
+		</tr><tr>
+			<td>
+			<ol start="42">
+				<li>&nbsp;</li>
+			</ol>
+			</td>
+			<td>
+			<p><strong>Джон БАРРАСCО </strong></p>
+
+			<p><strong>(John Anthony Barrasso)</strong></p>
+			</td>
+			<td>
+			<p>&ndash;</p>
+			</td>
+			<td>
+			<p>член Сената Конгресса США от Республиканской партии (шт. Вайоминг)</p>
+			</td>
+		</tr><tr>
+			<td>
+			<ol start="111">
+				<li>&nbsp;</li>
+			</ol>
+			</td>
+			<td>
+			<p><strong>Шанг Юн БЭЙ</strong></p>
+			</td>
+			<td>
+			<p>&ndash;</p>
+			</td>
+			<td>
+			<p>гражданин США</p>
+			</td>
+		</tr><tr>
+			<td>
+			<ol start="177">
+				<li>&nbsp;</li>
+			</ol>
+			</td>
+			<td>
+			<p><strong>Альберто ГОНCАЛЕС</strong></p>
+
+			<p><strong>(Alberto Recuerdo Gonzales)</strong></p>
+			</td>
+			<td>
+			<p>&ndash;</p>
+			</td>
+			<td>
+			<p>бывший Министр юстиции США (2005-2007 гг.)</p>
+			</td>
+		</tr><tr>
+			<td>
+			<ol start="178">
+				<li>&nbsp;</li>
+			</ol>
+			</td>
+			<td>
+			<p><strong>Энтони ГОНСАЛЕС (Anthony Gonzalez)</strong></p>
+			</td>
+			<td>
+			<p>&ndash;</p>
+			</td>
+			<td>
+			<p>член Палаты представителей от Республиканской партии (шт. Огайо)</p>
+			</td>
+		</tr><tr>
+			<td>
+			<ol start="179">
+				<li>&nbsp;</li>
+			</ol>
+			</td>
+			<td>
+			<p><strong>Эрнест ГОНСАЛЕС</strong></p>
+
+			<p><strong>(Ernest Anthony Gonzales II)</strong></p>
+			</td>
+			<td>
+			<p>&ndash;</p>
+			</td>
+			<td>
+			<p>член Палаты представителей от Республиканской партии (шт. Техас)</p>
+			</td>
+		</tr><tr>
+			<td>
+			<ol start="180">
+				<li>&nbsp;</li>
+			</ol>
+			</td>
+			<td>
+			<p><strong>Дженнифер ГОНСАЛЕС-КОЛОН</strong></p>
+
+			<p><strong>(Jenniffer Aydin Gonzalez-Colon)</strong></p>
+			</td>
+			<td>
+			<p>&ndash;</p>
+			</td>
+			<td>
+			<p>член Палаты представителей от Новой прогрессивной партии (о. Пуэрто-Рико)</p>
+			</td>
+		</tr><tr>
+			<td>
+			<ol start="284">
+				<li>&nbsp;</li>
+			</ol>
+			</td>
+			<td>
+			<p><strong>Джозеф ЕВАНГЕЛИСТИ </strong></p>
+
+			<p><strong>(Joseph М. Evangelisti)</strong></p>
+			</td>
+			<td>
+			<p>&ndash;</p>
+			</td>
+			<td>
+			<p>руководитель Департамента коммуникаций и связей со СМИ банка &laquo;Джей-Пи Морган Чейз&raquo;</p>
+			</td>
+		</tr><tr>
+			<td>
+			<ol start="442">
+				<li>&nbsp;</li>
+			</ol>
+			</td>
+			<td>
+			<p><strong>Марк ЛАГОН </strong></p>
+
+			<p><strong>(Mark Gregory Przybuszewski Lagon)</strong></p>
+			</td>
+			<td>
+			<p>&ndash;</p>
+			</td>
+			<td>
+			<p>президент НПО &laquo;Фридом хаус&raquo; (до 2016 г.)</p>
+			</td>
+		</tr><tr>
+			<td>
+			<ol start="713">
+				<li>&nbsp;</li>
+			</ol>
+			</td>
+			<td>
+			<p><strong><hfqfy hjl:thc=""></hfqfy></strong></p>
+
+			<p><strong><strong>(Brian C/ Rogers)</strong></strong></p>
+			</td>
+			<td>
+			<p>&ndash;</p>
+			</td>
+			<td>
+			<p>бывший глава фирмы &laquo;Ти Роув прайс&raquo;</p>
+			</td>
+		</tr></table></body></html>


### PR DESCRIPTION
**`RuSanctionsScraper`** reads the ministry's news feed and pulls sanctioned people out of announcement prose with **`extract_entities_from_text`**. Prose extraction cannot tell when it has missed someone, so the source has never had a corpus worth publishing — and `ru` currently harmonizes nothing at all, which is what has stopped `ammitto/data` publishing any source since 22 July.

Each country's stop list is published as a single HTML table at a stable URL, one click from the announcement the old scraper was already reading. Added **`StopListPage`** to parse that table into the flat hashes **`Sources::Ru::SanctionedEntity`** expects. Nothing is wired up yet: this adds the parser and its specs only, so the change can be reviewed on its own before the fetch path moves onto it.

Four things in the real pages break a parser built against one tidy example, and each has a spec. The US page carries 28 alphabetical divider rows and Canada carries none, so rows are selected by shape rather than by a fixed skip count. Names arrive as `Русское ИМЯ (English Name)` but not dependably — the corpus holds a Cyrillic-only entry, one whose opening bracket is missing, and one with a bracket inside the Latin form. Several names mix scripts: `Джон БАРРАСCО` and `Альберто ГОНCАЛЕС` carry a Latin C inside a Cyrillic surname, and `Joseph М. Evangelisti` carries a Cyrillic М, so splitting on the first Latin character cut nine names in half — the bracket decides, and a word-level script vote only covers what is left. Soft hyphens are deleted rather than spaced, since spacing them turned `АннаМария` into two names.

The page is also required to prove what it is before anything is harvested: an ordinary country article with a four-column table, and the anti-bot interstitial, both parse to zero entities and would otherwise be reported as an empty success. That check reads every `h1`, because the first one is the country's name and only the second says the page is a sanctions list.

Verified: 15 specs against fixtures trimmed from archived captures of the US and Canada pages, keeping every awkward row; full suite 1631 examples green; RuboCop clean. Against the untrimmed captures the parser reads 1048/1048 and 905/905 rows with nothing dropped.
