### PR TITLE
Refuse a document-type id that cannot become a safe path

### DIFF
--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -936,14 +936,20 @@ module Ammitto
           source = parts.find { |p| registered_source?(p) }
           local_id = parts.last
 
-          # The same guard the organization and instrument paths apply, for
-          # the same reason: a component that cannot safely become a
-          # filename is refused here rather than handed to the filesystem,
-          # where the answer depends on the platform — Linux accepts
-          # characters Windows rejects, so an unvalidated write succeeds
-          # quietly on one runner and raises Errno::EINVAL on the other —
-          # and a '..' component would write outside the node tree.
-          # Document types were the one path of the three without it.
+          # The same guard the organization and instrument paths apply,
+          # for the same reason: a component this exporter refuses is
+          # refused here rather than handed to the filesystem. Document
+          # types were the one path of the three without it, so what is
+          # closed is the asymmetry between them.
+          #
+          # The guard is narrow, and #unusable_filename_component? is
+          # explicit that it is not a Windows-safe filename check: it
+          # covers path escapes and the URL-significant ? # %, of which
+          # ? is the one divergence the corpus produced — writing
+          # happily on Linux and raising Errno::EINVAL on Windows, so
+          # the same export succeeded or failed depending on the runner.
+          # Widening it to the full Windows contract belongs with that
+          # predicate, for all three paths at once.
           #
           # Both components are checked to match the organization path
           # exactly, though only local_id can fail today: source comes from

--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -944,6 +944,18 @@ module Ammitto
           # quietly on one runner and raises Errno::EINVAL on the other —
           # and a '..' component would write outside the node tree.
           # Document types were the one path of the three without it.
+          #
+          # Both components are checked to match the organization path
+          # exactly, though only local_id can fail today: source comes from
+          # #registered_source?, so an unsafe segment never matches and
+          # .compact drops the nil. Diverging here to save one comparison
+          # is how the two drift apart again.
+          #
+          # Fatal, unlike the duplicate-claim policy above, because the two
+          # defects differ in kind: a duplicated row has a safe resolution
+          # and keeps the first claimant, while a component the filesystem
+          # cannot hold has none — the alternatives are writing outside the
+          # node tree or behaving differently per platform.
           [source, local_id].compact.each do |component|
             next unless unusable_filename_component?(component)
 

--- a/lib/ammitto/serialization/json_ld_graph_exporter.rb
+++ b/lib/ammitto/serialization/json_ld_graph_exporter.rb
@@ -936,6 +936,22 @@ module Ammitto
           source = parts.find { |p| registered_source?(p) }
           local_id = parts.last
 
+          # The same guard the organization and instrument paths apply, for
+          # the same reason: a component that cannot safely become a
+          # filename is refused here rather than handed to the filesystem,
+          # where the answer depends on the platform — Linux accepts
+          # characters Windows rejects, so an unvalidated write succeeds
+          # quietly on one runner and raises Errno::EINVAL on the other —
+          # and a '..' component would write outside the node tree.
+          # Document types were the one path of the three without it.
+          [source, local_id].compact.each do |component|
+            next unless unusable_filename_component?(component)
+
+            raise Ammitto::Error,
+                  "Document type identifier #{type_id.inspect} yields " \
+                  "unusable path component #{component.inspect}"
+          end
+
           if source
             dir = File.join(@output_dir, 'node', 'document-type', source)
             FileUtils.mkdir_p(dir)

--- a/spec/ammitto/serialization/json_ld_graph_exporter_document_type_path_spec.rb
+++ b/spec/ammitto/serialization/json_ld_graph_exporter_document_type_path_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+require 'tmpdir'
+require 'ammitto/serialization/json_ld_graph_exporter'
+
+# Organizations, instruments and document types all turn a source-supplied
+# identifier into a path component. Two of the three refused a component
+# the filesystem would answer differently on Linux and Windows; document
+# types handed it over. Latent rather than live when this was written —
+# 0 unsafe basenames across the 36 document-type files a current harmonize
+# emits — which is the moment to close it.
+RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
+  let(:output_dir) { Dir.mktmpdir('ammitto_doctype_path') }
+  let(:exporter) do
+    described_class.new(output_dir: output_dir,
+                        context_url: 'https://www.ammitto.org/ontology/context.jsonld')
+  end
+
+  after { FileUtils.rm_rf(output_dir) }
+
+  def with_document_type(id)
+    exporter.document_types[id] = { '@id' => id, '@type' => 'DocumentType' }
+    exporter.send(:export_document_type_nodes)
+  end
+
+  it 'refuses a local id holding a question mark' do
+    # The corpus case behind the rule: `?` writes happily on Linux and
+    # raises Errno::EINVAL on Windows, so the same export succeeded or
+    # failed depending on the runner.
+    id = 'https://www.ammitto.org/document-type/un/what?'
+
+    expect { with_document_type(id) }
+      .to raise_error(Ammitto::Error, /unusable path component "what\?"/)
+  end
+
+  it 'refuses a local id that would climb out of the node tree' do
+    id = 'https://www.ammitto.org/document-type/un/..'
+
+    expect { with_document_type(id) }
+      .to raise_error(Ammitto::Error, /unusable path component/)
+  end
+
+  it 'writes an ordinary document type where it always did' do
+    id = 'https://www.ammitto.org/document-type/un/resolution'
+
+    with_document_type(id)
+
+    expect(File.file?(File.join(output_dir, 'node', 'document-type', 'un',
+                                'resolution.jsonld'))).to be true
+  end
+
+  it 'writes one with no recognised source at the top level' do
+    id = 'https://www.ammitto.org/document-type/decision'
+
+    with_document_type(id)
+
+    expect(File.file?(File.join(output_dir, 'node', 'document-type',
+                                'decision.jsonld'))).to be true
+  end
+end

