### PR TITLE
Judge fetch recency by the newest run on the page, not the first

### DIFF
--- a/scripts/fleet_health.sh
+++ b/scripts/fleet_health.sh
@@ -176,6 +176,11 @@ MAX_AGE_HOURS=$((10#$MAX_AGE_HOURS))
 # closes the window — and never fewer than the 10 this has always used.
 COMPLETED_PER_PAGE=$((STREAK_LIMIT + 1))
 if [ "$COMPLETED_PER_PAGE" -lt 10 ]; then COMPLETED_PER_PAGE=10; fi
+# Recency is judged over a page rather than a single item, so one stale
+# entry cannot decide it. Five is enough: the newest of five is right
+# unless the endpoint is stale about all five, and a page this small
+# costs the same one request the one-item page did.
+SCHEDULE_PER_PAGE=5
 if [ "$COMPLETED_PER_PAGE" -gt 100 ]; then COMPLETED_PER_PAGE=100; fi
 
 # Fetch one API document. kind: workflow | schedule_runs | completed_runs.
@@ -195,8 +200,19 @@ api_get() {
       path="$base" ;;
     # Recency: newest scheduled run of any status, so a run still in
     # progress still counts as the cron having fired.
+    #
+    # Several are fetched and the newest is chosen by created_at rather
+    # than taking position zero of a one-item page. This endpoint has
+    # been observed serving a stale page: on 2026-08-18 it reported
+    # data-uk's last scheduled run as 2026-07-22 while that repository
+    # had in fact run and committed every morning, and the monitor paged
+    # on a healthy repo for it. The same query was seen returning three
+    # different answers inside two minutes on 2026-08-19. A false page
+    # trains everyone to ignore the channel, and the identical mechanism
+    # can hand back a recent run for a repository whose cron has died,
+    # which is the failure this monitor exists to prevent.
     schedule_runs)
-      path="$base/runs?event=schedule&per_page=1" ;;
+      path="$base/runs?event=schedule&per_page=$SCHEDULE_PER_PAGE" ;;
     # Streak: scheduled runs only. A red PR run must never page the
     # fleet, and a green push run must never clear a real streak.
     completed_runs)
@@ -344,10 +360,12 @@ while IFS= read -r line <&3; do
 
   if [ "$unreadable" -eq 0 ]; then
     state="$(jq -r '.state' <<<"$workflow_json")"
-    last_sched="$(jq -r '.workflow_runs[0].created_at // empty' \
-      <<<"$schedule_json")"
-    last_sched_conclusion="$(jq -r '.workflow_runs[0].conclusion // empty' \
-      <<<"$schedule_json")"
+    newest_sched="$(jq -c '[.workflow_runs[]?
+          | select(.created_at != null)]
+          | sort_by(.created_at) | last // {}' <<<"$schedule_json")"
+    last_sched="$(jq -r '.created_at // empty' <<<"$newest_sched")"
+    last_sched_conclusion="$(jq -r '.conclusion // empty' \
+      <<<"$newest_sched")"
     seq="$(jq -r '[.workflow_runs[]? | .conclusion
           | if . == "success" then "S"
             elif . == "failure" or . == "timed_out"

--- a/scripts/fleet_health.sh
+++ b/scripts/fleet_health.sh
@@ -276,8 +276,12 @@ doc_valid() { # kind json
                    and ((.conclusion == null) or (.conclusion | type == "string"))))' \
         >/dev/null 2>&1 <<<"$json" ;;
     *)
+      # created_at is required here too, because the streak is ordered by
+      # it rather than by the position the API returned.
       jq -e 'type == "object" and (.workflow_runs | type == "array")
              and (.workflow_runs | all(type == "object"
+                   and (.created_at | type == "string")
+                   and (.created_at | length > 0)
                    and ((.conclusion == null) or (.conclusion | type == "string"))))' \
         >/dev/null 2>&1 <<<"$json" ;;
   esac
@@ -366,11 +370,19 @@ while IFS= read -r line <&3; do
     last_sched="$(jq -r '.created_at // empty' <<<"$newest_sched")"
     last_sched_conclusion="$(jq -r '.conclusion // empty' \
       <<<"$newest_sched")"
