### PR TITLE
Publish a catalogue so the API's artefacts can be found

### DIFF
--- a/lib/ammitto/cli/harmonize_command.rb
+++ b/lib/ammitto/cli/harmonize_command.rb
@@ -142,6 +142,12 @@ module Ammitto
 
           puts 'Exporting ontology data...' if options[:verbose]
           @ontology_exporter.export(output_dir)
+
+          # Last, so the catalogue can see the search index and the
+          # ontology files above as well as everything the graph
+          # exporter wrote. It lists only what is on disk, so anything
+          # a failing source did not produce is simply absent.
+          @exporter.export_manifest
         end
 
         print_summary(results)

--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -461,6 +461,20 @@ module Ammitto
         end
       end
 
+      # Whether a directory holds anything a consumer could fetch: its
+      # own index, a file, or a subdirectory that does.
+      def published?(dir)
+        return true if File.exist?(File.join(dir, 'index.jsonld'))
+
+        files = Dir.glob(File.join(dir, '*.{jsonld,json}'))
+                   .reject { |f| File.basename(f).start_with?('index.') }
+        return true if files.any?
+
+        Dir.glob(File.join(dir, '*'))
+           .select { |f| File.directory?(f) }
+           .any? { |sub| published?(sub) }
+      end
+
       # Directory-shaped artefacts. Each reports its own index where one
       # exists, so a consumer follows one link rather than guessing the
       # members.
@@ -490,8 +504,14 @@ module Ammitto
           # node/entry, each with its own index. Judging a collection by
           # its direct files alone dropped the entire node API from the
           # catalogue while still listing it as something we publish.
+          #
+          # A subdirectory only counts when something was written into
+          # it. `create_directories` makes node/list unconditionally and
+          # nothing ever writes there — list nodes go to
+          # node/entry/<source>/<list_type> — so listing every directory
+          # would advertise an empty one.
           nested = Dir.glob(File.join(dir, '*'))
-                      .select { |f| File.directory?(f) }
+                      .select { |f| File.directory?(f) && published?(f) }
                       .map { |f| File.basename(f) }
                       .sort
           index = File.exist?(File.join(dir, 'index.jsonld'))

--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -414,8 +414,15 @@ module Ammitto
       # them: the full dataset, its Turtle rendering, the ontology, the
       # facets and all but one source aggregate could only be found by
       # guessing a path. This is the entry point that makes them
-      # discoverable, and the slice families already follow the same
-      # `Index` shape.
+      # discoverable.
+      #
+      # It shares `@type: "Index"` and the `entries` key with the slice
+      # documents, and nothing more: a slice's entries are `{"@id": ...}`
+      # node references, while these carry a name, a media type and a
+      # byte size, and the slice MASTERS use `available` rather than
+      # `entries` at all. Said plainly because a near-miss is worse than
+      # a fresh shape — a consumer written against a slice half-reads
+      # this and then fails on the payload.
       #
       # Entries are emitted only for files that exist on disk once the
       # rest of the export has run, so the catalogue cannot advertise

--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -486,11 +486,21 @@ module Ammitto
                        .map { |f| File.basename(f) }
                        .reject { |f| f.start_with?('index.') }
                        .sort
-          next if members.empty? && !File.exist?(File.join(dir, 'index.jsonld'))
+          # node/ holds no files of its own, only node/entity and
+          # node/entry, each with its own index. Judging a collection by
+          # its direct files alone dropped the entire node API from the
+          # catalogue while still listing it as something we publish.
+          nested = Dir.glob(File.join(dir, '*'))
+                      .select { |f| File.directory?(f) }
+                      .map { |f| File.basename(f) }
+                      .sort
+          index = File.exist?(File.join(dir, 'index.jsonld'))
+          next if members.empty? && nested.empty? && !index
 
           entry = { 'name' => name, 'url' => name, 'description' => description }
-          entry['index'] = "#{name}/index.jsonld" if File.exist?(File.join(dir, 'index.jsonld'))
+          entry['index'] = "#{name}/index.jsonld" if index
           entry['members'] = members unless members.empty?
+          entry['collections'] = nested unless nested.empty?
           entry
         end
       end

--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -403,6 +403,98 @@ module Ammitto
         extract_instruments(entry, source_code)
       end
 