--- a/spec/ammitto/serialization/json_ld_graph_exporter_document_type_path_spec.rb
+++ b/spec/ammitto/serialization/json_ld_graph_exporter_document_type_path_spec.rb
@@ -32,14 +32,16 @@ RSpec.describe Ammitto::Serialization::JsonLdGraphExporter do
     id = 'https://www.ammitto.org/document-type/un/what?'
 
     expect { with_document_type(id) }
-      .to raise_error(Ammitto::Error, /unusable path component "what\?"/)
+      .to raise_error(Ammitto::Error,
+                      /Document type identifier .* unusable path component "what\?"/)
   end
 
   it 'refuses a local id that would climb out of the node tree' do
     id = 'https://www.ammitto.org/document-type/un/..'
 
     expect { with_document_type(id) }
-      .to raise_error(Ammitto::Error, /unusable path component/)
+      .to raise_error(Ammitto::Error,
+                      /Document type identifier .* unusable path component/)
   end
 
   it 'writes an ordinary document type where it always did' do


### PR DESCRIPTION
Three exports turn a source-supplied identifier into a path component under `node/`. **`export_organization_nodes`** and the instrument path refuse a component that cannot safely become a filename; **`export_document_type_nodes`** handed it to the filesystem. That is the asymmetry, and the reason the other two carry the guard applies here unchanged: Linux accepts characters Windows rejects, so an unvalidated write succeeds quietly on one runner and raises `Errno::EINVAL` on the other, and a `..` component writes outside the node tree.

Applied the same **`unusable_filename_component?`** check to the document-type path, raising with the identifier that produced the bad component rather than the component alone, so the offending record is nameable from the message.

Latent rather than live, which is why it is a small change and not an incident: a current fifteen-source harmonize emits 36 document-type files and **0 of them carry an unsafe basename**. Fixing it while nothing is broken is the cheap moment; the expensive one is after a supporting-data file starts shipping an identifier with a `?` in it and the export behaves differently depending on which runner picked it up. Found while reviewing ammitto#59, where it is named as deliberately out of scope.

Fatal rather than warned about, which is worth stating because this file does the opposite one screen earlier: a duplicated supporting-data claim keeps the first claimant and carries on, deliberately, since "losing the whole graph over one duplicated row is the worse outcome". The two defects differ in kind. A duplicate has a safe resolution; a component the filesystem cannot hold has none — the alternatives are writing outside the node tree or behaving differently depending on the runner. Organizations and instruments already made that call for this class, so this follows them rather than inventing a policy.

A review round noted the raise escapes before `print_summary` and `enforce_health_gates`, so it aborts the run rather than arriving as a classified gate failure. That is true of the organization path too, and it is the existing shape; moving all three into the gate machinery is a larger change than making the third match the other two.

Both components are checked, matching the organization path, though only `local_id` can fail today: `source` comes from `registered_source?`, so an unsafe segment never matches and `.compact` drops the nil. Kept anyway, with the reason in the code — diverging to save one comparison is how the two drifted apart in the first place.

Verified: the two refusal examples are red on unmodified `main` — the writes simply succeed there — and the two that pin the ordinary paths pass before and after, so the guard does not narrow what already published. Suite 1,691 green, rubocop clean over 433 files.

A later round found the comment overclaiming: it read as though the guard made the path Windows-safe. It does not, and `unusable_filename_component?` says so itself — it covers path escapes and the URL-significant `?`, `#`, `%`, of which `?` is the one divergence the corpus actually produced, writing happily on Linux and raising `Errno::EINVAL` on Windows. The comment now says that, and says widening it to the full Windows contract belongs with the predicate, for all three paths at once.

---

Reviewed by Codex, not by Copilot: every Copilot request since 2026-08-18 15:20 returns "the user who requested the review has reached their quota limit", as a submitted review with zero comments. Recorded here so the review provenance is not assumed from the absence of comments.