-    seq="$(jq -r '[.workflow_runs[]? | .conclusion
-          | if . == "success" then "S"
-            elif . == "failure" or . == "timed_out"
-                 or . == "startup_failure" then "F"
-            else "C" end] | join("")' <<<"$completed_json")"
+    # Newest first, by created_at rather than by the order the API
+    # returned. `window` below takes everything before the first S as
+    # "since the last success", so a stale success ahead of newer
+    # failures clears a real streak, and stale failures ahead of a newer
+    # success invent one. Same reason the recency read was changed: this
+    # endpoint promises filters and paging, not an order.
+    seq="$(jq -r '[.workflow_runs[]? | {created_at, conclusion}]
+          | sort_by(.created_at) | reverse
+          | map(if .conclusion == "success" then "S"
+                elif .conclusion == "failure" or .conclusion == "timed_out"
+                     or .conclusion == "startup_failure" then "F"
+                else "C" end)
+          | join("")' <<<"$completed_json")"
 
     if [ "$state" != "active" ]; then
       reasons+=("workflow state is '$state' — the schedule is not running")

--- a/scripts/fleet_health_test.sh
+++ b/scripts/fleet_health_test.sh
@@ -337,7 +337,7 @@ cat > "$TMP/bin/gh" <<'STUB'
 if [ "$1" = "api" ]; then
   echo "$2" >> "$GH_PATHS"
   case "$2" in
-    *"/runs?"*"event=schedule"*"per_page=1") printf '{"workflow_runs":[{"created_at":"%s","conclusion":"success"}]}' "$SCHED_TS" ;;
+    *"/runs?"*"event=schedule"*"per_page=5") printf '{"workflow_runs":[{"created_at":"%s","conclusion":"success"}]}' "$SCHED_TS" ;;
     *"/runs?"*"event=schedule"*) printf '{"workflow_runs":[{"conclusion":"success"},{"conclusion":"success"},{"conclusion":"success"}]}' ;;
     *"/runs?"*) printf '{"workflow_runs":[{"conclusion":"failure"},{"conclusion":"failure"},{"conclusion":"failure"},{"conclusion":"failure"}]}' ;;
     *) printf '{"path":".github/workflows/fetch.yml","state":"active"}' ;;
@@ -379,7 +379,7 @@ esac
 if [ "$1" = "api" ]; then
   echo "$2" >> "$GH_PATHS"
   case "$2" in
-    *"/runs?"*"per_page=1") printf '{"workflow_runs":[{"created_at":"%s","conclusion":"success"}]}' "$SCHED_TS" ;;
+    *"/runs?"*"per_page=5") printf '{"workflow_runs":[{"created_at":"%s","conclusion":"success"}]}' "$SCHED_TS" ;;
     *"/runs?"*) printf '{"workflow_runs":[{"conclusion":"success"},{"conclusion":"success"}]}' ;;
     *) printf '{"state":"active"}' ;;
   esac
@@ -408,6 +408,39 @@ env -u GH_TOKEN -u GITHUB_TOKEN PATH="$TMP/bin2:$PATH" \
   || pass "did not fall through to anonymous curl"
 
 echo "== streak: the page must be large enough to reach the threshold =="