+      # Catalogue of everything this run published, at api/v1/index.jsonld
+      #
+      # Deliberately NOT part of #export: the search index and the
+      # ontology are written by the caller afterwards, so a catalogue
+      # built during #export would omit them. The caller invokes this
+      # last, once nothing further will be written.
+      #
+      # Every artefact was already reachable by URL, but nothing listed
+      # them: the full dataset, its Turtle rendering, the ontology, the
+      # facets and all but one source aggregate could only be found by
+      # guessing a path. This is the entry point that makes them
+      # discoverable, and the slice families already follow the same
+      # `Index` shape.
+      #
+      # Entries are emitted only for files that exist on disk once the
+      # rest of the export has run, so the catalogue cannot advertise
+      # something that was never written. A source that failed its gate
+      # is absent here rather than listed and 404ing.
+      # @return [void]
+      def export_manifest
+        entries = manifest_datasets + manifest_collections
+
+        write_json(
+          File.join(@output_dir, 'index.jsonld'),
+          {
+            '@context' => @context_url,
+            '@type' => 'Index',
+            'slice' => 'catalogue',
+            'generated' => @stats[:generated_at],
+            'entries' => entries
+          }
+        )
+      end
+
+      # Single-file artefacts, each described so a consumer can choose
+      # without downloading: all.ttl alone is over a hundred megabytes.
+      # @return [Array<Hash>] present files only
+      def manifest_datasets
+        [
+          ['all.jsonld', 'application/ld+json', 'Every node in one graph'],
+          ['all.ttl', 'text/turtle', 'The same graph as Turtle'],
+          ['search-index.json', 'application/json', 'Flattened records for search'],
+          ['stats.json', 'application/json', 'Entity and entry counts per source'],
+          ['context.jsonld', 'application/ld+json', 'JSON-LD context for every node']
+        ].filter_map do |name, media_type, description|
+          path = File.join(@output_dir, name)
+          next unless File.exist?(path)
+
+          {
+            'name' => name,
+            'url' => name,
+            'mediaType' => media_type,
+            'description' => description,
+            'bytes' => File.size(path)
+          }
+        end
+      end
+
+      # Directory-shaped artefacts. Each reports its own index where one
+      # exists, so a consumer follows one link rather than guessing the
+      # members.
+      # @return [Array<Hash>] present directories only
+      def manifest_collections
+        [
+          ['sources', 'One aggregate per source'],
+          ['facets', 'Value lists for filtering'],
+          ['ontology', 'Classes, properties and hierarchy'],
+          ['node', 'Individual entity and entry nodes'],
+          ['by-authority', 'Entries grouped by authority'],
+          ['by-regime', 'Entries grouped by regime'],
+          ['by-type', 'Entries grouped by entity type'],
+          ['by-status', 'Entries grouped by status'],
+          ['by-list', 'Entries grouped by list'],
+          ['by-organization', 'Documents grouped by organization'],
+          ['by-document-type', 'Documents grouped by document type']
+        ].filter_map do |name, description|
+          dir = File.join(@output_dir, name)
+          next unless Dir.exist?(dir)
+
+          members = Dir.glob(File.join(dir, '*.{jsonld,json}'))
+                       .map { |f| File.basename(f) }
+                       .reject { |f| f.start_with?('index.') }
+                       .sort
+          next if members.empty? && !File.exist?(File.join(dir, 'index.jsonld'))
+
+          entry = { 'name' => name, 'url' => name, 'description' => description }
+          entry['index'] = "#{name}/index.jsonld" if File.exist?(File.join(dir, 'index.jsonld'))
+          entry['members'] = members unless members.empty?
+          entry
+        end
+      end
+
       # Export all nodes to files
       # @return [void]
       def export

