### PR TITLE
Carry the regime name on the reference the entry publishes

### DIFF
--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -533,8 +533,17 @@ module Ammitto
           'description' => regime['description']
         }.compact
 
-        # Replace entry regime with @id reference
-        entry['regime'] = { '@id' => regime_id }
+        # Replace entry regime with an @id reference carrying its label.
+        #
+        # The name rides along rather than being left to a second fetch
+        # because consumers do not make one: the site derives its regime
+        # badge from the IRI tail instead, and an identifier is a poor
+        # label. Measured over the published set, 158 of 178 regimes
+        # display worse for it — "1533 Democratic People S Republic Of
+        # The Congo" where the node says "1533 (Democratic People's
+        # Republic of the Congo)", and "Au Afghanistan" for "Afghanistan".
+        entry['regime'] = { '@id' => regime_id,
+                            'name' => regime['name'] }.compact
 
         @stats[:total_regimes] = @regimes.length
       end

--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -542,8 +542,15 @@ module Ammitto
         # display worse for it — "1533 Democratic People S Republic Of
         # The Congo" where the node says "1533 (Democratic People's
         # Republic of the Congo)", and "Au Afghanistan" for "Afghanistan".
+        #
+        # The label is the node's, not this entry's. Several source codes
+        # can map to one regime — `sources/us/transformer.rb` sends both
+        # IRAN and IRGC to code IRAN, named "Iran" and "Iran (IRGC)" —
+        # and the node keeps whichever arrived first. A reference echoing
+        # its own entry's name would then disagree with the node it
+        # points at, inside one graph.
         entry['regime'] = { '@id' => regime_id,
-                            'name' => regime['name'] }.compact
+                            'name' => @regimes[slug]['name'] }.compact
 
         @stats[:total_regimes] = @regimes.length
       end

--- a/spec/ammitto/serialization/json_ld_graph_exporter_regime_name_spec.rb
+++ b/spec/ammitto/serialization/json_ld_graph_exporter_regime_name_spec.rb
@@ -57,6 +57,29 @@ RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
     expect(reference).not_to have_key('name')
   end
 
+  # The search index reads the SAME entry hash, after the graph exporter
+  # has mutated it: harmonize_command.rb calls add_node then
+  # search_indexer.add on one object. So stripping the name off the
+  # reference also blinded the facet builder, whose `name` field fell back
+  # to code.upcase for every regime published — AL_QAIDA where the source
+  # says Al-Qaida. The search-index spec's own fixtures already carried a
+  # name on the reference; nothing produced one.
+  it 'leaves the search index a regime name to put in its facet' do
+    require 'ammitto/serialization/search_index_exporter'
+    indexer = Ammitto::Serialization::SearchIndexExporter.new
+    entity = { '@id' => 'https://www.ammitto.org/entity/un/e1',
+               '@type' => 'PersonEntity',
+               'names' => [{ 'fullName' => 'Someone' }] }
+    entry = { '@id' => 'https://www.ammitto.org/entry/un/consolidated/e1',
+              '@type' => 'SanctionEntry',
+              'regime' => { 'code' => 'AL_QAIDA', 'name' => 'Al-Qaida' } }
+
+    exporter.add_node(entity: entity, entry: entry, source: :un)
+    indexer.add(entity, entry)
+
+    expect(indexer.facets[:regimes]['al_qaida'][:name]).to eq('Al-Qaida')
+  end
+
   it 'leaves the regime node itself unchanged' do
     add_entry('code' => 'AL_QAIDA', 'name' => 'Al-Qaida',
               'description' => 'x')

--- a/spec/ammitto/serialization/json_ld_graph_exporter_regime_name_spec.rb
+++ b/spec/ammitto/serialization/json_ld_graph_exporter_regime_name_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+require 'tmpdir'
+require 'ammitto/serialization/json_ld_graph_exporter'
+
+# The entry's regime reference carried an @id and nothing else, so a
+# consumer wanting a label had either to fetch the regime node or invent
+# one from the identifier. The site invents one, and 158 of the 178
+# published regimes read worse for it.
+RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
+  let(:output_dir) { Dir.mktmpdir('ammitto_regime_name') }
+  let(:exporter) do
+    described_class.new(output_dir: output_dir,
+                        context_url: 'https://www.ammitto.org/ontology/context.jsonld')
+  end
+
+  after { FileUtils.rm_rf(output_dir) }
+
+  def add_entry(regime)
+    exporter.add_node(
+      entity: { '@id' => 'https://www.ammitto.org/entity/un/e1',
+                '@type' => 'PersonEntity' },
+      entry: { '@id' => 'https://www.ammitto.org/entry/un/consolidated/e1',
+               '@type' => 'SanctionEntry', 'regime' => regime },
+      source: :un
+    )
+  end
+
+  def reference
+    exporter.entries.values.first['regime']
+  end
+
+  it 'carries the regime name beside the reference' do
+    add_entry('code' => '1533', 'name' => "1533 (Democratic People's " \
+                                          'Republic of the Congo)')
+
+    expect(reference).to eq(
+      '@id' => 'https://www.ammitto.org/regime/1533',
+      'name' => "1533 (Democratic People's Republic of the Congo)"
+    )
+  end
+
+  it 'still points at the regime node' do
+    add_entry('code' => 'AU_AFGHANISTAN', 'name' => 'Afghanistan')
+
+    expect(reference['@id']).to eq(exporter.regimes.values.first['@id'])
+  end
+
+  it 'omits the name rather than emitting a null when the source has none' do
+    # A key holding null is worse than an absent key: a consumer testing
+    # for presence gets a truthy answer and renders nothing.
+    add_entry('code' => 'RUSSIA')
+
+    expect(reference).to eq('@id' => 'https://www.ammitto.org/regime/russia')
+    expect(reference).not_to have_key('name')
+  end
+
+  it 'leaves the regime node itself unchanged' do
+    add_entry('code' => 'AL_QAIDA', 'name' => 'Al-Qaida',
+              'description' => 'x')
+
+    node = exporter.regimes.values.first
+    expect(node).to include('@type' => 'SanctionRegime', 'name' => 'Al-Qaida',
+                            'code' => 'AL_QAIDA', 'description' => 'x')
+  end
+end

