### PR TITLE
Sanitize regime IRIs so the published RDF parses

### DIFF
--- a/lib/ammitto/serialization/json_ld_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_exporter.rb
@@ -10,6 +10,7 @@
 #   entity_jsonld = exporter.export_entity(entity_id)
 
 require_relative '../ontology/json_ld_context'
+require_relative '../utils/iri_sanitizer'
 
 module Ammitto
   module Serialization
@@ -141,7 +142,7 @@ module Ammitto
         # Regime reference
         if entry_data['regime_code']
           doc['regime'] = {
-            '@id' => "https://www.ammitto.org/regime/#{entry_data['regime_code']}"
+            '@id' => Ammitto::Utils::IriSanitizer.regime_iri(entry_data['regime_code'])
           }
         end
 

--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -520,7 +520,7 @@ module Ammitto
         # path and the IRI from disagreeing again. It also merges codes
         # differing only in trailing whitespace: "ca_moldova" and
         # "ca_moldova " were one regime published as two nodes.
-        slug = Ammitto::Utils::IriSanitizer.sanitize(code_lower)
+        slug = Ammitto::Utils::IriSanitizer.regime_slug(code_lower)
         regime_id = Ammitto::Utils::IriSanitizer.regime_iri(code_lower)
 
         # Store full regime if not already present

--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'digest'
+require_relative '../utils/iri_sanitizer'
 require 'fileutils'
 require 'json'
 require 'time'
@@ -511,10 +512,19 @@ module Ammitto
         return unless code
 
         code_lower = code.to_s.downcase
-        regime_id = "#{BASE_URI}/regime/#{code_lower}"
+        # Keyed by the slug, not the raw code. The key becomes a node
+        # filename, and Canada publishes bilingual codes: "CA_China /
+        # Chine" wrote node/regime/"ca_china "/chine.jsonld while the
+        # node advertised .../regime/ca_china-chine, so it 404d at its
+        # own @id. Slugging both from one function is what keeps the
+        # path and the IRI from disagreeing again. It also merges codes
+        # differing only in trailing whitespace: "ca_moldova" and
+        # "ca_moldova " were one regime published as two nodes.
+        slug = Ammitto::Utils::IriSanitizer.sanitize(code_lower)
+        regime_id = Ammitto::Utils::IriSanitizer.regime_iri(code_lower)
 
         # Store full regime if not already present
-        @regimes[code_lower] ||= {
+        @regimes[slug] ||= {
           '@context' => @context_url,
           '@id' => regime_id,
           '@type' => 'SanctionRegime',
@@ -994,7 +1004,7 @@ module Ammitto
         regime_index = {
           '@context' => @context_url,
           '@type' => 'Index',
-          'nodes' => @regimes.keys.sort.map { |code| { '@id' => "#{BASE_URI}/regime/#{code}" } }
+          'nodes' => @regimes.keys.sort.map { |code| { '@id' => Ammitto::Utils::IriSanitizer.regime_iri(code) } }
         }
         write_json(File.join(@output_dir, 'node', 'regime', 'index.jsonld'), regime_index)
 
@@ -1151,7 +1161,7 @@ module Ammitto
             '@context' => @context_url,
             '@type' => 'Index',
             'slice' => 'by-regime',
-            'regime' => { '@id' => "#{BASE_URI}/regime/#{code}" },
+            'regime' => { '@id' => Ammitto::Utils::IriSanitizer.regime_iri(code) },
             'entries' => entries
           }
           write_json(File.join(slices_dir, "#{code}.jsonld"), index)
@@ -1162,7 +1172,7 @@ module Ammitto
           '@context' => @context_url,
           '@type' => 'Index',
           'slice' => 'by-regime',
-          'available' => by_regime.keys.sort.map { |code| "#{BASE_URI}/regime/#{code}" }
+          'available' => by_regime.keys.sort.map { |code| Ammitto::Utils::IriSanitizer.regime_iri(code) }
         }
         write_json(File.join(slices_dir, 'index.jsonld'), master)
       end

