### PR TITLE
Report the harmonize outcome as JSON so CI stops parsing the log

### DIFF
--- a/lib/ammitto/cli.rb
+++ b/lib/ammitto/cli.rb
@@ -176,6 +176,10 @@ module Ammitto
                          desc: 'Sources exempt from the health gates: zero entities, source errors, ' \
                                'missing aggregates, and the quality floors will not fail the run ' \
                                '(comma-separated). Per-file transform errors always fail.'
+    option :report, type: :string,
+                    desc: 'Write the run outcome as JSON to PATH, including per-source gate ' \
+                          'failures. Written even when the gates fail, so CI can report what ' \
+                          'broke without parsing this command output.'
     def harmonize(*sources)
       require_relative 'cli/harmonize_command'
       Cmd::HarmonizeCommand.new(options, sources).run

--- a/lib/ammitto/cli/harmonize_command.rb
+++ b/lib/ammitto/cli/harmonize_command.rb
@@ -3,6 +3,7 @@
 require 'fileutils'
 require 'yaml'
 require 'json'
+require 'time'
 require_relative '../serialization/json_ld_graph_exporter'
 require_relative '../serialization/search_index_exporter'
 require_relative '../serialization/ontology_exporter'
@@ -47,6 +48,11 @@ module Ammitto
       # entities to be overwhelmingly identifiable.
       MIN_UNIQUE_ID_RATIO = 0.5
       MIN_NAMED_ENTITY_RATIO = 0.9
+
+      # Stamped into every --report file. A consumer that reads a shape
+      # it does not recognise should say so rather than guess, which is
+      # the whole reason for reporting instead of parsing the log.
+      REPORT_SCHEMA = 'ammitto-harmonize-report/v1'
 
       # Initialize with options and sources
       # @param options [Hash] command options
@@ -139,6 +145,9 @@ module Ammitto
         end
 
         print_summary(results)
+        # Written before the gates raise, because a failing run is
+        # precisely the one a caller needs the report for.
+        write_report(results) if options[:report]
         enforce_health_gates(results)
       end
 
@@ -1457,6 +1466,68 @@ module Ammitto
 
         puts "Graph totals: #{stats[:total_entities]} entities, " \
              "#{stats[:total_entries]} entries (deduplicated)"
+      end
+
+      # Write the run's outcome as JSON.
+      #
+      # The printed summary is for a human reading a log; a CI job needs
+      # the same facts without parsing prose. ammitto/data was recovering
+      # them by regexing this command's stdout for "Harmonize health gate
+      # failed:" and two-space-indented rows, which couples a workflow to
+      # wording this command is free to change, and reads a raised
+      # Thor::Error message as if it were an interface.
+      #
+      # @param results [Array<Hash>] harmonize results
+      # @return [void]
+      def write_report(results)
+        path = options[:report]
+        FileUtils.mkdir_p(File.dirname(path))
+        File.write(path, "#{JSON.pretty_generate(report_payload(results))}\n")
+        puts "Wrote report: #{path}" if options[:verbose]
+      end
+
+      # The report body, classified by the same gate evaluation the exit
+      # code uses, so the two can never disagree.
+      # @param results [Array<Hash>] harmonize results
+      # @return [Hash] report payload
+      def report_payload(results)
+        evaluate_gates(results)
+        failed, rest = results.partition { |r| (r[:gate_failures] || []).any? }
+        exempted, clean = rest.partition { |r| (r[:exempted_failures] || []).any? }
+        stats = @exporter&.stats
+
+        {
+          'schema' => REPORT_SCHEMA,
+          'generated_at' => Time.now.utc.iso8601,
+          # False means #enforce_health_gates is about to raise, so a
+          # caller can act on the outcome without inspecting an exit code
+          # it may have lost to a pipe.
+          'gates_passed' => failed.empty?,
+          'counts' => { 'succeeded' => clean.length,
+                        'failed' => failed.length,
+                        'exempted' => exempted.length },
+          'totals' => { 'entities' => stats&.dig(:total_entities),
+                        'entries' => stats&.dig(:total_entries) },
+          'sources' => results.map { |r| report_source(r) }
+        }
+      end
+
+      # One source's outcome. Per-file transform errors are reported
+      # separately from gate failures because no exemption clears them.
+      # @param result [Hash] per-source result
+      # @return [Hash] source entry
+      def report_source(result)
+        {
+          'code' => result[:code].to_s,
+          'status' => result[:status].to_s,
+          'entities' => result[:entities].to_i,
+          'entries' => result[:entries].to_i,
+          'error' => result[:error],
+          'gate_failures' => result[:gate_failures] || [],
+          'exempted_failures' => result[:exempted_failures] || [],
+          'transform_errors' => result[:errors] || [],
+          'quality' => result[:quality] || {}
+        }
       end
     end
   end