--- a/spec/ammitto/serialization/json_ld_graph_exporter_regime_name_spec.rb
+++ b/spec/ammitto/serialization/json_ld_graph_exporter_regime_name_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
 
   after { FileUtils.rm_rf(output_dir) }
 
-  def add_entry(regime)
+  def add_entry(regime, ref = 'e1')
     exporter.add_node(
-      entity: { '@id' => 'https://www.ammitto.org/entity/un/e1',
+      entity: { '@id' => "https://www.ammitto.org/entity/un/#{ref}",
                 '@type' => 'PersonEntity' },
-      entry: { '@id' => 'https://www.ammitto.org/entry/un/consolidated/e1',
+      entry: { '@id' => "https://www.ammitto.org/entry/un/consolidated/#{ref}",
                '@type' => 'SanctionEntry', 'regime' => regime },
       source: :un
     )
@@ -64,20 +64,37 @@ RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
   # to code.upcase for every regime published — AL_QAIDA where the source
   # says Al-Qaida. The search-index spec's own fixtures already carried a
   # name on the reference; nothing produced one.
-  it 'leaves the search index a regime name to put in its facet' do
+  #
+  # Indexing the SECOND entry is what makes this depend on the mutation.
+  # Its own hash says "Iran (IRGC)"; only the exporter's rewrite carries
+  # the node's "Iran" onto it. An example indexing an unrewritten hash
+  # would pass with `extract_regime` deleted, because the indexer falls
+  # back to the source's own `code` and `name` when there is no `@id`.
+  it 'gives the facet the regime name the node holds, not the entry\'s' do
     require 'ammitto/serialization/search_index_exporter'
     indexer = Ammitto::Serialization::SearchIndexExporter.new
-    entity = { '@id' => 'https://www.ammitto.org/entity/un/e1',
-               '@type' => 'PersonEntity',
-               'names' => [{ 'fullName' => 'Someone' }] }
-    entry = { '@id' => 'https://www.ammitto.org/entry/un/consolidated/e1',
-              '@type' => 'SanctionEntry',
-              'regime' => { 'code' => 'AL_QAIDA', 'name' => 'Al-Qaida' } }
+    add_entry({ 'code' => 'IRAN', 'name' => 'Iran' }, 'e1')
+    add_entry({ 'code' => 'IRAN', 'name' => 'Iran (IRGC)' }, 'e2')
 
-    exporter.add_node(entity: entity, entry: entry, source: :un)
-    indexer.add(entity, entry)
+    second = exporter.entries.values.last
+    indexer.add({ '@id' => 'https://www.ammitto.org/entity/un/e2',
+                  '@type' => 'PersonEntity',
+                  'names' => [{ 'fullName' => 'Someone' }] }, second)
 
-    expect(indexer.facets[:regimes]['al_qaida'][:name]).to eq('Al-Qaida')
+    expect(indexer.facets[:regimes]['iran'][:name]).to eq('Iran')
+  end
+
+  # us/transformer.rb sends IRAN and IRGC to one code under two names,
+  # and the node keeps the first. A reference echoing its own entry's
+  # name would contradict the node it points at, in one graph.
+  it 'publishes the node\'s name on every reference to it' do
+    add_entry({ 'code' => 'IRAN', 'name' => 'Iran' }, 'e1')
+    add_entry({ 'code' => 'IRAN', 'name' => 'Iran (IRGC)' }, 'e2')
+
+    names = exporter.entries.values.map { |e| e.dig('regime', 'name') }
+
+    expect(exporter.regimes.values.map { |r| r['name'] }).to eq(['Iran'])
+    expect(names).to eq(%w[Iran Iran])
   end
 
   it 'leaves the regime node itself unchanged' do

--- a/spec/ammitto/serialization/json_ld_graph_exporter_spec.rb
+++ b/spec/ammitto/serialization/json_ld_graph_exporter_spec.rb
@@ -151,7 +151,8 @@ RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
 
       expect(exporter.regimes).to have_key('dprk')
       expect(exporter.regimes['dprk']['name']).to eq('Democratic People\'s Republic of Korea')
-      expect(entry['regime']).to eq({ '@id' => 'https://www.ammitto.org/regime/dprk' })
+      expect(entry['regime']).to eq({ '@id' => 'https://www.ammitto.org/regime/dprk',
+                                      'name' => 'Democratic People\'s Republic of Korea' })
     end
 
     it 'extracts and deduplicates legal instruments' do
@@ -218,7 +219,10 @@ RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
       data = JSON.parse(File.read(entry_file))
       expect(data['@id']).to eq('https://www.ammitto.org/entry/un/consolidated-list/KPi.066')
       expect(data['authority']).to eq({ '@id' => 'https://www.ammitto.org/authority/un' })
-      expect(data['regime']).to eq({ '@id' => 'https://www.ammitto.org/regime/dprk' })
+      # The regime reference carries its label alongside the identifier, so
+      # a consumer has a name to show without a second fetch.
+      expect(data['regime']).to eq({ '@id' => 'https://www.ammitto.org/regime/dprk',
+                                     'name' => 'DPRK' })
     end
 
     it 'exports authority node files' do


### PR DESCRIPTION
The site shows `1533 Democratic People S Republic Of The Congo`, `Au Afghanistan` and `Al Qaida` on entity pages, because **`useEntityData.ts:443`** builds the regime badge by pulling the tail off the `@id` and title-casing it. The graph already holds the real names — `1533 (Democratic People's Republic of the Congo)`, `Afghanistan`, `Al-Qaida` — on the regime nodes, but **`extract_regime`** replaces the entry's inline regime with `{"@id": …}` alone, so a page has nothing to show without a second fetch and invents a label instead. Measured over the published set: **158 of 178 regimes read worse** than the name sitting one file away.

Put the name on the reference: `{"@id": …, "name": …}`, omitted rather than null when the source states none, since a key holding null answers a presence check truthily and then renders nothing. The regime node, the `by-regime` slices and the `@id` itself are untouched, so this is additive — a consumer reading only `@id` sees no difference. The site half is ammitto/ammitto.github.io#30, which prefers the name over the derived label; either can land alone, and nothing changes on the page until both do.

It repairs a second, independent thing, found after the first draft. The search index reads the **same entry hash** the graph exporter has just mutated — `harmonize_command.rb:480-481` calls `add_node` then `search_indexer.add` on one object — so stripping the name off the reference also blinded **`remember_regime_name`**, and `facets/regimes.json` fell back to `code.upcase` for **every** regime published. Measured over a full fifteen-source run: **178 of 178 facets fall back on `main`, 117 of 179 carry a distinct name here** — `Russia/Ukraine` for `russia`, `Switzerland SECO Sanctions` for `ch_seco`, `Japan End-User List (METI)` for `jp-eul`. The remaining 62 are unchanged on purpose: they are OFAC programme codes like `SDNTK` and `GLOMAG` whose node `name` **is** the code, so there is no better label to reach. The facet's `name` field was built to carry the source's name and could never reach one. `search_index_exporter_spec.rb:32` has been feeding it a reference with a name all along — a shape nothing produced.

The label on the reference is the **node's**, not the entry's own. Several source codes map to one regime — `sources/us/transformer.rb:33-34` sends both `IRAN` and `IRGC` to code `IRAN`, named `Iran` and `Iran (IRGC)` — and the node keeps whichever arrived first. Publishing each entry's own name would have put two different labels on one `@id` inside one graph; reproduced before fixing it, two entries under `IRAN` gave a node named `Iran` and references reading `Iran` and `Iran (IRGC)`. First-wins was already the node's rule on `main`, so no published label moves; the references now agree with it. `sources/ca/transformer.rb` has the same shape for `CA_SEMA`, and picking between two names for one regime is a question this change makes visible rather than one it creates.

Verified: 1,687 specs green, rubocop clean over 432 files. The new spec is red on unmodified `main` with two value mismatches — the reference missing its name, and the facet name coming back `nil` where it should read `Al-Qaida` — and dropping the `.compact` fails the example that pins a nameless regime to an absent key rather than a null. Two further mutants, added after a review round: publishing the entry's own name instead of the node's fails the two examples that pin canonicalization, and removing the reference rewrite entirely fails five of the six — including the search-index example, which previously survived it because the indexer falls back to the source's own `code` and `name` when there is no `@id`. It now indexes the SECOND of two entries, whose own hash says `Iran (IRGC)`, so only the rewrite can put `Iran` on it. Two existing examples asserted the old two-key shape and now assert the three-key one; no other assertion in the suite moved.

---

Reviewed by Codex, not by Copilot: every Copilot request since 2026-08-18 15:20 returns "the user who requested the review has reached their quota limit", as a submitted review with zero comments. Recorded here so the review provenance is not assumed from the absence of comments.