--- a/spec/ammitto/serialization/json_ld_graph_exporter_manifest_spec.rb
+++ b/spec/ammitto/serialization/json_ld_graph_exporter_manifest_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+require 'json'
+require 'tmpdir'
+require 'ammitto/serialization/json_ld_graph_exporter'
+
+# The catalogue's whole value is that a consumer can trust it. A listing
+# that names a file which was never written is worse than no listing,
+# because it turns a guessable 404 into a documented one.
+RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @output_dir = dir
+      example.run
+    end
+  end
+
+  attr_reader :output_dir
+
+  let(:exporter) do
+    described_class.new(output_dir: output_dir, combine: combine)
+  end
+  let(:combine) { true }
+
+  def manifest
+    JSON.parse(File.read(File.join(output_dir, 'index.jsonld')))
+  end
+
+  def named(name)
+    manifest['entries'].find { |e| e['name'] == name }
+  end
+
+  def add_entry(ref, source: :eu)
+    entity = {
+      '@id' => "https://www.ammitto.org/entity/#{source}/#{ref}",
+      '@type' => 'PersonEntity',
+      'names' => [{ 'fullName' => "Person #{ref}" }]
+    }
+    entry = {
+      '@id' => "https://www.ammitto.org/entry/#{source}/#{ref}",
+      '@type' => 'SanctionEntry',
+      'referenceNumber' => ref
+    }
+    exporter.add_node(entity: entity, entry: entry, source: source)
+  end
+
+  # Mirrors the CLI's order: the graph exporter runs, then the caller
+  # writes the per-source aggregates, the search index and the ontology,
+  # and only then is the catalogue built. Building it earlier would omit
+  # the three artefacts written last.
+  before do
+    add_entry('E-1')
+    exporter.export
+    FileUtils.mkdir_p(File.join(output_dir, 'sources'))
+    File.write(File.join(output_dir, 'sources', 'eu.jsonld'), '{}')
+    File.write(File.join(output_dir, 'search-index.json'), '[]')
+    exporter.export_manifest
+  end
+
+  it 'writes a catalogue at the root of the published tree' do
+    expect(File.exist?(File.join(output_dir, 'index.jsonld'))).to be(true)
+    expect(manifest['@type']).to eq('Index')
+    expect(manifest['slice']).to eq('catalogue')
+  end
+
+  it 'names the full dataset in both serialisations' do
+    expect(named('all.jsonld')).to include('mediaType' => 'application/ld+json')
+    expect(named('all.ttl')).to include('mediaType' => 'text/turtle')
+  end
+
+  it 'reports each dataset size, since one of them is very large' do
+    # all.ttl is over 100 MB in production. A consumer choosing between
+    # serialisations should not have to start the download to find out.
+    sizes = manifest['entries'].filter_map { |e| e['bytes'] }
+    expect(sizes).to all(be > 0)
+    expect(named('all.jsonld')['bytes']).to eq(
+      File.size(File.join(output_dir, 'all.jsonld'))
+    )
+  end
+
+  it 'lists the per-source aggregates that were written' do
+    sources = named('sources')
+
+    expect(sources['members']).to include('eu.jsonld')
+  end
+
+  it 'points a collection at its own index where one exists' do
+    expect(named('by-authority')['index']).to eq('by-authority/index.jsonld')
+  end
+
+  # The failure this guards against: a source that fails its health gate
+  # produces no aggregate, and a hardcoded catalogue would still name it.
+  it 'never names a file that was not written' do
+    urls = manifest['entries'].map { |e| e['url'] }
+    urls.reject { |u| Dir.exist?(File.join(output_dir, u)) }.each do |u|
+      expect(File.exist?(File.join(output_dir, u))).to be(true), "catalogued #{u}, which does not exist"
+    end
+
+    member_paths = manifest['entries'].flat_map do |e|
+      (e['members'] || []).map { |m| File.join(e['url'], m) }
+    end
+
+    member_paths.each do |rel|
+      expect(File.exist?(File.join(output_dir, rel))).to be(true), "catalogued #{rel}, which does not exist"
+    end
+  end
+
+  it 'omits the aggregated files when they were not produced' do
+    # `--combine` is optional; without it there is no all.jsonld to name.
+    other = Dir.mktmpdir
+    exp = described_class.new(output_dir: other, combine: false)
+    exp.add_node(
+      entity: { '@id' => 'https://www.ammitto.org/entity/eu/E-2',
+                '@type' => 'PersonEntity',
+                'names' => [{ 'fullName' => 'Person E-2' }] },
+      entry: { '@id' => 'https://www.ammitto.org/entry/eu/E-2',
+               '@type' => 'SanctionEntry' },
+      source: :eu
+    )
+    exp.export
+    exp.export_manifest
+
+    names = JSON.parse(File.read(File.join(other, 'index.jsonld')))['entries']
+                .map { |e| e['name'] }
+
+    expect(names).not_to include('all.jsonld')
+    expect(names).not_to include('all.ttl')
+  ensure
+    FileUtils.remove_entry(other) if other
+  end
+end

--- a/spec/ammitto/serialization/json_ld_graph_exporter_manifest_spec.rb
+++ b/spec/ammitto/serialization/json_ld_graph_exporter_manifest_spec.rb
@@ -71,8 +71,10 @@ RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
   end
 
   it 'reports each dataset size, since one of them is very large' do