--- a/lib/ammitto/cli/harmonize_command.rb
+++ b/lib/ammitto/cli/harmonize_command.rb
@@ -151,6 +151,12 @@ module Ammitto
         # about immediately and raised only once the gates have had their
         # say, so an unwritable path cannot replace "ru: No YAML files
         # found" with an Errno the operator has to work backwards from.
+        #
+        # The rule is the report's alone, and does not extend upward to
+        # the three exporters. They are what the command exists to
+        # produce; if one raises, the artefacts do not exist, and that
+        # outranks a gate saying one source contributed nothing. Only a
+        # diagnostic ABOUT the run yields to the run's own verdict.
         report_error = options[:report] ? write_report(results) : nil
         enforce_health_gates(results)
         raise Thor::Error, report_error if report_error

--- a/lib/ammitto/cli/harmonize_command.rb
+++ b/lib/ammitto/cli/harmonize_command.rb
@@ -146,9 +146,14 @@ module Ammitto
 
         print_summary(results)
         # Written before the gates raise, because a failing run is
-        # precisely the one a caller needs the report for.
-        write_report(results) if options[:report]
+        # precisely the one a caller needs the report for. A write that
+        # fails must not become the run's diagnosis, though: it is warned
+        # about immediately and raised only once the gates have had their
+        # say, so an unwritable path cannot replace "ru: No YAML files
+        # found" with an Errno the operator has to work backwards from.
+        report_error = options[:report] ? write_report(results) : nil
         enforce_health_gates(results)
+        raise Thor::Error, report_error if report_error
       end
 
       # Health gates: a run that produced no data or swallowed errors must
@@ -1478,12 +1483,19 @@ module Ammitto
       # Thor::Error message as if it were an interface.
       #
       # @param results [Array<Hash>] harmonize results
-      # @return [void]
+      # @return [String, nil] failure message, or nil when written
       def write_report(results)
         path = options[:report]
         FileUtils.mkdir_p(File.dirname(path))
         File.write(path, "#{JSON.pretty_generate(report_payload(results))}\n")
         puts "Wrote report: #{path}" if options[:verbose]
+        nil
+      rescue SystemCallError, IOError => e
+        # Warned here and returned rather than raised: the caller decides
+        # when it can afford to be the run's error (see #run).
+        message = "Could not write report to #{path}: #{e.message}"
+        warn message
+        message
       end
 
       # The report body, classified by the same gate evaluation the exit
@@ -1514,14 +1526,18 @@ module Ammitto
 
       # One source's outcome. Per-file transform errors are reported
       # separately from gate failures because no exemption clears them.