+# Recency must come from the newest run on the page, not from position
+# zero. The endpoint has been observed serving a stale page: on
+# 2026-08-18 it reported data-uk's last scheduled run as three weeks old
+# while that repository was committing every morning, and the monitor
+# paged on a healthy repo for it. This stub puts the OLD run first, so a
+# reader that trusts position zero calls a healthy repo stale.
+echo "== recency: the newest run on the page wins, whatever its position =="
+cat > "$TMP/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "api" ]; then
+  [ -n "${GH_PATHS:-}" ] && echo "$2" >> "$GH_PATHS"
+  case "$2" in
+    *"/runs?"*"event=schedule"*"status=completed"*)
+      printf '{"workflow_runs":[{"created_at":"%s","conclusion":"success"}]}' "$SCHED_TS" ;;
+    *"/runs?"*"event=schedule"*)
+      printf '{"workflow_runs":[{"created_at":"%s","conclusion":"success"},{"created_at":"%s","conclusion":"success"}]}' "$SCHED_OLD" "$SCHED_TS" ;;
+    *) printf '{"path":".github/workflows/fetch.yml","state":"active"}' ;;
+  esac
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$TMP/bin/gh"
+printf 'data-order\n' > "$TMP/repos_order.txt"
+rc=0
+PATH="$TMP/bin:$PATH" GH_TOKEN=stub-token \
+  SCHED_TS="$(iso '3 hours ago')" SCHED_OLD="$(iso '30 days ago')" \
+  FLEET_HEALTH_FIXTURES= FLEET_HEALTH_REPOS_FILE="$TMP/repos_order.txt" \
+  "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report_order.md" > /dev/null || rc=$?
+[ "$rc" -eq 0 ] \
+  && pass "the newest run on the page decides recency, not position zero" \
+  || fail "a stale entry ahead of the newest one paged a healthy repo (exit $rc)"
+
 # per_page was pinned at 10 while FLEET_HEALTH_STREAK is configurable, so
 # any threshold above 10 could never be reached: the streak stayed short
 # of the limit forever and a dead repo read healthy — the silent OK this

--- a/scripts/fleet_health_test.sh
+++ b/scripts/fleet_health_test.sh
@@ -32,11 +32,16 @@ schedule_fixture() { # repo age conclusion
   printf '{"workflow_runs":[{"created_at":"%s","conclusion":"%s"}]}' \
     "$(iso "$2")" "$3" > "$FIX/$1__schedule_runs.json"
 }
-completed_fixture() { # repo conclusion...
-  local repo="$1" runs="" c
+completed_fixture() { # repo conclusion... (newest first, as the caller reads)
+  local repo="$1" runs="" c i=0
   shift
+  # Timestamps descend with position, so a fixture written newest-first
+  # still reads newest-first once the script orders by created_at. The
+  # real endpoint always carries created_at; a fixture without one would
+  # be testing a document the API does not produce.
   for c in "$@"; do
-    runs="$runs{\"conclusion\":\"$c\"},"
+    runs="$runs{\"created_at\":\"$(iso "$((i + 1)) hours ago")\",\"conclusion\":\"$c\"},"
+    i=$((i + 1))
   done
   printf '{"workflow_runs":[%s]}' "${runs%,}" \
     > "$FIX/${repo}__completed_runs.json"
@@ -338,8 +343,8 @@ if [ "$1" = "api" ]; then
   echo "$2" >> "$GH_PATHS"
   case "$2" in
     *"/runs?"*"event=schedule"*"per_page=5") printf '{"workflow_runs":[{"created_at":"%s","conclusion":"success"}]}' "$SCHED_TS" ;;
-    *"/runs?"*"event=schedule"*) printf '{"workflow_runs":[{"conclusion":"success"},{"conclusion":"success"},{"conclusion":"success"}]}' ;;
-    *"/runs?"*) printf '{"workflow_runs":[{"conclusion":"failure"},{"conclusion":"failure"},{"conclusion":"failure"},{"conclusion":"failure"}]}' ;;
+    *"/runs?"*"event=schedule"*) printf '{"workflow_runs":[{"created_at":"%s","conclusion":"success"},{"created_at":"%s","conclusion":"success"},{"created_at":"%s","conclusion":"success"}]}' "$SCHED_TS" "$SCHED_TS" "$SCHED_TS" ;;
+    *"/runs?"*) printf '{"workflow_runs":[{"created_at":"%s","conclusion":"failure"},{"created_at":"%s","conclusion":"failure"},{"created_at":"%s","conclusion":"failure"},{"created_at":"%s","conclusion":"failure"}]}' "$SCHED_TS" "$SCHED_TS" "$SCHED_TS" "$SCHED_TS" ;;
     *) printf '{"path":".github/workflows/fetch.yml","state":"active"}' ;;
   esac
   exit 0
@@ -380,7 +385,7 @@ if [ "$1" = "api" ]; then
   echo "$2" >> "$GH_PATHS"
   case "$2" in
     *"/runs?"*"per_page=5") printf '{"workflow_runs":[{"created_at":"%s","conclusion":"success"}]}' "$SCHED_TS" ;;