-    # all.ttl is over 100 MB in production. A consumer choosing between
-    # serialisations should not have to start the download to find out.
+    # The two serialisations of the same graph differ by an order of
+    # magnitude on the wire, because the host compresses one and not the
+    # other. A consumer choosing between them should not have to start
+    # the download to find that out.
     sizes = manifest['entries'].filter_map { |e| e['bytes'] }
     expect(sizes).to all(be > 0)
     expect(named('all.jsonld')['bytes']).to eq(

--- a/spec/ammitto/serialization/json_ld_graph_exporter_manifest_spec.rb
+++ b/spec/ammitto/serialization/json_ld_graph_exporter_manifest_spec.rb
@@ -88,6 +88,16 @@ RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
     expect(sources['members']).to include('eu.jsonld')
   end
 
+  # node/ has no files of its own: only node/entity and node/entry, each
+  # with its own index. Judging a collection by its direct files alone
+  # dropped the whole node API from the catalogue.
+  it 'lists a collection whose content is entirely in subdirectories' do
+    node = named('node')
+
+    expect(node).not_to be_nil, 'node/ must appear in the catalogue'
+    expect(node['collections']).to include('entity', 'entry')
+  end
+
   it 'points a collection at its own index where one exists' do
     expect(named('by-authority')['index']).to eq('by-authority/index.jsonld')
   end
@@ -101,7 +111,8 @@ RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
     end
 
     member_paths = manifest['entries'].flat_map do |e|
-      (e['members'] || []).map { |m| File.join(e['url'], m) }
+      (e['members'] || []).map { |m| File.join(e['url'], m) } +
+        (e['collections'] || []).map { |c| File.join(e['url'], c) }
     end
 
     member_paths.each do |rel|

--- a/spec/ammitto/serialization/json_ld_graph_exporter_manifest_spec.rb
+++ b/spec/ammitto/serialization/json_ld_graph_exporter_manifest_spec.rb
@@ -98,6 +98,16 @@ RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
     expect(node['collections']).to include('entity', 'entry')
   end
 
+  # `create_directories` makes node/list unconditionally and nothing ever
+  # writes there: list nodes go to node/entry/<source>/<list_type>. The
+  # catalogue must not name it, or it advertises a directory a consumer
+  # cannot fetch anything from.
+  it 'omits a subdirectory nothing was written into' do
+    expect(Dir.exist?(File.join(output_dir, 'node', 'list'))).to be(true)
+
+    expect(named('node')['collections']).not_to include('list')
+  end
+
   it 'points a collection at its own index where one exists' do
     expect(named('by-authority')['index']).to eq('by-authority/index.jsonld')
   end

--- a/spec/integration/harmonize_pipeline_spec.rb
+++ b/spec/integration/harmonize_pipeline_spec.rb
@@ -100,6 +100,11 @@ RSpec.describe 'harmonize pipeline (integration)' do
     expect(named['search-index.json']['bytes'])
       .to eq(File.size(File.join(api, 'search-index.json')))
     expect(named['sources']['members']).to include('eu.jsonld')
+    # One artefact from each of the two exporters that run after the
+    # graph exporter, because "late enough" is two orderings, not one.
+    # Asserting only the search index leaves a catalogue written
+    # between the two green while cataloguing no ontology at all.
+    expect(named['ontology']['members']).to include('classes.jsonld')
     # Every catalogued path resolves to something that exists.
     named.each_value do |entry|
       next unless entry['name']

--- a/spec/integration/harmonize_pipeline_spec.rb
+++ b/spec/integration/harmonize_pipeline_spec.rb
@@ -82,6 +82,33 @@ RSpec.describe 'harmonize pipeline (integration)' do
   # YAML, the entity node, the search index, and the context artifact
   # that types the two new keys. Checking the models alone would prove
   # only that the fields exist, not that they are published.
+  # The manifest spec drives the exporter directly, so it cannot see
+  # whether the CLI still calls export_manifest, or whether it runs late
+  # enough to catalogue what the search indexer and ontology exporter
+  # wrote. Deleting the call site leaves that spec green; this one goes
+  # red, and the sizes are compared against the files on disk rather than
+  # against the numbers the manifest reports about itself.
+  it 'catalogues what the run wrote, after the run wrote it' do
+    write_eu_fixture(@workdir)
+    run_harmonize(['eu'], @workdir)
+    api = File.join(@workdir, 'api', 'v1')
+
+    manifest = JSON.parse(File.read(File.join(api, 'index.jsonld')))
+    named = manifest.fetch('entries').to_h { |e| [e['name'], e] }
+
+    expect(named).to include('search-index.json', 'stats.json', 'sources')
+    expect(named['search-index.json']['bytes'])
+      .to eq(File.size(File.join(api, 'search-index.json')))
+    expect(named['sources']['members']).to include('eu.jsonld')
+    # Every catalogued path resolves to something that exists.
+    named.each_value do |entry|
+      next unless entry['name']
+
+      expect(File.exist?(File.join(api, entry['name'])))
+        .to be(true), "catalogued #{entry['name']} is not on disk"
+    end
+  end
+
   it 'publishes a stated span of birth years end to end' do
     processed = File.join(@workdir, 'data-eu', 'processed')
     FileUtils.mkdir_p(processed)


### PR DESCRIPTION
Everything the API publishes is reachable, and almost none of it is findable. `all.jsonld`, `all.ttl`, the ontology, the context, the facets and twelve of the thirteen source aggregates can only be reached by guessing a path: there is no index at the root, GitHub Pages serves no directory listings, and the API documentation page names exactly two endpoints, `sources/eu.jsonld` and `stats.json`.

Added **`export_manifest`**, which writes `api/v1/index.jsonld` cataloguing what the run produced: the single-file datasets with their media type and byte size, and each collection with its own index and members. It shares `@type: "Index"` and the `entries` key with the slice documents and nothing more, which the code now says in as many words: a slice's entries are `{"@id": …}` node references, these carry a name, a media type and a byte size, and the slice masters use `available` rather than `entries` at all. A near-miss is worse than a fresh shape, because a consumer written against a slice half-reads this and then fails on the payload.

Entries come from `File.exist?` and `Dir.exist?` at write time rather than from a list of what ought to be there, so the catalogue cannot name a file that was never written. A source that fails its health gate produces no aggregate and is simply absent, rather than documented and 404ing.

Sizes are reported because the two serialisations of the same graph do not cost the same to fetch, and nothing says so. Measured live on 2026-08-18 with `Accept-Encoding: gzip`:

| file | wire bytes | time | `content-encoding` |
|---|---|---|---|
| `all.jsonld` | 7,928,351 | 23.8s | gzip |
| `all.ttl` | 115,166,876 | 42.4s | none |

GitHub Pages does not compress `text/turtle`, so the RDF rendering transfers fourteen times the JSON-LD one for the same content. A consumer choosing between them should not have to start the download to discover that.

The manifest reports the size on disk rather than the transferred size, since the producer cannot know how a host will serve it. That is still the number that distinguishes these two.

The catalogue is **not** part of **`export`**. The search index and the ontology are written by the caller afterwards, so a manifest built during `export` would omit both. `harmonize` now calls it last, once nothing further will be written.

## Test plan

Seven specs, mirroring the CLI's ordering so the catalogue sees the artefacts written after the graph exporter runs. They cover the root catalogue, both serialisations of the full dataset, the reported sizes, per-source aggregates, a collection linking to its own index, and the aggregated files being omitted when `--combine` is off.

The load-bearing one asserts every catalogued path exists on disk, including collection members.

Mutants, each confirmed applied before running: removing the `File.exist?` guard so absent files are listed, and reporting zero bytes. Both turn the suite red.

Two things a review round changed, both worth naming.

The branch carried **748 lines of the RU stop-list scraper** — four files with nothing to do with a catalogue, left over from work that was dropped. Rebuilt from `main` with the four manifest commits alone: 318 lines across four files, all of them this feature.

And the spec drove `export_manifest` directly, so it could not see whether the CLI still calls it, or calls it late enough to catalogue what the search indexer and ontology exporter wrote. Deleting the call site left it green — verified, not assumed. `spec/integration/harmonize_pipeline_spec.rb` now runs a real harmonize and checks the catalogue against the files on disk: every entry resolves, and `search-index.json`'s recorded size is compared with `File.size` rather than with the manifest's own claim. Deleting the call site now fails that example.

A later round found the integration example still half-proving its own claim: it asserted `search-index.json` but nothing the ontology exporter writes, so a catalogue built between the two exporters stayed green. It now also asserts `ontology`'s members include `classes.jsonld` — one artefact from each of the two exporters that run after the graph exporter. Moving `export_manifest` above the ontology export fails it.

Full suite 1,701 examples green, RuboCop clean over 434 files.

## Not addressed

`sources/`, `facets/`, `ontology/` and `node/` still have no index of their own; the catalogue lists their members directly instead. Giving them the same `index.jsonld` the slice families have would be consistent, but it changes those directories' published contents rather than adding to the root, so it belongs in its own change.

---

Reviewed by Codex, not by Copilot: every Copilot request since 2026-08-18 15:20 returns "the user who requested the review has reached their quota limit", as a submitted review with zero comments. Recorded here so the review provenance is not assumed from the absence of comments.