+      #
+      # Counts are passed through rather than coerced: a source that
+      # errored never reached a count, and null says that where 0 would
+      # read as a measurement a jq snippet or a dashboard would trust.
       # @param result [Hash] per-source result
       # @return [Hash] source entry
       def report_source(result)
         {
           'code' => result[:code].to_s,
           'status' => result[:status].to_s,
-          'entities' => result[:entities].to_i,
-          'entries' => result[:entries].to_i,
+          'entities' => result[:entities],
+          'entries' => result[:entries],
           'error' => result[:error],
           'gate_failures' => result[:gate_failures] || [],
           'exempted_failures' => result[:exempted_failures] || [],

--- a/lib/ammitto/cli/harmonize_command.rb
+++ b/lib/ammitto/cli/harmonize_command.rb
@@ -1490,10 +1490,22 @@ module Ammitto
         File.write(path, "#{JSON.pretty_generate(report_payload(results))}\n")
         puts "Wrote report: #{path}" if options[:verbose]
         nil
-      rescue SystemCallError, IOError => e
+      rescue StandardError => e
+        # Deliberately broad. Rescuing only the IO errors left the
+        # serialization uncovered: JSON.pretty_generate raises
+        # JSON::GeneratorError on a source error carrying an invalid
+        # UTF-8 byte, which is neither SystemCallError nor IOError, so it
+        # escaped and replaced "ru: No YAML files found" with a JSON
+        # error on exactly the failing runs this report describes.
+        #
+        # The rule is about precedence, not about which exceptions
+        # exist: producing the diagnostic must never outrank the
+        # diagnosis. Anything that goes wrong here is reported as a
+        # report failure and yields to the gates.
+        #
         # Warned here and returned rather than raised: the caller decides
         # when it can afford to be the run's error (see #run).
-        message = "Could not write report to #{path}: #{e.message}"
+        message = "Could not write report to #{path}: #{e.class}: #{e.message}"
         warn message
         message
       end

--- a/spec/ammitto/cli/harmonize_command_report_spec.rb
+++ b/spec/ammitto/cli/harmonize_command_report_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+require 'json'
+require 'thor'
+require 'tmpdir'
+require 'ammitto/cli/harmonize_command'
+
+# ammitto/data recovered these facts by regexing this command's stdout for
+# "Harmonize health gate failed:" and two-space-indented rows, which reads
+# a raised Thor::Error message as an interface and couples a workflow to
+# wording this command is free to change. --report is that interface.
+RSpec.describe Ammitto::Cmd::HarmonizeCommand do
+  let(:dir) { Dir.mktmpdir('ammitto_report') }
+  let(:path) { File.join(dir, 'nested', 'harmonize-report.json') }
+  let(:options) { { report: path } }
+  let(:command) { described_class.new(options, []) }
+
+  after { FileUtils.rm_rf(dir) }
+
+  def report_for(results)
+    command.send(:write_report, results)
+    JSON.parse(File.read(path))
+  end
+
+  it 'stamps the schema so a consumer can refuse a shape it does not know' do
+    report = report_for([{ code: :au, status: :success, entities: 3, entries: 3 }])
+
+    expect(report['schema']).to eq('ammitto-harmonize-report/v1')
+  end
+
+  it 'creates the directory the path names' do
+    report_for([{ code: :au, status: :success, entities: 1, entries: 1 }])
+
+    expect(File.file?(path)).to be true
+  end
+
+  it 'reports a source error as a gate failure with gates_passed false' do
+    report = report_for([{ code: :ru, status: :error,
+                           error: 'No YAML files found' }])
+
+    expect(report['gates_passed']).to be false
+    expect(report['counts']).to eq('succeeded' => 0, 'failed' => 1,
+                                   'exempted' => 0)
+    entry = report['sources'].first
+    expect(entry['code']).to eq('ru')
+    expect(entry['error']).to eq('No YAML files found')
+    expect(entry['gate_failures']).to eq(['ru: No YAML files found'])
+  end
+
+  it 'reports an --allow-empty source as exempted and lets the gates pass' do
+    options[:allow_empty] = 'ru'
+
+    report = report_for([{ code: :ru, status: :error,
+                           error: 'No YAML files found' }])
+
+    expect(report['gates_passed']).to be true
+    expect(report['counts']).to eq('succeeded' => 0, 'failed' => 0,
+                                   'exempted' => 1)
+    entry = report['sources'].first
+    expect(entry['gate_failures']).to be_empty
+    expect(entry['exempted_failures']).to eq(['ru: No YAML files found'])
+  end
+
+  it 'keeps a per-file transform error failing even for an exempt source' do
+    # No exemption clears these, so the report must not file them under
+    # exempted_failures where a reader would discount them.
+    options[:allow_empty] = 'ch'
+
+    report = report_for([{ code: :ch, status: :success, entities: 3,
+                           entries: 3, errors: ['x.yml: boom'] }])
+
+    entry = report['sources'].first
+    expect(report['gates_passed']).to be false
+    expect(entry['transform_errors']).to eq(['x.yml: boom'])
+    expect(entry['exempted_failures']).to be_empty
+  end
+
+  it 'agrees with the printed summary on every count' do
+    # The counts and the exit code come from one gate evaluation; a report
+    # that classified independently could contradict the log beside it.
+    # au needs its per-source aggregate on disk or the missing-aggregate
+    # gate fails it, which is the gate doing its job, not a fixture bug.
+    options[:output_dir] = File.join(dir, 'out')
+    FileUtils.mkdir_p(File.join(options[:output_dir], 'sources'))
+    aggregate = { '@graph' => [{ '@id' => 'https://www.ammitto.org/entity/au/e1',
+                                 'name' => 'Example Pty Ltd' }] }
+    File.write(File.join(options[:output_dir], 'sources', 'au.jsonld'),
+               JSON.generate(aggregate))
+    results = [{ code: :au, status: :success, entities: 5, entries: 5 },
+               { code: :ru, status: :error, error: 'No YAML files found' }]
+
+    expect { command.send(:print_summary, results) }
+      .to output(/1 succeeded, 1 failed, 0 exempted/).to_stdout
+    report = report_for(results)
+
+    expect(report['counts']).to eq('succeeded' => 1, 'failed' => 1,
+                                   'exempted' => 0)
+  end
+
+  it 'carries a UTC timestamp' do
+    report = report_for([{ code: :au, status: :success, entities: 1,
+                           entries: 1 }])
+
+    expect(report['generated_at']).to match(/\A\d{4}-\d{2}-\d{2}T[\d:]+Z\z/)
+  end
+
+  it 'writes nothing when --report is absent' do
+    bare = described_class.new({}, [])
+
+    expect(bare.options[:report]).to be_nil
+    expect(Dir.children(dir)).to be_empty
+  end
+
+  describe 'a run whose gates fail' do
+    before { allow($stdout).to receive(:write) }
+
+    # The report exists to describe a failure, so it has to be on disk by
+    # the time the gates raise. Ordering the two calls the other way round
+    # leaves the caller nothing to read on exactly the runs it needs one.
+    it 'still leaves the report on disk' do
+      sources_dir = File.join(dir, 'sources')
+      FileUtils.mkdir_p(File.join(sources_dir, 'data-ru', 'processed'))
+      run_options = { sources_dir: sources_dir,
+                      output_dir: File.join(dir, 'out'),
+                      report: path }
+
+      expect { described_class.new(run_options, ['ru']).run }
+        .to raise_error(Thor::Error, /ru: No YAML files found/)
+
+      report = JSON.parse(File.read(path))
+      expect(report['gates_passed']).to be false
+      expect(report['sources'].first['gate_failures'])
+        .to eq(['ru: No YAML files found'])
+    end
+  end
+end

--- a/spec/ammitto/cli/harmonize_command_report_spec.rb
+++ b/spec/ammitto/cli/harmonize_command_report_spec.rb
@@ -181,8 +181,13 @@ RSpec.describe Ammitto::Cmd::HarmonizeCommand do
       allow(cmd).to receive(:harmonize_source)
         .and_return(code: :ru, status: :error, error: "bad byte \xFF".b)
 
-      expect { cmd.run }
-        .to raise_error(Thor::Error, /ru: bad byte/)
+      # Asserting the gate message alone would not prove the report path
+      # ran at all: the gate error already contains "ru: bad byte", so a
+      # mutation that skipped write_report entirely would pass. The
+      # stderr warning is what shows serialization was attempted and
+      # failed, and the raised error shows the gate still won.
+      expect { expect { cmd.run }.to raise_error(Thor::Error, /ru: bad byte/) }
+        .to output(/Could not write report .*JSON::GeneratorError/).to_stderr
     end
 
     it 'warns as soon as the report fails, not only at the end' do

--- a/spec/ammitto/cli/harmonize_command_report_spec.rb
+++ b/spec/ammitto/cli/harmonize_command_report_spec.rb
@@ -99,33 +99,45 @@ RSpec.describe Ammitto::Cmd::HarmonizeCommand do
                                    'exempted' => 0)
   end
 