-    *"/runs?"*) printf '{"workflow_runs":[{"conclusion":"success"},{"conclusion":"success"}]}' ;;
+    *"/runs?"*) printf '{"workflow_runs":[{"created_at":"%s","conclusion":"success"},{"created_at":"%s","conclusion":"success"}]}' "$SCHED_TS" "$SCHED_TS" ;;
     *) printf '{"state":"active"}' ;;
   esac
 fi
@@ -423,7 +428,7 @@ if [ "$1" = "api" ]; then
     *"/runs?"*"event=schedule"*"status=completed"*)
       printf '{"workflow_runs":[{"created_at":"%s","conclusion":"success"}]}' "$SCHED_TS" ;;
     *"/runs?"*"event=schedule"*)
-      printf '{"workflow_runs":[{"created_at":"%s","conclusion":"success"},{"created_at":"%s","conclusion":"success"}]}' "$SCHED_OLD" "$SCHED_TS" ;;
+      printf '{"workflow_runs":[{"created_at":"%s","conclusion":"failure"},{"created_at":"%s","conclusion":"success"}]}' "$SCHED_OLD" "$SCHED_TS" ;;
     *) printf '{"path":".github/workflows/fetch.yml","state":"active"}' ;;
   esac
   exit 0
@@ -440,6 +445,48 @@ PATH="$TMP/bin:$PATH" GH_TOKEN=stub-token \
 [ "$rc" -eq 0 ] \
   && pass "the newest run on the page decides recency, not position zero" \
   || fail "a stale entry ahead of the newest one paged a healthy repo (exit $rc)"
+# The conclusion must come from the same run as the timestamp. It is
+# display-only, so nothing about the verdict catches it: reading it from
+# position zero reports the OLD run's conclusion beside the NEW run's
+# time, which is a row that describes no run that ever happened.
+if grep -q '(success)' "$TMP/report_order.md"; then
+  pass "the reported conclusion belongs to the run reported beside it"
+else
+  fail "conclusion came from a different run than the timestamp: $(grep 'data-order' "$TMP/report_order.md" || true)"
+fi
+
+# The streak reads the same endpoint and had the same positional trust:
+# `window` takes everything before the first S as "since the last
+# success", so an old success served ahead of newer failures clears a
+# real streak. This stub puts the OLD success first and three newer
+# failures after it; ordered correctly the repo pages, ordered by
+# position it reads clean.
+echo "== streak: the newest completed runs decide it, not API position =="
+cat > "$TMP/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "api" ]; then
+  [ -n "${GH_PATHS:-}" ] && echo "$2" >> "$GH_PATHS"
+  case "$2" in
+    *"/runs?"*"event=schedule"*"status=completed"*)
+      printf '{"workflow_runs":[{"created_at":"%s","conclusion":"success"},{"created_at":"%s","conclusion":"failure"},{"created_at":"%s","conclusion":"failure"},{"created_at":"%s","conclusion":"failure"}]}' "$SCHED_OLD" "$SCHED_MID" "$SCHED_NEWER" "$SCHED_TS" ;;
+    *"/runs?"*"event=schedule"*)
+      printf '{"workflow_runs":[{"created_at":"%s","conclusion":"failure"}]}' "$SCHED_TS" ;;
+    *) printf '{"path":".github/workflows/fetch.yml","state":"active"}' ;;
+  esac
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$TMP/bin/gh"
+rc=0
+PATH="$TMP/bin:$PATH" GH_TOKEN=stub-token \
+  SCHED_TS="$(iso '3 hours ago')" SCHED_NEWER="$(iso '4 hours ago')" \
+  SCHED_MID="$(iso '5 hours ago')" SCHED_OLD="$(iso '30 days ago')" \
+  FLEET_HEALTH_FIXTURES= FLEET_HEALTH_REPOS_FILE="$TMP/repos_order.txt" \
+  "$SCRIPT_DIR/fleet_health.sh" --report "$TMP/report_streak_order.md" > /dev/null || rc=$?
+[ "$rc" -eq 1 ] \
+  && pass "an old success served first cannot clear a real failure streak" \
+  || fail "the streak was cleared by API position (exit $rc)"
 
 # per_page was pinned at 10 while FLEET_HEALTH_STREAK is configurable, so
 # any threshold above 10 could never be reached: the streak stayed short