--- a/lib/ammitto/serialization/turtle_exporter.rb
+++ b/lib/ammitto/serialization/turtle_exporter.rb
@@ -57,9 +57,15 @@ module Ammitto
       end
 
       # Characters an IRIREF cannot contain, per the Turtle grammar:
-      # space and the delimiters. Their presence means the string is
-      # prose that merely starts with a URL, not an identifier.
-      IRI_FORBIDDEN = /[\s<>"{}|^`\\]/
+      # every codepoint in #x00-#x20 plus the delimiters. Their presence
+      # means the string is prose that merely starts with a URL, not an
+      # identifier.
+      #
+      # The range is spelled out rather than written `\s`, which covers
+      # only space, tab, newline, carriage return, form feed and vertical
+      # tab: it would let \x00-\x08 and \x0E-\x1F through. Non-ASCII is
+      # deliberately absent, because a Turtle IRIREF may hold it.
+      IRI_FORBIDDEN = /[\x00-\x20<>"{}|^`\\]/
 
       private
 

--- a/lib/ammitto/serialization/turtle_exporter.rb
+++ b/lib/ammitto/serialization/turtle_exporter.rb
@@ -56,6 +56,11 @@ module Ammitto
         File.write(@output_path, turtle)
       end
 
+      # Characters an IRIREF cannot contain, per the Turtle grammar:
+      # space and the delimiters. Their presence means the string is
+      # prose that merely starts with a URL, not an identifier.
+      IRI_FORBIDDEN = /[\s<>"{}|^`\\]/
+
       private
 
       # Convert JSON-LD data to Turtle format
@@ -207,7 +212,13 @@ module Ammitto
         when Float
           ["\"#{value}\"^^xsd:decimal"]
         when String
-          if value.start_with?('http://', 'https://')
+          # A value is emitted as an IRI on shape alone, and free text
+          # can begin with a URL: Australian remarks open with the
+          # company's website and continue in prose. Those became
+          # IRIREFs containing spaces, which the grammar forbids, and
+          # the published all.ttl stopped parsing at the first one.
+          # Anything a Turtle IRIREF cannot hold is a literal.
+          if value.start_with?('http://', 'https://') && !value.match?(IRI_FORBIDDEN)
             ["<#{value}>"]
           elsif value.match?(/^\d{4}-\d{2}-\d{2}$/)
             ["\"#{value}\"^^xsd:date"]

--- a/lib/ammitto/utils/iri_sanitizer.rb
+++ b/lib/ammitto/utils/iri_sanitizer.rb
@@ -270,6 +270,33 @@ module Ammitto
           "#{BASE_URI}/entity/#{sanitize(source)}/#{id}"
         end
 
+        # Generate a regime IRI.
+        #
+        # Regime codes arrive from the source untouched, and Canada
+        # publishes bilingual ones: "CA_Belarus / Bélarus", against
+        # OFAC's "CAATSA - Russia". Interpolating those into an IRI
+        # produced identifiers containing spaces, which a Turtle IRIREF
+        # forbids; the published all.ttl stopped parsing at the first
+        # one rather than degrading.
+        #
+        # Sanitized rather than raised on, unlike a local id: a regime
+        # is a shared classification, so distinct codes collapsing to
+        # one slug is a naming collision to notice, not a record lost.
+        # Accents are dropped rather than transliterated, which is what
+        # #sanitize has always done to every other IRI; changing that
+        # would move identifiers consumers already hold.
+        #
+        # @param code [String] regime code as the source states it
+        # @return [String] Full regime IRI
+        #
+        # @example
+        #   regime_iri("CA_Belarus / Bélarus")
+        #   # => "https://www.ammitto.org/regime/ca_belarus-blarus"
+        #
+        def regime_iri(code)
+          "#{BASE_URI}/regime/#{sanitize(code)}"
+        end
+
         # Generate an entry IRI (LIST-SPECIFIC).
         #
         # Entries are junction records linking entities to specific lists.
@@ -529,6 +556,12 @@ module Ammitto
              .gsub(/^-|-$/, '')          # Remove leading/trailing hyphens
              .downcase                   # Lowercase
              .slice(0, MAX_ID_LENGTH)    # Truncate
+             # Truncation can cut mid-word and leave the hyphen that
+             # preceded it dangling, and this method has to be
+             # idempotent: a slug is re-sanitized wherever an IRI is
+             # rebuilt from a stored key, and one that shortened on the
+             # second pass advertised an @id no node file answered to.
+             .sub(/-\z/, '')
         end
       end
     end

--- a/lib/ammitto/utils/iri_sanitizer.rb
+++ b/lib/ammitto/utils/iri_sanitizer.rb
@@ -294,7 +294,32 @@ module Ammitto
         #   # => "https://www.ammitto.org/regime/ca_belarus-blarus"
         #
         def regime_iri(code)
-          "#{BASE_URI}/regime/#{sanitize(code)}"
+          "#{BASE_URI}/regime/#{regime_slug(code)}"
+        end
+
+        # Slug for a regime code, as both the node filename and the
+        # last segment of its IRI.
+        #
+        # #sanitize truncates last, so a code cut mid-word keeps the
+        # hyphen that preceded the cut. That is harmless for a local
+        # id, which is sanitized once from the source record and never
+        # again, but a regime slug is re-sanitized every time an IRI is
+        # rebuilt from a stored key, and the second pass strips the
+        # dangling hyphen: the shortened @id then answered to no node
+        # file.
+        #
+        # Repaired here rather than inside #sanitize because that
+        # method also mints entity, entry, announcement and legal
+        # instrument ids. Stripping the hyphen there would merge a
+        # 64-character truncation ending in "-" with the 63-character
+        # id that is otherwise identical, aliasing two records onto one
+        # @id, and would move identifiers consumers already hold.
+        #
+        # @param code [String] regime code as the source states it
+        # @return [String] slug, stable under a second pass
+        #
+        def regime_slug(code)
+          sanitize(code).sub(/-\z/, '')
         end
 
         # Generate an entry IRI (LIST-SPECIFIC).
@@ -556,12 +581,6 @@ module Ammitto
              .gsub(/^-|-$/, '')          # Remove leading/trailing hyphens
              .downcase                   # Lowercase
              .slice(0, MAX_ID_LENGTH)    # Truncate
-             # Truncation can cut mid-word and leave the hyphen that
-             # preceded it dangling, and this method has to be
-             # idempotent: a slug is re-sanitized wherever an IRI is
-             # rebuilt from a stored key, and one that shortened on the
-             # second pass advertised an @id no node file answered to.
-             .sub(/-\z/, '')
         end
       end
     end

--- a/spec/ammitto/serialization/json_ld_graph_exporter_regime_iri_spec.rb
+++ b/spec/ammitto/serialization/json_ld_graph_exporter_regime_iri_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+require 'json'
+require 'tmpdir'
+require 'ammitto/serialization/json_ld_graph_exporter'
+
+# Regime codes reach the graph exactly as the source states them, and
+# Canada states them bilingually: "CA_China / Chine". Interpolated into
+# an IRI that produced .../regime/ca_china / chine -- a Turtle IRIREF
+# cannot hold a space, and every consumer that splits an IRI on "/"
+# reads the French half as the identifier.
+RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
+  let(:output_dir) { Dir.mktmpdir('ammitto_regime_iri') }
+  let(:exporter) do
+    described_class.new(output_dir: output_dir,
+                        context_url: 'https://www.ammitto.org/ontology/context.jsonld')
+  end
+
+  after { FileUtils.rm_rf(output_dir) }
+
+  def add_entry(ref, regime_code)
+    exporter.add_node(
+      entity: { '@id' => "https://www.ammitto.org/entity/ca/#{ref}",
+                '@type' => 'PersonEntity' },
+      entry: { '@id' => "https://www.ammitto.org/entry/ca/consolidated/#{ref}",
+               '@type' => 'SanctionEntry',
+               'regime' => { 'code' => regime_code, 'name' => regime_code } },
+      source: :ca
+    )
+  end
+
+  it 'mints a regime IRI a Turtle IRIREF can hold' do
+    add_entry('e1', 'CA_China / Chine')
+
+    id = exporter.regimes.values.first['@id']
+
+    expect(id).to eq('https://www.ammitto.org/regime/ca_china-chine')
+  end
+
+  it 'keys the regime by the same slug the IRI ends in' do
+    # The key becomes node/regime/<key>.jsonld. A key of "ca_china /
+    # chine" wrote the node inside a directory named "ca_china " and
+    # left it unreachable at the @id the node itself advertises.
+    add_entry('e1', 'CA_China / Chine')
+
+    key = exporter.regimes.keys.first
+    id = exporter.regimes.values.first['@id']
+
+    expect(key).to eq('ca_china-chine')
+    expect(id).to end_with("/#{key}")
+  end
+
+  it 'leaves the entry pointing at the sanitized regime' do
+    add_entry('e1', 'CA_China / Chine')
+
+    ref = exporter.entries.values.first.dig('regime', '@id')
+
+    expect(ref).to eq('https://www.ammitto.org/regime/ca_china-chine')
+    expect(ref.split('/').last).to eq('ca_china-chine')
+  end
+
+  it 'merges codes that differ only in trailing whitespace' do
+    # ca published both; they are one regime and were two nodes.
+    add_entry('e1', 'CA_Moldova')
+    add_entry('e2', 'CA_Moldova ')
+
+    expect(exporter.regimes.keys).to eq(['ca_moldova'])
+  end
+
+  it 'advertises an index @id the node filename answers to' do
+    # The key is the node filename and the index rebuilds the IRI from
+    # it, so the slug has to survive a second sanitizing pass. Canada's
+    # longest code truncates to exactly the limit and left a hyphen at
+    # the end; re-sanitizing dropped it and the index pointed at a file
+    # that was never written.
+    add_entry('e1', 'CA_Justice for victims of corrupt foreign officials ' \
+                    'regulations (JVCFOR) / Reglement relatif a la justice')
+
+    key = exporter.regimes.keys.first
+    id = exporter.regimes.values.first['@id']
+
+    expect(Ammitto::Utils::IriSanitizer.regime_iri(key)).to eq(id)
+    expect(id).to end_with("/#{key}")
+  end
+
+  it 'keeps a clean code byte-identical' do
+    add_entry('e1', 'BELARUS-EO14038')
+
+    expect(exporter.regimes.keys).to eq(['belarus-eo14038'])
+    expect(exporter.regimes.values.first['@id'])
+      .to eq('https://www.ammitto.org/regime/belarus-eo14038')
+  end
+end

--- a/spec/ammitto/serialization/turtle_exporter_iri_spec.rb
+++ b/spec/ammitto/serialization/turtle_exporter_iri_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ammitto/serialization/turtle_exporter'
+
+# The published all.ttl did not parse. Values were emitted as IRIs on
+# shape alone — anything starting with http(s) — and free text can begin
+# with a URL: Australian remarks open with the company's website and
+# continue in prose. Those became IRIREFs containing spaces, which the
+# Turtle grammar forbids, and RDF::Graph.load died at the first one
+# rather than skipping it.
+#
+# There was no spec for this class at all before.
+RSpec.describe Ammitto::Serialization::TurtleExporter do
+  # The constructor takes paths it never reads for this conversion.
+  subject(:exporter) { described_class.new(File::NULL, File::NULL) }
+
+  def convert(value)
+    exporter.send(:convert_value, value)
+  end
+
+  it 'emits a bare URL as an IRI' do
+    expect(convert('https://example.test/a')).to eq(['<https://example.test/a>'])
+  end
+
+  it 'emits prose beginning with a URL as a literal' do
+    # Shortened from a real au record.
+    text = 'https://enics.aero/; Listing: Autonomous Sanctions Amendment (No. 1) Instrument 2024'
+
+    result = convert(text).first
+
+    expect(result).not_to start_with('<')
+    expect(result).to include('enics.aero')
+  end
+
+  it 'never emits an IRIREF containing a character the grammar forbids' do
+    [
+      'https://example.test/a b',
+      "https://example.test/a\tb",
+      'https://example.test/a<b',
+      'https://example.test/a"b',
+      'https://ipnrf.ru/ ; Company Identification No., 1177456104638'
+    ].each do |value|
+      result = convert(value).first
+      next unless result.start_with?('<')
+
+      expect(result).not_to match(/[\s<>"{}|^`\\]/), "#{value.inspect} -> #{result.inspect}"
+    end
+  end
+
+  it 'still types dates and leaves other text alone' do
+    expect(convert('2024-01-31')).to eq(['"2024-01-31"^^xsd:date'])
+    expect(convert('plain').first).not_to start_with('<')
+  end
+end

--- a/spec/ammitto/serialization/turtle_exporter_iri_spec.rb
+++ b/spec/ammitto/serialization/turtle_exporter_iri_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe Ammitto::Serialization::TurtleExporter do
     [
       'https://example.test/a b',
       "https://example.test/a\tb",
+      # The grammar forbids every codepoint in #x00-#x20 and Ruby's \s
+      # covers six of them, so the controls it misses are named here.
+      "https://example.test/a\x00b",
+      "https://example.test/a\x08b",
+      "https://example.test/a\x0Eb",
+      "https://example.test/a\x1Fb",
       'https://example.test/a<b',
       'https://example.test/a"b',
       'https://ipnrf.ru/ ; Company Identification No., 1177456104638'
@@ -44,8 +50,17 @@ RSpec.describe Ammitto::Serialization::TurtleExporter do
       result = convert(value).first
       next unless result.start_with?('<')
 
-      expect(result).not_to match(/[\s<>"{}|^`\\]/), "#{value.inspect} -> #{result.inspect}"
+      expect(result).not_to match(/[\x00-\x20<>"{}|^`\\]/),
+                            "#{value.inspect} -> #{result.inspect}"
     end
+  end
+
+  it 'still emits an IRI carrying a character an IRIREF may hold' do
+    # The guard must not reach past the grammar. Non-ASCII is legal in an
+    # IRIREF, so widening to the control range must not demote it.
+    value = 'https://example.test/café'
+
+    expect(convert(value)).to eq(["<#{value}>"])
   end
 
   it 'still types dates and leaves other text alone' do

--- a/spec/ammitto/utils/iri_sanitizer_regime_spec.rb
+++ b/spec/ammitto/utils/iri_sanitizer_regime_spec.rb
@@ -47,14 +47,14 @@ RSpec.describe Ammitto::Utils::IriSanitizer do
     long = 'CA_Justice for victims of corrupt foreign officials ' \
            'regulations (JVCFOR) / Reglement relatif a la justice'
 
-    it 'sanitizes a truncated slug to itself' do
-      once = described_class.sanitize(long)
+    it 'slugs a truncated regime code to itself' do
+      once = described_class.regime_slug(long)
 
-      expect(described_class.sanitize(once)).to eq(once)
+      expect(described_class.regime_slug(once)).to eq(once)
     end
 
     it 'leaves no trailing hyphen after truncating' do
-      expect(described_class.sanitize(long)).not_to end_with('-')
+      expect(described_class.regime_slug(long)).not_to end_with('-')
     end
 
     it 'mints the same regime IRI from a code and from its own slug' do
@@ -62,6 +62,31 @@ RSpec.describe Ammitto::Utils::IriSanitizer do
       slug = iri.split('/').last
 
       expect(described_class.regime_iri(slug)).to eq(iri)
+    end
+  end
+
+  describe 'the repair stays out of the shared sanitizer' do
+    # Local ids are sanitized once, from the source record, and never
+    # rebuilt from a stored key, so they do not need the repair — and
+    # they cannot afford it. Truncation already collapses everything
+    # sharing a 64-character prefix; stripping the trailing hyphen
+    # would put the 63-character id in that same bucket, aliasing two
+    # records onto one @id. #sanitize therefore has to keep the hyphen
+    # even though #regime_slug drops it.
+    cut = "#{'a' * 63}-X"   # truncates to 63 a's plus a dangling hyphen
+    whole = 'a' * 63        # the same prefix, ending there
+
+    it 'keeps a truncated local id distinct from its own prefix' do
+      expect(described_class.entity_iri('ca', cut))
+        .not_to eq(described_class.entity_iri('ca', whole))
+    end
+
+    it 'preserves the hyphen truncation leaves behind' do
+      expect(described_class.sanitize(cut)).to end_with('-')
+    end
+
+    it 'drops that hyphen only for regimes' do
+      expect(described_class.regime_slug(cut)).not_to end_with('-')
     end
   end
 end

--- a/spec/ammitto/utils/iri_sanitizer_regime_spec.rb
+++ b/spec/ammitto/utils/iri_sanitizer_regime_spec.rb
@@ -21,13 +21,23 @@ RSpec.describe Ammitto::Utils::IriSanitizer do
         'CAATSA - Russia',
         'CA_Extremist Settler Violence / Violence extrémiste des colons',
         'CA_Justice for Victims of Corrupt Foreign Officials Regulations (JVCFOR)',
-        'SOUTH SUDAN'
+        'SOUTH SUDAN',
+        # Synthetic, and the only member that is: no source publishes a
+        # control character today, but the assertion below claims the
+        # whole #x00-#x20 range and an assertion should be given
+        # something in the range it claims.
+        "CA_Belarus\u0001 / B\u001Felarus"
       ]
 
       codes.each do |code|
         iri = described_class.regime_iri(code)
-        # The delimiters the grammar excludes outright.
-        expect(iri).not_to match(/[\s<>"{}|^`\\]/), "#{code.inspect} -> #{iri.inspect}"
+        # The whole set the grammar excludes, matching the exporter's
+        # own IRI_FORBIDDEN: #x00-#x20 and the delimiters. Written out
+        # rather than as \s, which covers six of those codepoints and
+        # would let the rest of the control range past the assertion
+        # while the example's name claims otherwise.
+        expect(iri).not_to match(/[\x00-\x20<>"{}|^`\\]/),
+                           "#{code.inspect} -> #{iri.inspect}"
       end
     end
 

--- a/spec/ammitto/utils/iri_sanitizer_regime_spec.rb
+++ b/spec/ammitto/utils/iri_sanitizer_regime_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ammitto/utils/iri_sanitizer'
+
+# A Turtle IRIREF cannot contain a space. Regime codes reach the graph
+# straight from the source, and Canada publishes bilingual ones with
+# slashes, accents and spaces, so interpolating a code into an IRI
+# produced 17 distinct identifiers that no RDF parser will read.
+RSpec.describe Ammitto::Utils::IriSanitizer do
+  describe '.regime_iri' do
+    it 'mints a usable IRI from a bilingual code carrying spaces' do
+      iri = described_class.regime_iri('CA_Belarus / Bélarus')
+
+      expect(iri).not_to include(' ')
+      expect(iri).to start_with('https://www.ammitto.org/regime/')
+    end
+
+    it 'never emits a character a Turtle IRIREF forbids' do
+      codes = [
+        'CAATSA - Russia',
+        'CA_Extremist Settler Violence / Violence extrémiste des colons',
+        'CA_Justice for Victims of Corrupt Foreign Officials Regulations (JVCFOR)',
+        'SOUTH SUDAN'
+      ]
+
+      codes.each do |code|
+        iri = described_class.regime_iri(code)
+        # The delimiters the grammar excludes outright.
+        expect(iri).not_to match(/[\s<>"{}|^`\\]/), "#{code.inspect} -> #{iri.inspect}"
+      end
+    end
+
+    it 'keeps distinct codes distinct' do
+      a = described_class.regime_iri('CAATSA - Russia')
+      b = described_class.regime_iri('CAATSA - Iran')
+
+      expect(a).not_to eq(b)
+    end
+  end
+
+  describe 'idempotence' do
+    # An IRI is rebuilt from a stored slug in several places, so a slug
+    # that changes on a second pass advertises an @id that no node file
+    # answers to. Truncation is what broke it: it cuts mid-word and
+    # leaves the preceding hyphen at the end.
+    long = 'CA_Justice for victims of corrupt foreign officials ' \
+           'regulations (JVCFOR) / Reglement relatif a la justice'
+
+    it 'sanitizes a truncated slug to itself' do
+      once = described_class.sanitize(long)
+
+      expect(described_class.sanitize(once)).to eq(once)
+    end
+
+    it 'leaves no trailing hyphen after truncating' do
+      expect(described_class.sanitize(long)).not_to end_with('-')
+    end
+
+    it 'mints the same regime IRI from a code and from its own slug' do
+      iri = described_class.regime_iri(long)
+      slug = iri.split('/').last
+
+      expect(described_class.regime_iri(slug)).to eq(iri)
+    end
+  end
+end


### PR DESCRIPTION
`all.ttl` is not valid Turtle. Regime IRIs are built by interpolating the source's own code, Canada publishes those bilingually (`CA_China / Chine`) and OFAC publishes `CAATSA - Russia`, and an IRIREF cannot hold a space: 4,567 of the 379,407 IRIREFs in the published file carry a character the grammar forbids, 4,472 of them on **`ammitto:hasRegime`**. The failure is quiet, which is the part that matters. On a two-statement fixture **`RDF::Graph.load`** does not raise; it loads the good statement, drops the bad one and says nothing, so a consumer gets a graph missing every regime link with no indication it is incomplete. **`RDF::Turtle::Reader`** with `validate: true` errors instead. The raw code was also the node filename and the tail **`by-regime`** groups on, so the slash was read as a path separator; that left eleven `node/regime` subdirectories, eleven regime `@id`s answering to no file at all, and ten Canadian slices published as ` bélarus.jsonld`, ` chine.jsonld`, ` russie.jsonld` and the like instead of their `ca_*` names.

Added **`IriSanitizer.regime_iri`** and routed all five minting sites through it, then keyed **`@regimes`** by that slug so the node path and the `@id` cannot disagree again; that also merges `ca_moldova` and `ca_moldova `, which were one regime published as two nodes, so the regime index drops from 180 entries to 178. Regime slugs also needed to survive a second sanitizing pass, since an IRI is rebuilt from a stored key in three places: `#sanitize` truncates last, so a code cut mid-word keeps the preceding hyphen and the second pass removes it, which is how an `@id` went on pointing at a file that was never written. That repair lives in **`IriSanitizer.regime_slug`** rather than in `#sanitize`, which also mints entity, entry, announcement and legal-instrument ids: dropping the hyphen there would merge a 64-character truncation ending in `-` with the 63-character id that is otherwise identical, aliasing two records onto one `@id`. Local ids keep exactly the values they have on main. Separately **`convert_value`** emitted an IRI on shape alone, and Australian remarks open with the company website before continuing in prose, so 78 of those became IRIREFs too; anything an IRIREF cannot hold is now a literal. **`IRI_FORBIDDEN`** spells out `#x00-#x20` rather than using `\s`, which covers only six of those codepoints and would pass `\x00-\x08` and `\x0E-\x1F` through, and it deliberately stops at ASCII because an IRIREF may hold non-ASCII.

Three identifier changes, all deliberate, none of which merges two regimes: 178 codes still yield 178 distinct IRIs. Accents are dropped rather than transliterated, exactly as `#sanitize` has always done. The unreferenced legacy **`JsonLdExporter`** now downcases its regime code like the graph exporter always has, so a clean `BELARUS-EO14038` becomes `belarus-eo14038` on that path; nothing requires or calls that class, and leaving the two exporters disagreeing about one IRI is the defect this change exists to remove. And regime codes are now subject to `MAX_ID_LENGTH`, which they escaped while being interpolated raw, so **five clean UK codes shorten**: the longest, `the_global_irregular_migration_and_trafficking_in_persons_sanctions_regulations_2025` at 84 characters, becomes `…_in_persons_sancti`. Every other IRI in the graph has always been truncated at 64; regimes were the exception because nothing sanitized them. The residual risk is that two UK instrument names agreeing for 64 characters would collide, and the repo already has the answer for that in `clamp_slug`, which keeps a shared prefix distinct with a digest; applying it consistently across regimes, authorities and document types is worth doing on its own rather than as a rider here.

Search and the facets were damaged the same way and are repaired with it. `search-index.json` and `facets/regimes.json` both key a regime by the tail of its IRI, so a code holding ` / ` was split there too: eleven Canadian regimes were indexed under French fragments beginning with a space — ` bélarus`, ` chine`, ` russie`, ` soudan du sud` — while their `ca_*` names appeared nowhere. The published tree said as much and nobody was reading it: 180 regime nodes against 169 facet entries and 169 distinct index values, eleven nodes reachable from neither. After the fix all three agree at 178, with no orphan in any direction.

One visible consequence on the site, disclosed rather than fixed here. **`useEntityData.ts:443`** builds the regime badge by pulling the tail off the `@id` and title-casing it, so shortening the tail shortens the badge: running that function over the real IRIs gives `Ca China / Chine` to `Ca China-Chine`, and `Ca Belarus / BéLarus` to `Ca Belarus-Blarus`. Clean codes are unaffected. The badge is deriving a label from an identifier, which is the actual defect: the regime node already carries `"name": "Belarus / Bélarus"`, accents and all, and the entry's regime reference is `{"@id": …}` alone so the page never sees it. Fixing that means the reference carrying the name and the page preferring it, in this repo and the site, and it is not part of making the RDF parse.

Left alone: **`export_document_type_nodes`** writes `local_id` to a filename without the `unusable_filename_component?` guard **`export_organization_nodes`** and the instrument path apply. That is the same defect class but a different one to fix, and it is latent rather than live: 0 unsafe basenames across its 36 files in a current run. It has its own change now, #62.

Verified locally: a full harmonize over all fifteen sources reproduces today's live result (13 succeeded, 2 failed on ru and un_vessels, 60,986 entities). `RDF::Turtle::Reader` with `validate: true` over the published-shape `all.ttl` logs 27,330 fatal recovery errors and ends in `RDF::ReaderError` after 2,459,585 statements; over the regenerated file it reads clean to 2,511,537 with no error at all, so the invalid IRIs were costing 51,952 statements. Forbidden characters in IRIREFs go 4,567 to 0, published paths holding whitespace 45 to 0, regime `@id`s with no node file 11 to 0, `ca_*` slices under `by-regime` 7 to 17. Suite 1,636 green, rubocop clean over 430 files. Mutation checks: restoring shape-only IRI detection fails 2 of the 5 turtle examples, `\s` in place of the explicit range fails 1, removing the trailing-hyphen strip from `regime_slug` fails 4 of the 9 sanitizer examples, moving that strip into `#sanitize` fails 2 of them on the aliased entity IRI, and keying the exporter's regimes by `#sanitize` again fails the example that pins the node filename to the `@id`. The forbidden-character example asserts the whole `#x00-#x20` range rather than `\s`, and is given one synthetic code carrying control characters so that claim is exercised: a sanitizer that keeps the control range fails that example and only that one.

---

Reviewed by Codex, not by Copilot: every Copilot request since 2026-08-18 15:20 returns "the user who requested the review has reached their quota limit", as a submitted review with zero comments. Recorded here so the review provenance is not assumed from the absence of comments.