-  it 'carries a UTC timestamp' do
+  it 'carries a UTC timestamp taken from the run' do
+    # Format alone would survive a hardcoded date, so the value has to be
+    # pinned to now as well.
+    before = Time.now.utc
+
     report = report_for([{ code: :au, status: :success, entities: 1,
                            entries: 1 }])
 
     expect(report['generated_at']).to match(/\A\d{4}-\d{2}-\d{2}T[\d:]+Z\z/)
+    stamped = Time.parse(report['generated_at'])
+    expect(stamped).to be_between(before - 1, Time.now.utc + 1)
   end
 
-  it 'writes nothing when --report is absent' do
-    bare = described_class.new({}, [])
+  it 'reports an errored source with no count rather than a count of zero' do
+    # 0 is a measurement. A source that never read a file did not measure
+    # anything, and a consumer charting "entities today" must not be
+    # handed a zero it will treat as one.
+    report = report_for([{ code: :ru, status: :error,
+                           error: 'No YAML files found' }])
 
-    expect(bare.options[:report]).to be_nil
-    expect(Dir.children(dir)).to be_empty
+    entry = report['sources'].first
+    expect(entry['entities']).to be_nil
+    expect(entry['entries']).to be_nil
   end
 
   describe 'a run whose gates fail' do
     before { allow($stdout).to receive(:write) }
 