@@ -589,7 +636,7 @@ cat > "$TMP/bin3/curl" <<'STUB'
 # One argument per line so an assertion can match a header exactly.
 { for a in "$@"; do echo "$a"; done; } >> "$CURL_LOG"
 case "$*" in
-  *status=completed*) printf '{"workflow_runs":[{"conclusion":"success"}]}' ;;
+  *status=completed*) printf '{"workflow_runs":[{"created_at":"%s","conclusion":"success"}]}' "$SCHED_TS" ;;
   *event=schedule*) printf '{"workflow_runs":[{"created_at":"%s","conclusion":"success"}]}' "$SCHED_TS" ;;
   *) printf '{"path":".github/workflows/fetch.yml","state":"active"}' ;;
 esac


### PR DESCRIPTION
The fleet monitor is currently paging on a repository that is healthy. Issue #57 reports **`data-uk`** as `UNHEALTHY`, last scheduled run `2026-07-22T08:34:22Z (failure)`, 652 hours old. `data-uk` has in fact run its scheduled fetch successfully every morning — 06:50 today, 06:49 yesterday, eight consecutive successes — and committed `chore: update UK sanctions data` each time.

The monitor asks for one run and trusts it: `runs?event=schedule&per_page=1`, then reads `workflow_runs[0]`. That endpoint intermittently serves a stale page for this repository. Sweeping twelve data repos and comparing the one-item answer against the newest of five, eleven agreed and `data-uk` did not:

```
MISMATCH data-uk: per_page=1 -> 2026-07-24T08:32:08Z | max of 5 -> 2026-08-19T06:50:26Z
```

It is intermittent rather than reproducible on demand — fifteen calls a minute later agreed on today's run, and earlier attempts returned `2026-03-31` and `2026-07-24` before settling. What did not vary across any observation is which form was right: **whenever the two disagreed, the one-item page was the stale one and the newest-of-five was correct.** One request and one item leaves nothing to cross-check against.

Ask for five and take the newest by `created_at`. A page this small costs the same single request, and one stale entry can no longer decide recency. The failure this closes is not the false page, which is merely annoying — it is the same mechanism handing back a **recent** run for a repository whose cron has died, which is the silent OK this monitor exists to kill. The file already says as much about its own streak query: "a dead repo read healthy — the silent OK this monitor exists to kill".

Verified: the self-test grew a case whose stub puts the old run **first** and the newest second, so a reader trusting position zero calls a healthy repo stale. It passes here and fails when the selection is reverted to `workflow_runs[0]` — checked by running the mutant, not by reading it. The whole self-test passes, and the two later cases that share the stub still assert the paths they check, which needed the new stub to keep logging them.

A review round found I had fixed half of it. The **streak** reads the same endpoint with `status=completed` and had the same positional trust: `window` takes everything before the first `S` as "since the last success", so an old success served ahead of newer failures clears a real streak, and stale failures ahead of a newer success invent one. Both were wrong for one reason, so both are now ordered by `created_at`, and `created_at` became required on that document too, since the streak now sorts on it. The self-test grew a matching case whose stub serves an old success first and three newer failures after it: ordered correctly the repo pages, ordered by position it reads clean. Reverting either selection fails its own case.

The same round named a mutation my first case could not kill — reading the conclusion from position zero while the timestamp came from the newest run, producing a row that describes no run that ever happened. It is display-only, so no verdict catches it; the case now asserts the rendered report and the mutation fails.

Not changed: the 48-hour limit, the acknowledgement mechanism, and `data-ru`'s parked status. `data-ru`'s schedule genuinely has not fired since 2026-05-11 and is acknowledged until 2026-09-07 pending a ruling on ru revival — that entry in #57 is correct and stays.

---

Reviewed by Codex, not by Copilot: every Copilot request since 2026-08-18 15:20 returns "the user who requested the review has reached their quota limit", as a submitted review with zero comments. Recorded here so the review provenance is not assumed from the absence of comments.