+    def run_options(report: path)
+      sources_dir = File.join(dir, 'sources')
+      FileUtils.mkdir_p(File.join(sources_dir, 'data-ru', 'processed'))
+      opts = { sources_dir: sources_dir, output_dir: File.join(dir, 'out') }
+      report ? opts.merge(report: report) : opts
+    end
+
     # The report exists to describe a failure, so it has to be on disk by
     # the time the gates raise. Ordering the two calls the other way round
     # leaves the caller nothing to read on exactly the runs it needs one.
     it 'still leaves the report on disk' do
-      sources_dir = File.join(dir, 'sources')
-      FileUtils.mkdir_p(File.join(sources_dir, 'data-ru', 'processed'))
-      run_options = { sources_dir: sources_dir,
-                      output_dir: File.join(dir, 'out'),
-                      report: path }
-
       expect { described_class.new(run_options, ['ru']).run }
         .to raise_error(Thor::Error, /ru: No YAML files found/)
 
@@ -133,6 +145,41 @@ RSpec.describe Ammitto::Cmd::HarmonizeCommand do
       expect(report['gates_passed']).to be false
       expect(report['sources'].first['gate_failures'])
         .to eq(['ru: No YAML files found'])
+    end
+
+    it 'writes no report at all without the flag' do
+      expect { described_class.new(run_options(report: nil), ['ru']).run }
+        .to raise_error(Thor::Error, /ru: No YAML files found/)
+
+      expect(File.exist?(path)).to be false
+    end
+
+    # An unwritable report must not become the run's diagnosis: the gate
+    # message is what the operator needs, and losing it to an Errno is
+    # exactly the failure the report was added to prevent.
+    it 'keeps the gate failure when the report cannot be written' do
+      blocked = File.join(dir, 'blocked')
+      File.write(blocked, 'not a directory')
+
+      expect do
+        described_class.new(run_options(report: File.join(blocked, 'r.json')),
+                            ['ru']).run
+      end.to raise_error(Thor::Error, /ru: No YAML files found/)
+    end
+
+    # With the gates satisfied there is nothing better to report, so the
+    # write failure is the run's outcome rather than a silent success.
+    it 'fails the run when only the report could not be written' do
+      blocked = File.join(dir, 'blocked2')
+      File.write(blocked, 'not a directory')
+      opts = { sources_dir: File.join(dir, 'sources'),
+               output_dir: File.join(dir, 'out'),
+               allow_empty: 'ru',
+               report: File.join(blocked, 'r.json') }
+      FileUtils.mkdir_p(File.join(dir, 'sources', 'data-ru', 'processed'))
+
+      expect { described_class.new(opts, ['ru']).run }
+        .to raise_error(Thor::Error, /Could not write report/)
     end
   end
 end

--- a/spec/ammitto/cli/harmonize_command_report_spec.rb
+++ b/spec/ammitto/cli/harmonize_command_report_spec.rb
@@ -167,6 +167,44 @@ RSpec.describe Ammitto::Cmd::HarmonizeCommand do
       end.to raise_error(Thor::Error, /ru: No YAML files found/)
     end
 
+    # The report is serialized before it is written, and serialization
+    # can fail on its own: a source error carrying an invalid UTF-8 byte
+    # makes JSON.pretty_generate raise, which is not an IO error. Left
+    # uncaught it replaced the gate message with a JSON error on exactly
+    # the runs the report exists to describe.
+    it 'keeps the gate failure when the report cannot be serialized' do
+      sources_dir = File.join(dir, 'sources')
+      FileUtils.mkdir_p(File.join(sources_dir, 'data-ru', 'processed'))
+      cmd = described_class.new({ sources_dir: sources_dir,
+                                  output_dir: File.join(dir, 'out'),
+                                  report: path }, ['ru'])
+      allow(cmd).to receive(:harmonize_source)
+        .and_return(code: :ru, status: :error, error: "bad byte \xFF".b)
+
+      expect { cmd.run }
+        .to raise_error(Thor::Error, /ru: bad byte/)
+    end
+
+    it 'warns as soon as the report fails, not only at the end' do
+      # The message reaches stderr immediately; the raise waits for the
+      # gates. Without this the warn could be deleted and the file stay
+      # green on the raised error alone.
+      blocked = File.join(dir, 'blocked3')
+      File.write(blocked, 'not a directory')
+      opts = { sources_dir: File.join(dir, 'sources'),
+               output_dir: File.join(dir, 'out'),
+               allow_empty: 'ru',
+               report: File.join(blocked, 'r.json') }
+      FileUtils.mkdir_p(File.join(dir, 'sources', 'data-ru', 'processed'))
+
+      expect do
+        described_class.new(opts, ['ru']).run
+      rescue Thor::Error
+        # The raise is asserted elsewhere; this example is about stderr.
+        nil
+      end.to output(/Could not write report/).to_stderr
+    end
+
     # With the gates satisfied there is nothing better to report, so the
     # write failure is the run's outcome rather than a silent success.
     it 'fails the run when only the report could not be written' do


### PR DESCRIPTION
`harmonize` prints its outcome and nothing else, so a caller that needs the facts has to read the prose back. ammitto/data does exactly that: 595 lines of JavaScript embedded in `harmonize.yml` regex the log for `Harmonize health gate failed:`, for `Harmonize complete:` and for two-space-indented `source: reason` rows, then rebuild the per-source classification from them. The first of those strings is a raised **`Thor::Error`** message, so a workflow is treating an exception's wording as an interface, and the data it recovers already exists structured one call earlier: **`evaluate_gates`** attaches `gate_failures` and `exempted_failures` to every per-source result before **`print_summary`** flattens them to text.

Added **`--report PATH`**, writing that same results array as JSON: schema marker, `gates_passed`, the succeeded/failed/exempted counts, deduplicated entity and entry totals, and one entry per source carrying its status, error, gate failures, exemptions, per-file transform errors and quality metrics. **`report_payload`** classifies through `evaluate_gates`, the one the exit code uses, so the report and the log beside it cannot disagree. Transform errors are reported under their own key rather than folded into failures, because no exemption clears them. The call sits before **`enforce_health_gates`** rather than after: a failing run is precisely the one a caller needs the report for, and ordering it the other way leaves nothing on disk on those runs. Consistent with `status`, `sources`, `search` and `get`, which all already offer machine-readable output. Without the flag nothing on the run path changes: no file is written and the printed summary is byte-identical. The only difference is a line in `ammitto help harmonize`.

A report that cannot be written must not become the run's diagnosis, so **`write_report`** rescues `SystemCallError`/`IOError`, warns at once, and returns the message for **`run`** to raise only after the gates have spoken: an unwritable path can no longer replace `ru: No YAML files found` with an `Errno` the operator has to work backwards from, and with the gates satisfied it still fails the run rather than passing quietly. Per-source counts are passed through rather than coerced, so a source that errored before reading anything reports `null` instead of a `0` a dashboard would chart as a measurement.

Verified locally: a real fifteen-source harmonize with `--report` exits 1 and still writes 6,168 bytes of JSON naming both live failures (`ru: No YAML files found`, `un_vessels: No YAML files found`) against 13 succeeded and 60,986 entities, matching the printed summary line for line. An errored source reports `"entities": null`. Suite 1,659 green, rubocop clean over 428 files. Mutation checks over the 12 new examples: pinning `gates_passed` to true fails 2, emptying `transform_errors` fails 1, moving the write after the gate raise fails 1 and leaves no file at all, dropping the rescue fails 2 with a bare `Errno::EEXIST`, and swallowing the write error fails 1.

---

Reviewed by Codex, not by Copilot: every Copilot request since 2026-08-18 15:20 returns "the user who requested the review has reached their quota limit", as a submitted review with zero comments. Recorded here so the review provenance is not assumed from the absence of comments.